### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Each line is a file pattern followed by one or more owners.
+# Refer to https://help.github.com/en/articles/about-code-owners
+
+# Order is important; the last matching pattern takes the most
+# precedence. Try to keep at least two owners (or an alias) per pattern.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, they will be requested for
+# review when someone opens a pull request.
+* @dthaler @thalerk @dancrossnyc


### PR DESCRIPTION
So github will automatically add Reviewers to PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added internal guidance clarifying the review assignment process and approval order.
- **Chores**
	- Updated default reviewer assignments to streamline how pull requests are routed for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->