### PR TITLE
chore: reformat, replace tabs with 4-space indent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 #AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: Left
 AlignEscapedNewlinesLeft: false
 AlignOperands:   true
 AlignAfterOpenBracket: DontAlign
@@ -20,6 +21,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BinPackParameters: true
+#BinPackLongBracedList: true
 BinPackArguments: true
 ColumnLimit:     80
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -46,9 +48,9 @@ PointerAlignment: Right
 #SpacesBeforeTrailingComments: 1
 Cpp11BracedListStyle: true
 Standard:        Cpp11
-IndentWidth:     8
-TabWidth:        8
-UseTab: ForIndentation
+IndentWidth:     4
+TabWidth:        4
+#UseTab: ForIndentation
 BreakBeforeBraces: Linux
 SortIncludes: false
 SpacesInParentheses: false
@@ -59,7 +61,6 @@ SpacesInCStyleCastParentheses: false
 SpaceAfterCStyleCast: false
 SpacesInContainerLiterals: true
 SpaceBeforeAssignmentOperators: true
-ContinuationIndentWidth: 4
 CommentPragmas:  '^ IWYU pragma:'
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 #SpaceBeforeParens: Never

--- a/arch.cc
+++ b/arch.cc
@@ -27,17 +27,18 @@
 void
 check_news(response_t *re)
 {
-	/* News article? */
-	if (!re->text.empty() && re->text[0].starts_with(",N")) {
-		/* Get article # */
-		if (sscanf(re->text[0].c_str() + 2, "%ld", &re->article) > 0 && re->article) {
-			re->text.clear();
-			get_article(re);
-		}
-		/* Get message id# */
-		if (re->text.size() > 1 && re->text[1].starts_with(",M"))
-			re->mid = re->text[1].substr(2);
-	}
+    /* News article? */
+    if (!re->text.empty() && re->text[0].starts_with(",N")) {
+        /* Get article # */
+        if (sscanf(re->text[0].c_str() + 2, "%ld", &re->article) > 0 &&
+            re->article) {
+            re->text.clear();
+            get_article(re);
+        }
+        /* Get message id# */
+        if (re->text.size() > 1 && re->text[1].starts_with(",M"))
+            re->mid = re->text[1].substr(2);
+    }
 }
 #endif
 
@@ -55,138 +56,135 @@ get_resp(           /* ARGUMENTS                      */
     int fast,       /* Don't save the actual text? */
     int num)
 {
-	std::string buff;
-	char done = 0;
+    std::string buff;
+    char done = 0;
 
-	/* Get response */
-	if (re->offset >= 0 && re->numchars > 0 && fast == GR_ALL) {
-		if (fseek(fp, re->textoff, 0)) {
-			auto off = std::to_string(re->textoff);
-			error("fseeking to ", off);
-		}
-		auto text = grab_more(fp, ",E", NULL);
-		if ((flags & O_SIGNATURE) == 0 && (st_glob.c_security & CT_EMAIL) != 0) {
-			auto it = std::find(std::begin(text), std::end(text), "--");
-			text.erase(it, std::end(text));
-		}
-		re->text = text;
+    /* Get response */
+    if (re->offset >= 0 && re->numchars > 0 && fast == GR_ALL) {
+        if (fseek(fp, re->textoff, 0)) {
+            auto off = std::to_string(re->textoff);
+            error("fseeking to ", off);
+        }
+        auto text = grab_more(fp, ",E", NULL);
+        if ((flags & O_SIGNATURE) == 0 &&
+            (st_glob.c_security & CT_EMAIL) != 0) {
+            auto it = std::find(std::begin(text), std::end(text), "--");
+            text.erase(it, std::end(text));
+        }
+        re->text = text;
 #ifdef NEWS
-		check_news(re);
+        check_news(re);
 #endif
-		return;
-	}
-	if (re->offset >= 0 && fseek(fp, re->offset, 0)) {
-		error("fseeking to ", std::format("{}", re->textoff));
-	}
-	if (re->offset < 0) { /* Find start of response */
-		short i, j;
-		for (i = 1; i <= num && re[-i].endoff < 0; i++)
-			; /* find prev offset */
-		for (j = i - 1; j > 0; j--) {
-			get_resp(fp, &(re[-j]), GR_OFFSET, num - j);
-		}
-		if (num && fseek(fp, re[-1].endoff, 0)) {
-			error("fseeking to ", std::format("{}", re[-1].endoff));
-		}
-	}
-	if (fast == GR_OFFSET) {
-		re->offset = ftell(fp);
-		while (ngets(buff, fp))
-			if (buff.starts_with(",T"))
-				break;
-		re->textoff = ftell(fp);
-		for (;;) {
-			if (!ngets(buff, fp) || buff.starts_with(",E")) {
-				re->endoff = ftell(fp);
-				break;
-			}
-			if (buff.starts_with(",R")) {
-				re->endoff = ftell(fp) - buff.size() - 1;
-				break;
-			}
-		}
-		re->numchars = -1;
-	} else {
+        return;
+    }
+    if (re->offset >= 0 && fseek(fp, re->offset, 0)) {
+        error("fseeking to ", std::format("{}", re->textoff));
+    }
+    if (re->offset < 0) { /* Find start of response */
+        short i, j;
+        for (i = 1; i <= num && re[-i].endoff < 0; i++); /* find prev offset */
+        for (j = i - 1; j > 0; j--) {
+            get_resp(fp, &(re[-j]), GR_OFFSET, num - j);
+        }
+        if (num && fseek(fp, re[-1].endoff, 0)) {
+            error("fseeking to ", std::format("{}", re[-1].endoff));
+        }
+    }
+    if (fast == GR_OFFSET) {
+        re->offset = ftell(fp);
+        while (ngets(buff, fp))
+            if (buff.starts_with(",T"))
+                break;
+        re->textoff = ftell(fp);
+        for (;;) {
+            if (!ngets(buff, fp) || buff.starts_with(",E")) {
+                re->endoff = ftell(fp);
+                break;
+            }
+            if (buff.starts_with(",R")) {
+                re->endoff = ftell(fp) - buff.size() - 1;
+                break;
+            }
+        }
+        re->numchars = -1;
+    } else {
 
 #ifdef NEWS
-		re->mid.clear();
-		re->article = 0;
+        re->mid.clear();
+        re->article = 0;
 #endif
-		re->parent = 0;
+        re->parent = 0;
 
-		while (!done && !(status & S_INT)) {
-			if (!ngets(buff, fp))
-				break; /* UNK error */
-			if (buff.size() < 2)
-				continue;
-			switch (buff[1]) {
-			case 'A':
-				re->fullname = buff.substr(2);
-				break;
+        while (!done && !(status & S_INT)) {
+            if (!ngets(buff, fp))
+                break; /* UNK error */
+            if (buff.size() < 2)
+                continue;
+            switch (buff[1]) {
+            case 'A':
+                re->fullname = buff.substr(2);
+                break;
 #if (SIZEOF_LONG == 8)
-			case 'D':
-				sscanf(buff.c_str() + 2, "%x", &(re->date));
-				break;
+            case 'D':
+                sscanf(buff.c_str() + 2, "%x", &(re->date));
+                break;
 #else
-			case 'D':
-				sscanf(buff.c_str() + 2, "%lx", &(re->date));
-				break;
+            case 'D':
+                sscanf(buff.c_str() + 2, "%lx", &(re->date));
+                break;
 #endif
-			case 'E':
-				done = 1;
-				re->endoff = ftell(fp);
-				break;
-			case 'R':
-				re->offset = ftell(fp) - buff.size() - 1;
-				sscanf(buff.c_str() + 2, "%hx", &(re->flags));
-				break;
-			/*
-		        case 'M':
-				re->mid = buff.substr(2);
-				break;
-			*/
-			case 'P':
-				sscanf(buff.c_str() + 2, "%hd", &(re->parent));
-				re->parent++;
-				break;
-			case 'T':
-				re->textoff = ftell(fp);
-				re->numchars = 0;
-				if (fast == GR_ALL) {
-					size_t endlen;
-					re->text = grab_more(fp, ",E", &endlen);
-					re->numchars = /*-",E"*/
-					    ftell(fp) - re->textoff - (endlen + 1);
-				} else {
-					while (ngets(buff, fp) &&
-					       !buff.starts_with(",E") &&
-					       !buff.starts_with(",R"))
-						;
-					re->text.clear(); /*-",E..." */
-					re->numchars = ftell(fp) - re->textoff -
-					               (buff.size() + 1);
-				}
+            case 'E':
+                done = 1;
+                re->endoff = ftell(fp);
+                break;
+            case 'R':
+                re->offset = ftell(fp) - buff.size() - 1;
+                sscanf(buff.c_str() + 2, "%hx", &(re->flags));
+                break;
+            /*
+                case 'M':
+                re->mid = buff.substr(2);
+                break;
+            */
+            case 'P':
+                sscanf(buff.c_str() + 2, "%hd", &(re->parent));
+                re->parent++;
+                break;
+            case 'T':
+                re->textoff = ftell(fp);
+                re->numchars = 0;
+                if (fast == GR_ALL) {
+                    size_t endlen;
+                    re->text = grab_more(fp, ",E", &endlen);
+                    re->numchars = /*-",E"*/
+                        ftell(fp) - re->textoff - (endlen + 1);
+                } else {
+                    while (ngets(buff, fp) && !buff.starts_with(",E") &&
+                           !buff.starts_with(",R"));
+                    re->text.clear(); /*-",E..." */
+                    re->numchars = ftell(fp) - re->textoff - (buff.size() + 1);
+                }
 #ifdef NEWS
-				check_news(re);
+                check_news(re);
 #endif
-				done = 1;
-				break;
-			case 'U': {
-				const auto who = str::split(buff.c_str() + 2, ",", false);
-				const auto n = who.size();
-				re->uid = 0;
-				if (n > 0)
-					re->uid = str::toi(who[0]);
-				re->login = (n > 1) ? std::string(who[1]) : "Unknown";
-				break;
-			}
-			}
-		}
-	}
-	if (debug & DB_ARCH)
-		std::println(
-		    "get_resp: returning response author {} date {} flags {} textoff {}",
-		    re->login, get_date(re->date, 0), re->flags, re->textoff);
+                done = 1;
+                break;
+            case 'U': {
+                const auto who = str::split(buff.c_str() + 2, ",", false);
+                const auto n = who.size();
+                re->uid = 0;
+                if (n > 0)
+                    re->uid = str::toi(who[0]);
+                re->login = (n > 1) ? std::string(who[1]) : "Unknown";
+                break;
+            }
+            }
+        }
+    }
+    if (debug & DB_ARCH)
+        std::println("get_resp: returning response author {} date {} flags {} "
+                     "textoff {}",
+            re->login, get_date(re->date, 0), re->flags, re->textoff);
 }
 /******************************************************************************/
 /* READ IN INFORMATION SUMMARIZING ALL THE RESPONSES IN AN ITEM               */
@@ -201,29 +199,29 @@ get_item(                         /* ARGUMENTS:                            */
     sumentry_t sum[MAX_ITEMS]     /* Buffer array holding info on items */
 )
 {
-	short i;
-	long offset = 0;
-	/* For each response */
-	for (i = 0; i < MAX_RESPONSES; i++) {
-		re[i].offset = re[i].endoff = -1;
-		re[i].date = 0;
-	}
+    short i;
+    long offset = 0;
+    /* For each response */
+    for (i = 0; i < MAX_RESPONSES; i++) {
+        re[i].offset = re[i].endoff = -1;
+        re[i].date = 0;
+    }
 
-	/* Find EOF */
-	fseek(fp, 0L, 2);
-	offset = ftell(fp);
-	rewind(fp);
+    /* Find EOF */
+    fseek(fp, 0L, 2);
+    offset = ftell(fp);
+    rewind(fp);
 
-	/* Get all responses, and fix sum file NR value */
-	for (i = 0; !i || re[i - 1].endoff < offset; i++) {
-		get_resp(fp, &(re[i]), (short)GR_OFFSET, i);
-		if (debug & DB_ARCH)
-			std::println("{:2} Offset = {:4} Textoff = {:4}", i,
-			    re[i].offset, re[i].textoff);
-	}
-	if (sum[n - 1].nr != i) {
-		sum[n - 1].nr = i;
-		save_sum(sum, (short)(n - 1), confidx, &st_glob);
-		dirty_sum(n - 1);
-	}
+    /* Get all responses, and fix sum file NR value */
+    for (i = 0; !i || re[i - 1].endoff < offset; i++) {
+        get_resp(fp, &(re[i]), (short)GR_OFFSET, i);
+        if (debug & DB_ARCH)
+            std::println("{:2} Offset = {:4} Textoff = {:4}", i, re[i].offset,
+                re[i].textoff);
+    }
+    if (sum[n - 1].nr != i) {
+        sum[n - 1].nr = i;
+        save_sum(sum, (short)(n - 1), confidx, &st_glob);
+        dirty_sum(n - 1);
+    }
 }

--- a/change.cc
+++ b/change.cc
@@ -41,9 +41,9 @@
 #include "user.h"
 #include "yapp.h"
 
-const char *cfiles[] = {"logi_n", "logo_ut", "in_dex", "b_ull",
-    "we_lcome", "html_header", "rc", "sec_ret", "ul_ist",
-    "origin_list", "obs_ervers", "acl", "rc.www", ""};
+const char *cfiles[] = {"logi_n", "logo_ut", "in_dex", "b_ull", "we_lcome",
+    "html_header", "rc", "sec_ret", "ul_ist", "origin_list", "obs_ervers",
+    "acl", "rc.www", ""};
 
 //*****************************************************************************
 // CHANGE SYSTEM PARAMETERS
@@ -54,199 +54,193 @@ const char *cfiles[] = {"logi_n", "logo_ut", "in_dex", "b_ull",
 int
 change(int argc, char **argv)
 {
-	std::string buff;
-	bool done = false;
-	short i, j;
+    std::string buff;
+    bool done = false;
+    short i, j;
 
-	if (argc < 2) {
-		std::println("Change what?");
-		return 1;
-	}
-	for (j = 1; j < argc; j++) {
-		/* Security measure */
-		if ((orig_stdin[stdin_stack_top].type & STD_SANE) &&
-		    match(argv[j], "noverbose"))
-			continue;
+    if (argc < 2) {
+        std::println("Change what?");
+        return 1;
+    }
+    for (j = 1; j < argc; j++) {
+        /* Security measure */
+        if ((orig_stdin[stdin_stack_top].type & STD_SANE) &&
+            match(argv[j], "noverbose"))
+            continue;
 
-		/* Process changing flags */
-		for (const auto &opt : option) {
-			if (match(argv[j], opt.name)) {
-				flags |= opt.mask;
-				done = true;
-				break;
-			} else if (strncmp(argv[j], "no", 2) == 0 &&
-			           match(argv[j] + 2, opt.name)) {
-				flags &= ~opt.mask;
-				done = true;
-				break;
-			}
-		}
-		if (done)
-			continue;
+        /* Process changing flags */
+        for (const auto &opt : option) {
+            if (match(argv[j], opt.name)) {
+                flags |= opt.mask;
+                done = true;
+                break;
+            } else if (strncmp(argv[j], "no", 2) == 0 &&
+                       match(argv[j] + 2, opt.name)) {
+                flags &= ~opt.mask;
+                done = true;
+                break;
+            }
+        }
+        if (done)
+            continue;
 
-		if (match(argv[j], "n_ame") || match(argv[j], "full_name") ||
-		    match(argv[j], "u_ser")) {
-			std::println("Your old name is: {}", st_glob.fullname);
-			if (!(flags & O_QUIET)) {
-				std::print("Enter replacement or return to keep old? ");
-				std::fflush(stdout);
-			}
-			if (ngets(buff, st_glob.inp) && !buff.empty()) {
-				/* Expand seps in name IF first character is %
-				 */
-				if (buff[0] == '%') {
-					const char *str, *f;
-					str = buff.c_str() + 1;
-					f = get_sep(&str);
-					buff = f;
-				}
-				if (sane_fullname(buff))
-					st_glob.fullname = buff;
-			} else
-				std::println("Name not changed.");
-		} else if (match(argv[j], "p_assword") ||
-		           match(argv[j], "passwd")) {
-			passwd(0, NULL);
-		} else if (match(argv[j], "li_st")) {
-			if (partfile_perm() == SL_USER)
-				edit(partdir, ".cflist", 0);
-			else
-				priv_edit(partdir, ".cflist",
-				    2); /* 2=force install */
-			refresh_list();
-		} else if (match(argv[j], "cfonce")) {
-			edit(work, ".cfonce", 0);
-		} else if (match(argv[j], "cfrc")) {
-			edit(work, ".cfrc", 0);
-		} else if (match(argv[j], "cfjoin")) {
-			edit(work, ".cfjoin", 0);
-		} else if (match(argv[j], "cgirc") ||
-		           match(argv[j], "illegal") ||
-		           match(argv[j], "matched")) {
-			struct stat st;
-			const auto defpath =
-			    str::concat({get_conf_param("bbsdir", BBSDIR), "/www"});
-			const auto wwwdir = get_conf_param("wwwdir", defpath);
-			if (!is_sysop(0))
-				return 1;
-			std::string file;
-			if (argv[j][0] == 'c')
-				file = str::concat({wwwdir, "/rc.", expand("cgidir", DM_VAR)});
-			else
-				file = str::join("/", {wwwdir, argv[j]});
+        if (match(argv[j], "n_ame") || match(argv[j], "full_name") ||
+            match(argv[j], "u_ser")) {
+            std::println("Your old name is: {}", st_glob.fullname);
+            if (!(flags & O_QUIET)) {
+                std::print("Enter replacement or return to keep old? ");
+                std::fflush(stdout);
+            }
+            if (ngets(buff, st_glob.inp) && !buff.empty()) {
+                /* Expand seps in name IF first character is %
+                 */
+                if (buff[0] == '%') {
+                    const char *str, *f;
+                    str = buff.c_str() + 1;
+                    f = get_sep(&str);
+                    buff = f;
+                }
+                if (sane_fullname(buff))
+                    st_glob.fullname = buff;
+            } else
+                std::println("Name not changed.");
+        } else if (match(argv[j], "p_assword") || match(argv[j], "passwd")) {
+            passwd(0, NULL);
+        } else if (match(argv[j], "li_st")) {
+            if (partfile_perm() == SL_USER)
+                edit(partdir, ".cflist", 0);
+            else
+                priv_edit(partdir, ".cflist", 2); /* 2=force install */
+            refresh_list();
+        } else if (match(argv[j], "cfonce")) {
+            edit(work, ".cfonce", 0);
+        } else if (match(argv[j], "cfrc")) {
+            edit(work, ".cfrc", 0);
+        } else if (match(argv[j], "cfjoin")) {
+            edit(work, ".cfjoin", 0);
+        } else if (match(argv[j], "cgirc") || match(argv[j], "illegal") ||
+                   match(argv[j], "matched")) {
+            struct stat st;
+            const auto defpath =
+                str::concat({get_conf_param("bbsdir", BBSDIR), "/www"});
+            const auto wwwdir = get_conf_param("wwwdir", defpath);
+            if (!is_sysop(0))
+                return 1;
+            std::string file;
+            if (argv[j][0] == 'c')
+                file = str::concat({wwwdir, "/rc.", expand("cgidir", DM_VAR)});
+            else
+                file = str::join("/", {wwwdir, argv[j]});
 
-			/* Assert existence of file */
-			if (stat(file.c_str(), &st)) {
-				FILE *fp = fopen(file.c_str(), "w");
-				if (fp == NULL) {
-					error("creating ", file);
-					return 1;
-				}
-				fclose(fp);
-			}
-			priv_edit(file, "", 0);
-			return 1;
-		} else if (match(argv[j], "ig_noreeof")) {
-			unix_cmd("/bin/stty eof ^-");
-		} else if (match(argv[j], "noig_noreeof")) {
-			unix_cmd("/bin/stty eof ^D");
-		} else if (match(argv[j], "ch_at")) {
-			unix_cmd("mesg y");
-		} else if (match(argv[j], "noch_at")) {
-			unix_cmd("mesg n");
-		} else if (match(argv[j], "resign")) {
-			command("resign", 0);
-		} else if (match(argv[j], "sa_ne")) {
-			undefine(DM_SANE);
-		} else if (match(argv[j], "supers_ane")) {
-			undefine(DM_SANE | DM_SUPERSANE);
-		} else if (match(argv[j], "save_seen")) {
-			if (confidx >= 0) {
-				const auto config = get_config(confidx);
-				if (config.size() > CF_PARTFILE)
-					write_part(config[CF_PARTFILE]);
-			}
-		} else if (match(argv[j], "sum_mary")) {
-			if (!(st_glob.c_status & CS_FW)) {
-				wputs("Sorry, you can't do that!\n");
-				return 1;
-			}
-			std::println("Regenerating summary file; please wait");
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			save_sum(sum, (short)-1, confidx, &st_glob);
+            /* Assert existence of file */
+            if (stat(file.c_str(), &st)) {
+                FILE *fp = fopen(file.c_str(), "w");
+                if (fp == NULL) {
+                    error("creating ", file);
+                    return 1;
+                }
+                fclose(fp);
+            }
+            priv_edit(file, "", 0);
+            return 1;
+        } else if (match(argv[j], "ig_noreeof")) {
+            unix_cmd("/bin/stty eof ^-");
+        } else if (match(argv[j], "noig_noreeof")) {
+            unix_cmd("/bin/stty eof ^D");
+        } else if (match(argv[j], "ch_at")) {
+            unix_cmd("mesg y");
+        } else if (match(argv[j], "noch_at")) {
+            unix_cmd("mesg n");
+        } else if (match(argv[j], "resign")) {
+            command("resign", 0);
+        } else if (match(argv[j], "sa_ne")) {
+            undefine(DM_SANE);
+        } else if (match(argv[j], "supers_ane")) {
+            undefine(DM_SANE | DM_SUPERSANE);
+        } else if (match(argv[j], "save_seen")) {
+            if (confidx >= 0) {
+                const auto config = get_config(confidx);
+                if (config.size() > CF_PARTFILE)
+                    write_part(config[CF_PARTFILE]);
+            }
+        } else if (match(argv[j], "sum_mary")) {
+            if (!(st_glob.c_status & CS_FW)) {
+                wputs("Sorry, you can't do that!\n");
+                return 1;
+            }
+            std::println("Regenerating summary file; please wait");
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            save_sum(sum, (short)-1, confidx, &st_glob);
 #ifdef SUBJFILE
-			rewrite_subj(confidx); /* re-write subjects file */
+            rewrite_subj(confidx); /* re-write subjects file */
 #endif
-		} else if (match(argv[j], "nosum_mary")) {
-			if (!(st_glob.c_status & CS_FW)) {
-				wputs("Sorry, you can't do that!\n");
-				return 1;
-			}
-			const auto path = str::concat({conflist[confidx].location, "/sum"});
-			rm(path, SL_OWNER);
+        } else if (match(argv[j], "nosum_mary")) {
+            if (!(st_glob.c_status & CS_FW)) {
+                wputs("Sorry, you can't do that!\n");
+                return 1;
+            }
+            const auto path = str::concat({conflist[confidx].location, "/sum"});
+            rm(path, SL_OWNER);
 #ifdef SUBJFILE
-			const auto subjpath = str::concat({conflist[confidx].location, "/subjects"});
-			rm(subjpath, SL_OWNER);
-			clear_subj(confidx); /* re-write subjects file */
+            const auto subjpath =
+                str::concat({conflist[confidx].location, "/subjects"});
+            rm(subjpath, SL_OWNER);
+            clear_subj(confidx); /* re-write subjects file */
 #endif
-		} else if (match(argv[j], "rel_oad")) {
-			if (confidx >= 0) {
-				const auto config = get_config(confidx);
-				if (config.size() > CF_PARTFILE)
-					read_part(config[CF_PARTFILE], part, &st_glob, confidx);
-			}
-			st_glob.sumtime = 0;
-		} else if (match(argv[j], "config")) {
-			if (!is_sysop(0))
-				return 1;
-			if (confidx >= 0) {
-				priv_edit(
-				    conflist[confidx].location, "config", 0);
-				clear_cache();
-				const auto config = get_config(confidx);
-				if (!config.empty()) {
-					st_glob.c_security = security_type(config, confidx);
-					upd_maillist(st_glob.c_security, config, confidx);
-				}
-			}
-			return 1;
-		} else {
-			for (i = 0; cfiles[i][0]; i++) {
-				if (match(argv[j], cfiles[i])) {
-					if (i == 11) {
-						if (!check_acl(CHACL_RIGHT, confidx)) {
-							if ((flags & O_QUIET) == 0)
-								std::println("Permission denied.");
-							return 1;
-						}
-					} else {
-						if (!(st_glob.c_status &
-						        CS_FW)) {
-							std::println("You aren't a {}.",
-							    fairwitness());
-							return 1;
-						}
-					}
-					priv_edit(conflist[confidx].location, compress(cfiles[i]), 0);
-					const auto path = str::join("/",
-					    {conflist[confidx].location, compress(cfiles[i])});
-					chmod(path.c_str(),
-					    (st_glob.c_security & CT_BASIC)
-					        ? 0600
-					        : 0644);
+        } else if (match(argv[j], "rel_oad")) {
+            if (confidx >= 0) {
+                const auto config = get_config(confidx);
+                if (config.size() > CF_PARTFILE)
+                    read_part(config[CF_PARTFILE], part, &st_glob, confidx);
+            }
+            st_glob.sumtime = 0;
+        } else if (match(argv[j], "config")) {
+            if (!is_sysop(0))
+                return 1;
+            if (confidx >= 0) {
+                priv_edit(conflist[confidx].location, "config", 0);
+                clear_cache();
+                const auto config = get_config(confidx);
+                if (!config.empty()) {
+                    st_glob.c_security = security_type(config, confidx);
+                    upd_maillist(st_glob.c_security, config, confidx);
+                }
+            }
+            return 1;
+        } else {
+            for (i = 0; cfiles[i][0]; i++) {
+                if (match(argv[j], cfiles[i])) {
+                    if (i == 11) {
+                        if (!check_acl(CHACL_RIGHT, confidx)) {
+                            if ((flags & O_QUIET) == 0)
+                                std::println("Permission denied.");
+                            return 1;
+                        }
+                    } else {
+                        if (!(st_glob.c_status & CS_FW)) {
+                            std::println("You aren't a {}.", fairwitness());
+                            return 1;
+                        }
+                    }
+                    priv_edit(
+                        conflist[confidx].location, compress(cfiles[i]), 0);
+                    const auto path = str::join(
+                        "/", {conflist[confidx].location, compress(cfiles[i])});
+                    chmod(path.c_str(),
+                        (st_glob.c_security & CT_BASIC) ? 0600 : 0644);
 
-					/* Re-initialize acl when doing "change
-					 * acl" */
-					if (i == 11)
-						reinit_acl();
-					return 1;
-				}
-			}
-			std::println("Bad parameters near \"{}\"", argv[j]);
-			return 2;
-		}
-	}
-	return 1;
+                    /* Re-initialize acl when doing "change
+                     * acl" */
+                    if (i == 11)
+                        reinit_acl();
+                    return 1;
+                }
+            }
+            std::println("Bad parameters near \"{}\"", argv[j]);
+            return 2;
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* DISPLAY SYSTEM PARAMETERS                                                  */
@@ -257,243 +251,236 @@ change(int argc, char **argv)
 int
 display(int argc, char **argv)
 {
-	time_t t;
-	const char *noconferr = "Not in a conference!\n";
-	short i, j;
-	bool done = false;
+    time_t t;
+    const char *noconferr = "Not in a conference!\n";
+    short i, j;
+    bool done = false;
 
-	for (j = 1; j < argc; j++) {
-		/* Display flag settings */
-		for (const auto &opt : option) {
-			if (match(argv[j], opt.name)) {
-				std::println("{} flag is {}",
-				    compress(opt.name),
-				    (flags & opt.mask) ? "on" : "off");
-				done = true;
-				break;
-			}
-		}
-		if (match(argv[j], "ma_iltext")) {
-			refresh_stats(sum, part, &st_glob);
-			check_mail(1);
-		}
-		if (done)
-			continue;
+    for (j = 1; j < argc; j++) {
+        /* Display flag settings */
+        for (const auto &opt : option) {
+            if (match(argv[j], opt.name)) {
+                std::println("{} flag is {}", compress(opt.name),
+                    (flags & opt.mask) ? "on" : "off");
+                done = true;
+                break;
+            }
+        }
+        if (match(argv[j], "ma_iltext")) {
+            refresh_stats(sum, part, &st_glob);
+            check_mail(1);
+        }
+        if (done)
+            continue;
 
-		if (match(argv[j], "fl_ags")) {
-			for (const auto &opt : option) {
-				std::print("{:<10} : {}{}",
-				    compress(opt.name),
-				    (flags & opt.mask) ? "ON " : "off",
-				    (i % 4 == 3) ? "\n" : "    ");
-			}
-			if (i % 4)
-				std::println("");
-		} else if (match(argv[j], "c_onference")) {
-			refresh_stats(sum, part, &st_glob);
-			sepinit(IS_START);
-			confsep(expand("confmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "conferences")) {
-			command("list", 0);
-		} else if (match(argv[j], "d_ate") || match(argv[j], "t_ime")) {
-			time(&t);
-			std::print("Time is {}", ctime(&t));
-		} else if (match(argv[j], "def_initions") ||
-		           match(argv[j], "ma_cros")) {
-			command("define", 0);
-		} else if (match(argv[j], "v_ersion")) {
-			extern const char *regto;
-			std::println("YAPP {}  Copyright (c)1995 Armidale Software", VERSION);
-			std::println("{}", regto);
-		} else if (match(argv[j], "ret_ired")) {
-			int c = 0;
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			std::print("{}s retired:", Topic());
-			for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
-				if (sum[i - 1].flags & IF_RETIRED) {
-					if (!c)
-						std::println("");
-					std::print("{:4}", i);
-					c++;
-				}
-			}
-			if (c)
-				std::println("Total: {} {}s retired.\n", c, topic());
-			else
-				std::println(" <none>");
-		} else if (match(argv[j], "fro_zen")) {
-			int c = 0;
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			std::print("{}s frozen:", Topic());
-			for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
-				if (sum[i - 1].flags & IF_FROZEN) {
-					if (!c)
-						std::println("");
-					std::println("{:4}", i);
-					c++;
-				}
-			}
-			if (c)
-				std::println("\nTotal: {} {}s frozen.", c, topic());
-			else
-				std::println(" <none>");
-		} else if (match(argv[j], "f_orgotten")) {
-			int c = 0;
-			std::print("{}s forgotten:", Topic());
-			for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
-				if (part[i - 1].nr < 0) {
-					if (!c)
-						std::println("");
-					std::println("{:4}", i);
-					c++;
-				}
-			}
-			if (c)
-				std::println("\nTotal: {} {}s forgotten.", c, topic());
-			else
-				std::println(" <none>");
-		} else if (match(argv[j], "sup_eruser")) {
-			std::println("fw superuser {}",
-			    (st_glob.c_status & CS_FW) ? "yes" : "no");
-		} else if (match(argv[j], "fw_slist") ||
-		           match(argv[j], "fair_witnesslist") ||
-		           match(argv[j], "fair_witnesses")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else {
-				const auto config = get_config(confidx);
-				if (config.size() > CF_FWLIST)
-					std::println("fair witnesses: {}", config[CF_FWLIST]);
-			}
-		} else if (match(argv[j], "i_ndex") ||
-		           match(argv[j], "ag_enda")) {
-			sepinit(IS_START);
-			confsep(expand("indxmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "li_st")) {
-			show_cflist();
-		} else if (match(argv[j], "b_ulletin")) {
-			sepinit(IS_START);
-			confsep(expand("bullmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "w_elcome")) {
-			sepinit(IS_START);
-			confsep(expand("wellmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "logi_n")) {
-			sepinit(IS_START);
-			confsep(expand("linmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "logo_ut")) {
-			sepinit(IS_START);
-			confsep(expand("loutmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else if (match(argv[j], "cfjoin")) {
-			more(work, ".cfjoin");
-		} else if (match(argv[j], "cfonce")) {
-			more(work, ".cfonce");
-		} else if (match(argv[j], "cfrc")) {
-			more(work, ".cfrc");
+        if (match(argv[j], "fl_ags")) {
+            for (const auto &opt : option) {
+                std::print("{:<10} : {}{}", compress(opt.name),
+                    (flags & opt.mask) ? "ON " : "off",
+                    (i % 4 == 3) ? "\n" : "    ");
+            }
+            if (i % 4)
+                std::println("");
+        } else if (match(argv[j], "c_onference")) {
+            refresh_stats(sum, part, &st_glob);
+            sepinit(IS_START);
+            confsep(expand("confmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "conferences")) {
+            command("list", 0);
+        } else if (match(argv[j], "d_ate") || match(argv[j], "t_ime")) {
+            time(&t);
+            std::print("Time is {}", ctime(&t));
+        } else if (match(argv[j], "def_initions") ||
+                   match(argv[j], "ma_cros")) {
+            command("define", 0);
+        } else if (match(argv[j], "v_ersion")) {
+            extern const char *regto;
+            std::println(
+                "YAPP {}  Copyright (c)1995 Armidale Software", VERSION);
+            std::println("{}", regto);
+        } else if (match(argv[j], "ret_ired")) {
+            int c = 0;
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            std::print("{}s retired:", Topic());
+            for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
+                if (sum[i - 1].flags & IF_RETIRED) {
+                    if (!c)
+                        std::println("");
+                    std::print("{:4}", i);
+                    c++;
+                }
+            }
+            if (c)
+                std::println("Total: {} {}s retired.\n", c, topic());
+            else
+                std::println(" <none>");
+        } else if (match(argv[j], "fro_zen")) {
+            int c = 0;
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            std::print("{}s frozen:", Topic());
+            for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
+                if (sum[i - 1].flags & IF_FROZEN) {
+                    if (!c)
+                        std::println("");
+                    std::println("{:4}", i);
+                    c++;
+                }
+            }
+            if (c)
+                std::println("\nTotal: {} {}s frozen.", c, topic());
+            else
+                std::println(" <none>");
+        } else if (match(argv[j], "f_orgotten")) {
+            int c = 0;
+            std::print("{}s forgotten:", Topic());
+            for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
+                if (part[i - 1].nr < 0) {
+                    if (!c)
+                        std::println("");
+                    std::println("{:4}", i);
+                    c++;
+                }
+            }
+            if (c)
+                std::println("\nTotal: {} {}s forgotten.", c, topic());
+            else
+                std::println(" <none>");
+        } else if (match(argv[j], "sup_eruser")) {
+            std::println(
+                "fw superuser {}", (st_glob.c_status & CS_FW) ? "yes" : "no");
+        } else if (match(argv[j], "fw_slist") ||
+                   match(argv[j], "fair_witnesslist") ||
+                   match(argv[j], "fair_witnesses")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else {
+                const auto config = get_config(confidx);
+                if (config.size() > CF_FWLIST)
+                    std::println("fair witnesses: {}", config[CF_FWLIST]);
+            }
+        } else if (match(argv[j], "i_ndex") || match(argv[j], "ag_enda")) {
+            sepinit(IS_START);
+            confsep(expand("indxmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "li_st")) {
+            show_cflist();
+        } else if (match(argv[j], "b_ulletin")) {
+            sepinit(IS_START);
+            confsep(expand("bullmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "w_elcome")) {
+            sepinit(IS_START);
+            confsep(expand("wellmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "logi_n")) {
+            sepinit(IS_START);
+            confsep(expand("linmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "logo_ut")) {
+            sepinit(IS_START);
+            confsep(expand("loutmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else if (match(argv[j], "cfjoin")) {
+            more(work, ".cfjoin");
+        } else if (match(argv[j], "cfonce")) {
+            more(work, ".cfonce");
+        } else if (match(argv[j], "cfrc")) {
+            more(work, ".cfrc");
 #ifdef WWW
-		} else if (match(argv[j], "origin_list")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "originlist");
+        } else if (match(argv[j], "origin_list")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "originlist");
 #endif
-		} else if (match(argv[j], "ul_ist")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "ulist");
-		} else if (match(argv[j], "obs_ervers")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "observers");
-		} else if (match(argv[j], "acl")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "acl");
-		} else if (match(argv[j], "html_header")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "htmlheader");
-		} else if (match(argv[j], "rc")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "rc");
-		} else if (match(argv[j], "wwwrc") ||
-		           match(argv[j], "rc.www")) {
-			/* conference specific WWW modified rc file */
-			if (confidx < 0)
-				wputs(noconferr);
-			else
-				more(conflist[confidx].location, "rc.www");
-		} else if (match(argv[j], "log_messages")) {
-			if (confidx < 0)
-				wputs(noconferr);
-			else {
-				std::println("login message:");
-				more(conflist[confidx].location, "login");
-				std::println("logout message:");
-				more(conflist[confidx].location, "logout");
-			}
-		} else if (match(argv[j], "n_ew")) {
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			sepinit(IS_ITEM);
-			open_pipe();
-			confsep(expand("linmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-			check_mail(1);
-		} else if (match(argv[j], "n_ame") || match(argv[j], "u_ser"))
-			std::println("User: {}", fullname_in_conference(&st_glob));
-		else if (match(argv[j], "p_articipants")) {
-			participants(0, (char **)0);
-		} else if (match(argv[j], "s_een")) {
-			int c = 0;
-			FILE *fp;
-			refresh_sum(0, confidx, sum, part, &st_glob);
+        } else if (match(argv[j], "ul_ist")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "ulist");
+        } else if (match(argv[j], "obs_ervers")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "observers");
+        } else if (match(argv[j], "acl")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "acl");
+        } else if (match(argv[j], "html_header")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "htmlheader");
+        } else if (match(argv[j], "rc")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "rc");
+        } else if (match(argv[j], "wwwrc") || match(argv[j], "rc.www")) {
+            /* conference specific WWW modified rc file */
+            if (confidx < 0)
+                wputs(noconferr);
+            else
+                more(conflist[confidx].location, "rc.www");
+        } else if (match(argv[j], "log_messages")) {
+            if (confidx < 0)
+                wputs(noconferr);
+            else {
+                std::println("login message:");
+                more(conflist[confidx].location, "login");
+                std::println("logout message:");
+                more(conflist[confidx].location, "logout");
+            }
+        } else if (match(argv[j], "n_ew")) {
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            sepinit(IS_ITEM);
+            open_pipe();
+            confsep(expand("linmsg", DM_VAR), confidx, &st_glob, part, 0);
+            check_mail(1);
+        } else if (match(argv[j], "n_ame") || match(argv[j], "u_ser"))
+            std::println("User: {}", fullname_in_conference(&st_glob));
+        else if (match(argv[j], "p_articipants")) {
+            participants(0, (char **)0);
+        } else if (match(argv[j], "s_een")) {
+            int c = 0;
+            FILE *fp;
+            refresh_sum(0, confidx, sum, part, &st_glob);
 
-			/* Display seen item status */
-			open_pipe();
-			if (status & S_PAGER)
-				fp = st_glob.outp;
-			else
-				fp = stdout;
-			std::println(fp, "{} se re fl   lastseen             etime                mtime", topic());
-			std::println(fp, "");
-			for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
-				if (!part[i - 1].nr)
-					continue;
-				std::print(fp, "{:4} {:2} {:2} {:2X}   {} ", i,
-				    abs(part[i - 1].nr), sum[i - 1].nr,
-				    sum[i - 1].flags,
-				    get_date(part[i - 1].last, 0).c_str() + 4);
-				std::print(fp, "{} ", get_date(sum[i - 1].first, 0).c_str() + 4);
-				std::println(fp, "{}", get_date(sum[i - 1].last, 0) .c_str()+ 4);
-				c++;
-			}
-			std::println(fp, "total {} {}s in seen map", c, topic());
-			std::println(fp, "");
-		} else if (match(argv[j], "s_ize"))
-			std::println("No longer supported");
-		else if (match(argv[j], "strings"))
-			std::println("No longer supported");
-		else if (match(argv[j], "fds"))
-			mdump();
-		else if (match(argv[j], "w_hoison"))
-			unix_cmd("who");
-		else if (const auto var = expand(argv[j], ~0); !var.empty())
-			std::println("{} = {}", argv[j], var);
-		else {
-			std::println("Bad parameters near \"{}\"", argv[j]);
-			return 2;
-		}
-	}
-	return 1;
+            /* Display seen item status */
+            open_pipe();
+            if (status & S_PAGER)
+                fp = st_glob.outp;
+            else
+                fp = stdout;
+            std::println(fp,
+                "{} se re fl   lastseen             etime                mtime",
+                topic());
+            std::println(fp, "");
+            for (i = st_glob.i_first; i <= st_glob.i_last; i++) {
+                if (!part[i - 1].nr)
+                    continue;
+                std::print(fp, "{:4} {:2} {:2} {:2X}   {} ", i,
+                    abs(part[i - 1].nr), sum[i - 1].nr, sum[i - 1].flags,
+                    get_date(part[i - 1].last, 0).c_str() + 4);
+                std::print(
+                    fp, "{} ", get_date(sum[i - 1].first, 0).c_str() + 4);
+                std::println(
+                    fp, "{}", get_date(sum[i - 1].last, 0).c_str() + 4);
+                c++;
+            }
+            std::println(fp, "total {} {}s in seen map", c, topic());
+            std::println(fp, "");
+        } else if (match(argv[j], "s_ize"))
+            std::println("No longer supported");
+        else if (match(argv[j], "strings"))
+            std::println("No longer supported");
+        else if (match(argv[j], "fds"))
+            mdump();
+        else if (match(argv[j], "w_hoison"))
+            unix_cmd("who");
+        else if (const auto var = expand(argv[j], ~0); !var.empty())
+            std::println("{} = {}", argv[j], var);
+        else {
+            std::println("Bad parameters near \"{}\"", argv[j]);
+            return 2;
+        }
+    }
+    return 1;
 }

--- a/conf.cc
+++ b/conf.cc
@@ -45,104 +45,106 @@ FILE *conffp;
 unsigned int
 security_type(const std::vector<std::string> &config, int idx)
 {
-	unsigned int sec = 0;
-	int i, n;
+    unsigned int sec = 0;
+    int i, n;
 
-	if (config.size() <= CF_SECURITY)
-		return 0;
-	const auto fields = str::split(config[CF_SECURITY], ", ");
-	n = fields.size();
-	for (i = 0; i < n; i++) {
-		if (isdigit(fields[i][0]))
-			sec |= str::toi(config[CF_SECURITY]);
-		else if (match(fields[i], "pass_word"))
-			sec = (sec & ~CT_BASIC) | CT_PASSWORD;
-		else if (match(fields[i], "ulist"))
-			sec = (sec & ~CT_BASIC) | CT_PRESELECT;
-		else if (match(fields[i], "pub_lic"))
-			sec = (sec & ~CT_BASIC) | CT_OLDPUBLIC;
-		else if (match(fields[i], "prot_ected"))
-			sec = (sec & ~CT_BASIC) | CT_PUBLIC;
-		else if (match(fields[i], "read_only"))
-			sec |= CT_READONLY;
+    if (config.size() <= CF_SECURITY)
+        return 0;
+    const auto fields = str::split(config[CF_SECURITY], ", ");
+    n = fields.size();
+    for (i = 0; i < n; i++) {
+        if (isdigit(fields[i][0]))
+            sec |= str::toi(config[CF_SECURITY]);
+        else if (match(fields[i], "pass_word"))
+            sec = (sec & ~CT_BASIC) | CT_PASSWORD;
+        else if (match(fields[i], "ulist"))
+            sec = (sec & ~CT_BASIC) | CT_PRESELECT;
+        else if (match(fields[i], "pub_lic"))
+            sec = (sec & ~CT_BASIC) | CT_OLDPUBLIC;
+        else if (match(fields[i], "prot_ected"))
+            sec = (sec & ~CT_BASIC) | CT_PUBLIC;
+        else if (match(fields[i], "read_only"))
+            sec |= CT_READONLY;
 #ifdef NEWS
-		else if (match(fields[i], "news_group"))
-			sec |= CT_NEWS;
+        else if (match(fields[i], "news_group"))
+            sec |= CT_NEWS;
 #endif
-		else if (match(fields[i], "mail_list"))
-			sec |= CT_EMAIL;
-		else if (match(fields[i], "reg_istered"))
-			sec |= CT_REGISTERED;
-		else if (match(fields[i], "noenter"))
-			sec |= CT_NOENTER;
-	}
+        else if (match(fields[i], "mail_list"))
+            sec |= CT_EMAIL;
+        else if (match(fields[i], "reg_istered"))
+            sec |= CT_REGISTERED;
+        else if (match(fields[i], "noenter"))
+            sec |= CT_NOENTER;
+    }
 
-	if ((sec & CT_EMAIL) && (config.size() <= CF_EMAIL || config[CF_EMAIL].empty())) {
-		sec &= ~CT_EMAIL;
-		error("email address for ", compress(conflist[idx].name));
-	}
+    if ((sec & CT_EMAIL) &&
+        (config.size() <= CF_EMAIL || config[CF_EMAIL].empty())) {
+        sec &= ~CT_EMAIL;
+        error("email address for ", compress(conflist[idx].name));
+    }
 #ifdef NEWS
-	if (config.size() <= CF_NEWSGROUP)
-		sec &= ~CT_NEWS;
+    if (config.size() <= CF_NEWSGROUP)
+        sec &= ~CT_NEWS;
 #endif
 
 #ifdef WWW
-	{ /* If we find an originfile, then turn on originlist flag */
-		struct stat st;
-		const auto originfile = conflist[idx].location + "/originlist";
-		/* was access(), but that uses uid not euid */
-		if (!stat(originfile.c_str(), &st))
-			sec |= CT_ORIGINLIST;
-	}
+    { /* If we find an originfile, then turn on originlist flag */
+        struct stat st;
+        const auto originfile = conflist[idx].location + "/originlist";
+        /* was access(), but that uses uid not euid */
+        if (!stat(originfile.c_str(), &st))
+            sec |= CT_ORIGINLIST;
+    }
 #endif
-	return sec;
+    return sec;
 }
 
 bool
 is_fairwitness(int idx) /* conference index */
 {
-	const auto config = get_config(idx);
-	if (config.size() <= CF_FWLIST)
-		return false;
-	const auto fw = str::split(config[CF_FWLIST], ", ");
-	return str::contains(fw, login) || str::contains(fw, std::to_string(uid)) || is_sysop(1);
+    const auto config = get_config(idx);
+    if (config.size() <= CF_FWLIST)
+        return false;
+    const auto fw = str::split(config[CF_FWLIST], ", ");
+    return str::contains(fw, login) || str::contains(fw, std::to_string(uid)) ||
+           is_sysop(1);
 }
 
 std::vector<std::string>
 grab_recursive_list(const std::string &dir, const std::string &filename)
 {
-	constexpr size_t MAX = 1000000;
-	auto v = grab_file(dir, filename, GF_SILENT | GF_WORD | GF_IGNCMT);
-	if (v.empty())
-		return v;
-	size_t nl = v.size();
-	for (size_t i = 0; nl < MAX && i < nl; i++) {
-		if (!v[i].starts_with("/"))
-			continue;
-		// If it's another file, replace element with first element
-		// in list from file, and append the rest of the file's list
-		// to the end of the current list.  Note that we decrement
-		// the current index, so that the element we just put into
-		// this position will be considered on the next iteration.
-		const auto b = grab_file(v[i], "", GF_SILENT | GF_WORD | GF_IGNCMT);
-		if (b.empty()) {
-			// Replace file element with last in list.
-			v[i--] = v[--nl];
-			v.pop_back();
-			continue;
-		}
-		// Otherwise, set the current element to the first element
-		// of the new file, and append the rest of its contents, an
-		// additional b.size() - 1 lines, o the list and adjust the
-		// total size accordingly.  Note that we decrement the index
-		// so that the newly placed element at this position will be
-		// inspected on the next iteration of the loop.
-		v[i--] = b[0];
-		v.insert(v.end(), b.begin() + 1, b.end());
-		nl += b.size() - 1;
-	}
+    constexpr size_t MAX = 1000000;
+    auto v = grab_file(dir, filename, GF_SILENT | GF_WORD | GF_IGNCMT);
+    if (v.empty())
+        return v;
+    size_t nl = v.size();
+    for (size_t i = 0; nl < MAX && i < nl; i++) {
+        if (!v[i].starts_with("/"))
+            continue;
+        // If it's another file, replace element with first element
+        // in list from file, and append the rest of the file's list
+        // to the end of the current list.  Note that we decrement
+        // the current index, so that the element we just put into
+        // this position will be considered on the next iteration.
+        const auto b = grab_file(v[i], "", GF_SILENT | GF_WORD | GF_IGNCMT);
+        if (b.empty()) {
+            // Replace file element with last in list.
+            v[i--] = v[--nl];
+            v.pop_back();
+            continue;
+        }
+        // Otherwise, set the current element to the first element
+        // of the new file, and append the rest of its contents, an
+        // additional b.size() - 1 lines, o the list and adjust the
+        // total size accordingly.  Note that we decrement the index
+        // so that the newly placed element at this position will be
+        // inspected on the next iteration of the loop.
+        v[i--] = b[0];
+        v.insert(v.end(), b.begin() + 1, b.end());
+        nl += b.size() - 1;
+    }
 
-	return v;
+    return v;
 }
 
 // ARGUMENTS:
@@ -151,21 +153,19 @@ grab_recursive_list(const std::string &dir, const std::string &filename)
 bool
 is_inlistfile(int idx, const std::string &file)
 {
-	const auto lines{
-	    file[0] == '/' ?
-		grab_recursive_list(file, "") :
-		grab_recursive_list(conflist[idx].location, file)
-	};
-	const auto uidstr = std::to_string(uid);
-	return str::contains(lines, login) || str::contains(lines, uidstr);
+    const auto lines{file[0] == '/'
+                         ? grab_recursive_list(file, "")
+                         : grab_recursive_list(conflist[idx].location, file)};
+    const auto uidstr = std::to_string(uid);
+    return str::contains(lines, login) || str::contains(lines, uidstr);
 }
 
 std::string_view
 fullname_in_conference(status_t *stt)
 {
-	if (!stt->fullname[0] || str::eq(stt->fullname, DEFAULT_PSEUDO))
-		return fullname;
-	return stt->fullname;
+    if (!stt->fullname[0] || str::eq(stt->fullname, DEFAULT_PSEUDO))
+        return fullname;
+    return stt->fullname;
 }
 /******************************************************************************/
 /* PROCESS COMMAND LINE ARGUMENTS                                             */
@@ -182,161 +182,160 @@ Description:
 char
 join(const std::string &conf, int force, int secure)
 {
-	char buff[MAX_LINE_LENGTH];
-	struct stat st;
-	time_t t1;
-	int cp;
+    char buff[MAX_LINE_LENGTH];
+    struct stat st;
+    time_t t1;
+    int cp;
 
-	/* Initialize st_new structure */
-	st_new.outp = st_glob.outp;
-	st_new.inp = st_glob.inp;
-	st_new.mailsize = st_glob.mailsize;
-	st_new.c_security = st_new.i_current = st_new.c_status = 0;
-	st_new.sumtime = 0;
+    /* Initialize st_new structure */
+    st_new.outp = st_glob.outp;
+    st_new.inp = st_glob.inp;
+    st_new.mailsize = st_glob.mailsize;
+    st_new.c_security = st_new.i_current = st_new.c_status = 0;
+    st_new.sumtime = 0;
 #ifdef NEWS
-	st_new.c_article = 0;
+    st_new.c_article = 0;
 #endif
 
-	/* Reset name */
-	st_new.fullname = fullname;
+    /* Reset name */
+    st_new.fullname = fullname;
 
-	/* Check for existence */
-	if (conf.empty())
-		return 0;
-	joinidx = get_idx(conf, conflist);
-	if (joinidx < 0) {
-		if (!(flags & O_QUIET))
-			std::println("Cannot access {} {}.", conference(), conf);
-		return 0;
-	}
-	if (debug & DB_CONF)
-		std::println("join: {} dir={}", joinidx, conflist[joinidx].location);
+    /* Check for existence */
+    if (conf.empty())
+        return 0;
+    joinidx = get_idx(conf, conflist);
+    if (joinidx < 0) {
+        if (!(flags & O_QUIET))
+            std::println("Cannot access {} {}.", conference(), conf);
+        return 0;
+    }
+    if (debug & DB_CONF)
+        std::println("join: {} dir={}", joinidx, conflist[joinidx].location);
 
-	/* Read in config file */
-	const auto config = get_config(joinidx);
-	if (config.empty())
-		return 0;
+    /* Read in config file */
+    const auto config = get_config(joinidx);
+    if (config.empty())
+        return 0;
 
-	/* Pass security checks */
-	st_new.c_security = security_type(config, joinidx);
+    /* Pass security checks */
+    st_new.c_security = security_type(config, joinidx);
 
-	if (secure)
-		cp = secure;
-	else {
-		cp = check_acl(JOIN_RIGHT, joinidx);
-		if (!cp)
-			if (!(flags & O_QUIET)) {
-				std::cout << "You are not allowed to access the " <<
-				    compress(conflist[joinidx].name) << " " <<
-				    conference() << "." << std::endl;
-			}
-	}
+    if (secure)
+        cp = secure;
+    else {
+        cp = check_acl(JOIN_RIGHT, joinidx);
+        if (!cp)
+            if (!(flags & O_QUIET)) {
+                std::cout << "You are not allowed to access the "
+                          << compress(conflist[joinidx].name) << " "
+                          << conference() << "." << std::endl;
+            }
+    }
 
-	if (!cp) {
-		if (st_new.c_security & CT_READONLY)
-			force |= O_READONLY;
-		else {
-			return 0;
-		}
-	}
+    if (!cp) {
+        if (st_new.c_security & CT_READONLY)
+            force |= O_READONLY;
+        else {
+            return 0;
+        }
+    }
 
-	/* Force READONLY if login is in observer file */
-	if (is_inlistfile(joinidx, "observers"))
-		force |= O_READONLY;
+    /* Force READONLY if login is in observer file */
+    if (is_inlistfile(joinidx, "observers"))
+        force |= O_READONLY;
 
-	/* Do stuff with PARTDIR/.name.cf */
-	const auto partfile = str::join("/", {partdir, config[CF_PARTFILE]});
-	if (debug & DB_CONF)
-		std::println("join: Partfile={}", partfile);
-	if (stat(partfile.c_str(), &st)) { /* Not a member */
-		if (!((flags | force) & O_OBSERVE)) {
-			/* Main JOQ cmd loop */
-			mode = M_JOQ;
-			if ((flags | force) & O_AUTOJOIN) {
-				if (!(flags & O_QUIET)) {
-					const auto msg = std::format(
-					    "You are being automatically registered in {}\n",
-					    conflist[joinidx].location);
-					wputs(buff);
-				}
-				command("join", 0);
-			} else {
-				if (!(flags & O_QUIET)) {
-					std::println("You are not a member of {}",
-					    conflist[joinidx].location);
-					std::print("Do you wish to:");
-				}
-				while (mode == M_JOQ && get_command("", 0))
-					;
-			}
+    /* Do stuff with PARTDIR/.name.cf */
+    const auto partfile = str::join("/", {partdir, config[CF_PARTFILE]});
+    if (debug & DB_CONF)
+        std::println("join: Partfile={}", partfile);
+    if (stat(partfile.c_str(), &st)) { /* Not a member */
+        if (!((flags | force) & O_OBSERVE)) {
+            /* Main JOQ cmd loop */
+            mode = M_JOQ;
+            if ((flags | force) & O_AUTOJOIN) {
+                if (!(flags & O_QUIET)) {
+                    const auto msg = std::format(
+                        "You are being automatically registered in {}\n",
+                        conflist[joinidx].location);
+                    wputs(buff);
+                }
+                command("join", 0);
+            } else {
+                if (!(flags & O_QUIET)) {
+                    std::println("You are not a member of {}",
+                        conflist[joinidx].location);
+                    std::print("Do you wish to:");
+                }
+                while (mode == M_JOQ && get_command("", 0));
+            }
 
-			if (status & S_QUIT) {
-				std::println("registration aborted (didn't leave)");
-				status &= ~S_QUIT;
-				return 0;
-			}
-		}
-		t1 = (time_t)0;
-	} else {
-		t1 = st.st_mtime; /* last time .*.cf was touched */
-	}
-	if (debug & DB_CONF)
-		std::println("join: t1={:x}", t1);
+            if (status & S_QUIT) {
+                std::println("registration aborted (didn't leave)");
+                status &= ~S_QUIT;
+                return 0;
+            }
+        }
+        t1 = (time_t)0;
+    } else {
+        t1 = st.st_mtime; /* last time .*.cf was touched */
+    }
+    if (debug & DB_CONF)
+        std::println("join: t1={:x}", t1);
 
-	if (confidx >= 0)
-		leave(0, (char **)0);
+    if (confidx >= 0)
+        leave(0, (char **)0);
 
-	/* was ifdef STUPID_REOPEN */
-	{
-		FILE *inp = st_glob.inp;
-		memcpy(&st_glob, &st_new, sizeof(st_new));
-		st_glob.inp = inp;
-	}
+    /* was ifdef STUPID_REOPEN */
+    {
+        FILE *inp = st_glob.inp;
+        memcpy(&st_glob, &st_new, sizeof(st_new));
+        st_glob.inp = inp;
+    }
 
-	confidx = joinidx; /* passed all security checks */
-	// Lock the config file.
-	const auto configfile = conflist[confidx].location + "/config";
-	conffp = mopen(configfile, O_R);
-	read_part(config[CF_PARTFILE], part, &st_glob, confidx);
+    confidx = joinidx; /* passed all security checks */
+    // Lock the config file.
+    const auto configfile = conflist[confidx].location + "/config";
+    conffp = mopen(configfile, O_R);
+    read_part(config[CF_PARTFILE], part, &st_glob, confidx);
 
-	/* Set status */
-	if ((flags | force) & O_OBSERVE)
-		st_glob.c_status |= CS_OBSERVER;
-	if ((flags | force) & O_READONLY)
-		st_glob.c_status |= CS_NORESPONSE;
+    /* Set status */
+    if ((flags | force) & O_OBSERVE)
+        st_glob.c_status |= CS_OBSERVER;
+    if ((flags | force) & O_READONLY)
+        st_glob.c_status |= CS_NORESPONSE;
 
-	/* Allow FW to be specified by login or by UID */
-	if (is_fairwitness(confidx))
-		st_glob.c_status |= CS_FW;
-	if (debug & DB_CONF)
-		std::println("join: Status={}", status);
+    /* Allow FW to be specified by login or by UID */
+    if (is_fairwitness(confidx))
+        st_glob.c_status |= CS_FW;
+    if (debug & DB_CONF)
+        std::println("join: Status={}", status);
 
-	st_glob.sumtime = 0;
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    st_glob.sumtime = 0;
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	/* Source CONF/rc file and WORK/.cfrc files */
-	if (flags & O_SOURCE) {
-		source(conflist[confidx].location, "rc", STD_SANE, SL_OWNER);
-	}
+    /* Source CONF/rc file and WORK/.cfrc files */
+    if (flags & O_SOURCE) {
+        source(conflist[confidx].location, "rc", STD_SANE, SL_OWNER);
+    }
 
-	/* Display login file */
-	if (!(flags & O_QUIET)) {
-		sepinit(IS_START | IS_ITEM);
-		confsep(expand("linmsg", DM_VAR), confidx, &st_glob, part, 0);
-		check_mail(1);
-	}
-	custom_log("join", M_OK);
+    /* Display login file */
+    if (!(flags & O_QUIET)) {
+        sepinit(IS_START | IS_ITEM);
+        confsep(expand("linmsg", DM_VAR), confidx, &st_glob, part, 0);
+        check_mail(1);
+    }
+    custom_log("join", M_OK);
 
-	/* Source WORK/.cfrc files */
-	if (flags & O_SOURCE) {
-		mode = M_OK;
-		if (st_glob.c_status & CS_JUSTJOINED) {
-			source(bbsdir, ".cfjoin", 0, SL_OWNER);
-			source(work, ".cfjoin", 0, SL_USER);
-		}
-		source(work, ".cfrc", 0, SL_USER);
-	}
-	return 1;
+    /* Source WORK/.cfrc files */
+    if (flags & O_SOURCE) {
+        mode = M_OK;
+        if (st_glob.c_status & CS_JUSTJOINED) {
+            source(bbsdir, ".cfjoin", 0, SL_OWNER);
+            source(work, ".cfjoin", 0, SL_USER);
+        }
+        source(work, ".cfrc", 0, SL_USER);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* PROCESS COMMAND LINE ARGUMENTS                                             */
@@ -352,39 +351,38 @@ int
 leave(/* ARGUMENTS: (none)                   */
     int argc, char **argv)
 {
-	if (debug & DB_CONF)
-		std::println("leave: {}", confidx);
-	if (confidx < 0)
-		return 1; /* (noconf) */
+    if (debug & DB_CONF)
+        std::println("leave: {}", confidx);
+    if (confidx < 0)
+        return 1; /* (noconf) */
 
-	if (!argc || argv[0][0] != 'a') { /* not "abort" */
-		/* Display logout */
-		if (!(flags & O_QUIET)) {
-			sepinit(IS_START | IS_ITEM);
-			confsep(expand("loutmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		}
-		custom_log("leave", M_OK);
+    if (!argc || argv[0][0] != 'a') { /* not "abort" */
+        /* Display logout */
+        if (!(flags & O_QUIET)) {
+            sepinit(IS_START | IS_ITEM);
+            confsep(expand("loutmsg", DM_VAR), confidx, &st_glob, part, 0);
+        }
+        custom_log("leave", M_OK);
 
-		/* Write participation file unless observing */
-		if (!(st_glob.c_status & CS_OBSERVER)) {
-			const auto config = get_config(confidx);
-			if (config.size() <= CF_PARTFILE)
-				return 1;
-			write_part(config[CF_PARTFILE]);
-		}
-	}
-	st_glob.sumtime = 0;
-	st_glob.c_status = 0;
+        /* Write participation file unless observing */
+        if (!(st_glob.c_status & CS_OBSERVER)) {
+            const auto config = get_config(confidx);
+            if (config.size() <= CF_PARTFILE)
+                return 1;
+            write_part(config[CF_PARTFILE]);
+        }
+    }
+    st_glob.sumtime = 0;
+    st_glob.c_status = 0;
 
-	confidx = -1;
-	mclose(conffp);
-	undefine(DM_SANE);
+    confidx = -1;
+    mclose(conffp);
+    undefine(DM_SANE);
 
-	/* Re-source system rc file */
-	source(bbsdir, "rc", STD_SUPERSANE, SL_OWNER);
+    /* Re-source system rc file */
+    source(bbsdir, "rc", STD_SUPERSANE, SL_OWNER);
 
-	return (!argc || argv[0][0] != 'a');
+    return (!argc || argv[0][0] != 'a');
 }
 /******************************************************************************/
 /* CHECK A LIST OF CONFERENCES FOR NEW ITEMS                                  */
@@ -392,133 +390,131 @@ leave(/* ARGUMENTS: (none)                   */
 int
 check(int argc, char **argv)
 {
-	unsigned int sec;
-	bool all = false;
-	size_t count = 0;
-	size_t argidx = 1;
-	partentry_t part2[MAX_ITEMS], *part3;
-	sumentry_t sum2[MAX_ITEMS];
-	status_t *st, st_temp;
-	struct stat stt;
-	long force;
+    unsigned int sec;
+    bool all = false;
+    size_t count = 0;
+    size_t argidx = 1;
+    partentry_t part2[MAX_ITEMS], *part3;
+    sumentry_t sum2[MAX_ITEMS];
+    status_t *st, st_temp;
+    struct stat stt;
+    long force;
 
-	std::vector<std::string> args;
-	for (int i = 0; i < argc; i++)
-		args.push_back(argv[i]);
+    std::vector<std::string> args;
+    for (int i = 0; i < argc; i++) args.push_back(argv[i]);
 
 #ifdef INCLUDE_EXTRA_COMMANDS
-	/* Simple cfname dump for WWW */
-	if (flags & O_CGIBIN) {
-		sepinit(IS_START);
-		for (auto idx = 1uz; idx < conflist.size(); idx++) {
-			sepinit(IS_ITEM);
-			if (idx == conflist.size() - 1)
-				sepinit(IS_CFIDX);
-			confsep(expand("listmsg", DM_VAR), idx, &st_glob, part, 0);
-		}
-		return 1;
-	}
+    /* Simple cfname dump for WWW */
+    if (flags & O_CGIBIN) {
+        sepinit(IS_START);
+        for (auto idx = 1uz; idx < conflist.size(); idx++) {
+            sepinit(IS_ITEM);
+            if (idx == conflist.size() - 1)
+                sepinit(IS_CFIDX);
+            confsep(expand("listmsg", DM_VAR), idx, &st_glob, part, 0);
+        }
+        return 1;
+    }
 #endif
-	auto list = args.begin();
-	size_t size = 0;
+    auto list = args.begin();
+    size_t size = 0;
 
-	/* Check for before/since dates */
-	st_glob.since = st_glob.before = 0;
-	if (args.size() > argidx) {
-		if (match(args[argidx], "si_nce") ||
-		    match(args[argidx], "S=")) {
-			st_glob.since = since(args, &argidx);
-			argidx++;
-		} else if (match(args[argidx], "before") ||
-		           match(args[argidx], "B=")) {
-			st_glob.before = since(args, &argidx);
-			argidx++;
-		}
-	}
-	if (args.size() > argidx) { /* list given by user */
-		size = args.size() - argidx;
-		list += argidx;
-	} else if (args[0][0] == 'l') { /* use conflist */
-		all = 1;
-		size = conflist.size() - 1;
-	} else { /* use .cflist */
-		refresh_list();
-		size = cflist.size();
-		list = cflist.begin();
-	}
+    /* Check for before/since dates */
+    st_glob.since = st_glob.before = 0;
+    if (args.size() > argidx) {
+        if (match(args[argidx], "si_nce") || match(args[argidx], "S=")) {
+            st_glob.since = since(args, &argidx);
+            argidx++;
+        } else if (match(args[argidx], "before") || match(args[argidx], "B=")) {
+            st_glob.before = since(args, &argidx);
+            argidx++;
+        }
+    }
+    if (args.size() > argidx) { /* list given by user */
+        size = args.size() - argidx;
+        list += argidx;
+    } else if (args[0][0] == 'l') { /* use conflist */
+        all = 1;
+        size = conflist.size() - 1;
+    } else { /* use .cflist */
+        refresh_list();
+        size = cflist.size();
+        list = cflist.begin();
+    }
 
-	sepinit(IS_START);
-	for (auto i = 0uz; i < size && !(status & S_INT); i++) {
-		force = 0;
-		auto idx = (all) ? i + 1 : get_idx(list[i], conflist);
-		const auto cfname = (all) ? compress(conflist[idx].name) : list[i];
-		if (idx == ~0uz) {
-			std::println("Cannot access {} {}.", conference(), cfname);
-			continue;
-		}
-		const auto config = get_config(idx);
-		if (config.empty()) {
-			std::println("Cannot access {} {}.", conference(), cfname);
-			continue;
-		}
+    sepinit(IS_START);
+    for (auto i = 0uz; i < size && !(status & S_INT); i++) {
+        force = 0;
+        auto idx = (all) ? i + 1 : get_idx(list[i], conflist);
+        const auto cfname = (all) ? compress(conflist[idx].name) : list[i];
+        if (idx == ~0uz) {
+            std::println("Cannot access {} {}.", conference(), cfname);
+            continue;
+        }
+        const auto config = get_config(idx);
+        if (config.empty()) {
+            std::println("Cannot access {} {}.", conference(), cfname);
+            continue;
+        }
 
-		/* Pass security checks */
-		if (!check_acl(JOIN_RIGHT, idx))
-			continue;
-		if (!check_acl(RESPOND_RIGHT, idx))
-			force |= O_READONLY;
+        /* Pass security checks */
+        if (!check_acl(JOIN_RIGHT, idx))
+            continue;
+        if (!check_acl(RESPOND_RIGHT, idx))
+            force |= O_READONLY;
 
-		sec = security_type(config, idx);
+        sec = security_type(config, idx);
 
-		if (confidx >= 0 &&
-		    str::eq(conflist[idx].location, conflist[confidx].location))
-		{
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			st = &st_glob;
-			part3 = part;
-		} else {
-			st = &st_temp;
+        if (confidx >= 0 &&
+            str::eq(conflist[idx].location, conflist[confidx].location)) {
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            st = &st_glob;
+            part3 = part;
+        } else {
+            st = &st_temp;
 #ifdef NEWS
-			st->c_article = 0;
+            st->c_article = 0;
 #endif
-			/* Read in partfile */
-			read_part(config[CF_PARTFILE], part2, st, idx);
+            /* Read in partfile */
+            read_part(config[CF_PARTFILE], part2, st, idx);
 
-			/* Initialize c_status */
-			st->c_status = 0;
-			if (is_fairwitness(idx))
-				st->c_status |= CS_FW;
-			else
-				st->c_status &= ~CS_FW;
-			if ((flags | force) & O_OBSERVE)
-				st->c_status |= CS_OBSERVER;
-			else
-				st->c_status &= ~CS_OBSERVER;
-			if ((flags | force) & O_READONLY)
-				st->c_status |= CS_NORESPONSE;
-			else
-				st->c_status &= ~CS_NORESPONSE;
+            /* Initialize c_status */
+            st->c_status = 0;
+            if (is_fairwitness(idx))
+                st->c_status |= CS_FW;
+            else
+                st->c_status &= ~CS_FW;
+            if ((flags | force) & O_OBSERVE)
+                st->c_status |= CS_OBSERVER;
+            else
+                st->c_status &= ~CS_OBSERVER;
+            if ((flags | force) & O_READONLY)
+                st->c_status |= CS_NORESPONSE;
+            else
+                st->c_status &= ~CS_NORESPONSE;
 
-			const auto path = str::join("/", {partdir, config[CF_PARTFILE]});
-			st->parttime = (stat(path.c_str(), &stt)) ? 0 : stt.st_mtime;
-			st->c_security = security_type(config, idx);
+            const auto path = str::join("/", {partdir, config[CF_PARTFILE]});
+            st->parttime = (stat(path.c_str(), &stt)) ? 0 : stt.st_mtime;
+            st->c_security = security_type(config, idx);
 
-			/* Read in sumfile */
-			get_status(st, sum2, part2, idx);
-			part3 = part2;
-		}
-		st->c_security = sec;
+            /* Read in sumfile */
+            get_status(st, sum2, part2, idx);
+            part3 = part2;
+        }
+        st->c_security = sec;
 
-		if ((!st_glob.before || st->sumtime < st_glob.before) &&
-		    (st_glob.since <= st->sumtime)) {
-			st->count = ++count;
-			sepinit(IS_ITEM);
-			if (args.size() < 2 && current == i)
-				sepinit(IS_CFIDX);
-			confsep(expand((args[0][0] == 'l') ? "listmsg" : "checkmsg", DM_VAR), idx, st, part3, 0);
-		}
-	}
-	return 1;
+        if ((!st_glob.before || st->sumtime < st_glob.before) &&
+            (st_glob.since <= st->sumtime)) {
+            st->count = ++count;
+            sepinit(IS_ITEM);
+            if (args.size() < 2 && current == i)
+                sepinit(IS_CFIDX);
+            confsep(
+                expand((args[0][0] == 'l') ? "listmsg" : "checkmsg", DM_VAR),
+                idx, st, part3, 0);
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* ADVANCE TO NEXT CONFERENCES WITH NEW ITEMS                                 */
@@ -526,72 +522,72 @@ check(int argc, char **argv)
 int
 do_next(int argc, char **argv)
 {
-	/* LOCAL VARIABLES: */
-	short idx;
-	partentry_t part2[MAX_ITEMS];
-	sumentry_t sum2[MAX_ITEMS];
-	status_t st;
-	struct stat stt;
-	int cp = 0;
+    /* LOCAL VARIABLES: */
+    short idx;
+    partentry_t part2[MAX_ITEMS];
+    sumentry_t sum2[MAX_ITEMS];
+    status_t st;
+    struct stat stt;
+    int cp = 0;
 
-	if (argc > 1) {
-		std::println("Bad parameters near \"{}\"", argv[1]);
-		return 2;
-	}
-	refresh_list(); /* make sure .cflist is current */
-	for (; current + 1 < cflist.size() && !(status & S_INT); current++) {
-		idx = get_idx(cflist[current + 1], conflist);
-		if (idx < 0) {
-			std::println("Cannot access {} {}.",
-			    conference(), cflist[current + 1]);
-			continue;
-		}
-		const auto config = get_config(idx);
-		if (config.empty()) {
-			std::println("Cannot access {} {}.",
-			    conference(), cflist[current + 1]);
-			continue;
-		}
+    if (argc > 1) {
+        std::println("Bad parameters near \"{}\"", argv[1]);
+        return 2;
+    }
+    refresh_list(); /* make sure .cflist is current */
+    for (; current + 1 < cflist.size() && !(status & S_INT); current++) {
+        idx = get_idx(cflist[current + 1], conflist);
+        if (idx < 0) {
+            std::println(
+                "Cannot access {} {}.", conference(), cflist[current + 1]);
+            continue;
+        }
+        const auto config = get_config(idx);
+        if (config.empty()) {
+            std::println(
+                "Cannot access {} {}.", conference(), cflist[current + 1]);
+            continue;
+        }
 
-		/* Check security */
-		cp = check_acl(JOIN_RIGHT, idx);
-		if (!cp) {
-			if (!(flags & O_QUIET)) {
-				std::cout << "You are not allowed to access the " <<
-				    compress(conflist[joinidx].name) << " " <<
-				    conference() << "." << std::endl;
-			}
-			continue;
-		}
+        /* Check security */
+        cp = check_acl(JOIN_RIGHT, idx);
+        if (!cp) {
+            if (!(flags & O_QUIET)) {
+                std::cout << "You are not allowed to access the "
+                          << compress(conflist[joinidx].name) << " "
+                          << conference() << "." << std::endl;
+            }
+            continue;
+        }
 
-		if (confidx >= 0 &&
-		    str::eq(conflist[idx].location, conflist[confidx].location))
-		{
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			if (st_glob.i_newresp || st_glob.i_brandnew) {
-				join(cflist[++current], 0, cp);
-				return 1;
-			}
-		} else {
-			/* Read in partfile */
-			read_part(config[CF_PARTFILE], part2, &st, idx);
-			const auto partfile = str::join("/", {partdir, config[CF_PARTFILE]});
-			st.parttime = (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
-			st.c_security = security_type(config, idx);
+        if (confidx >= 0 &&
+            str::eq(conflist[idx].location, conflist[confidx].location)) {
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            if (st_glob.i_newresp || st_glob.i_brandnew) {
+                join(cflist[++current], 0, cp);
+                return 1;
+            }
+        } else {
+            /* Read in partfile */
+            read_part(config[CF_PARTFILE], part2, &st, idx);
+            const auto partfile =
+                str::join("/", {partdir, config[CF_PARTFILE]});
+            st.parttime = (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
+            st.c_security = security_type(config, idx);
 #ifdef NEWS
-			st.c_article = 0;
+            st.c_article = 0;
 #endif
-			get_status(&st, sum2, part2, idx); /* Read in sumfile */
-			st.sumtime = 0;
-			if (st.i_newresp || st.i_brandnew) {
-				join(cflist[++current], 0, cp);
-				return 1;
-			}
-		}
-		std::println("No new {}s in {}.", topic(), cflist[current + 1]);
-	}
-	std::println("No more {}s left.", conference());
-	return 2;
+            get_status(&st, sum2, part2, idx); /* Read in sumfile */
+            st.sumtime = 0;
+            if (st.i_newresp || st.i_brandnew) {
+                join(cflist[++current], 0, cp);
+                return 1;
+            }
+        }
+        std::println("No new {}s in {}.", topic(), cflist[current + 1]);
+    }
+    std::println("No more {}s left.", conference());
+    return 2;
 }
 /******************************************************************************/
 /* RESIGN FROM (UNJOIN) THE CURRENT CONFERENCE                                */
@@ -602,56 +598,55 @@ resign(         /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc > 1) {
-		std::println("Bad parameters near \"{}\"\n", argv[1]);
-		return 2;
-	}
-	if (st_glob.c_status & CS_OBSERVER) {
-		std::println("But you don't belong to this {}!\n", conference());
-		return 1;
-	}
-	if (get_yes("Are you sure you wish to resign? ", false)) {
-		const auto config = get_config(confidx);
-		if (config.empty())
-			return 1;
+    if (argc > 1) {
+        std::println("Bad parameters near \"{}\"\n", argv[1]);
+        return 2;
+    }
+    if (st_glob.c_status & CS_OBSERVER) {
+        std::println("But you don't belong to this {}!\n", conference());
+        return 1;
+    }
+    if (get_yes("Are you sure you wish to resign? ", false)) {
+        const auto config = get_config(confidx);
+        if (config.empty())
+            return 1;
 
-		/* Delete participation file */
-		const auto path = str::join("/", {partdir, config[CF_PARTFILE]});
-		rm(path, partfile_perm());
+        /* Delete participation file */
+        const auto path = str::join("/", {partdir, config[CF_PARTFILE]});
+        rm(path, partfile_perm());
 
-		/* Remove from .cflist if current is set */
-		if (current >= 0)
-			del_cflist(cflist[current]);
+        /* Remove from .cflist if current is set */
+        if (current >= 0)
+            del_cflist(cflist[current]);
 
-		/* Become an observer */
-		st_glob.c_status |= CS_OBSERVER;
-		std::println("You are now just an observer.");
+        /* Become an observer */
+        st_glob.c_status |= CS_OBSERVER;
+        std::println("You are now just an observer.");
 
-		/* Remove login/uid from ulist file: In this case, we don't
-		 * remove it from recursive files, only if it's in the top
-		 * level ulist */
-		if (is_auto_ulist(confidx)) {
-			const auto ulist = grab_file(conflist[confidx].location,
-			    "ulist", GF_WORD | GF_SILENT | GF_IGNCMT);
-			if (!ulist.empty()) {
-				const auto file = conflist[confidx].location + "/ulist";
-				const auto tmpfile = file + ".tmp";
-				const auto uidstr = std::to_string(uid);
-				for (const auto &user: ulist) {
-					if (!str::eq(login, user) &&
-					    !str::eq(uidstr, user)) {
-						// XXX: we ought to do better error recovery...
-						if (!write_file(tmpfile, user + "\n"))
-							break;
-					}
-				}
-				if (rename(tmpfile.c_str(), file.c_str()))
-					error("renaming ", file);
-			}
-			custom_log("resign", M_OK);
-		}
-	}
-	return 1;
+        /* Remove login/uid from ulist file: In this case, we don't
+         * remove it from recursive files, only if it's in the top
+         * level ulist */
+        if (is_auto_ulist(confidx)) {
+            const auto ulist = grab_file(conflist[confidx].location, "ulist",
+                GF_WORD | GF_SILENT | GF_IGNCMT);
+            if (!ulist.empty()) {
+                const auto file = conflist[confidx].location + "/ulist";
+                const auto tmpfile = file + ".tmp";
+                const auto uidstr = std::to_string(uid);
+                for (const auto &user : ulist) {
+                    if (!str::eq(login, user) && !str::eq(uidstr, user)) {
+                        // XXX: we ought to do better error recovery...
+                        if (!write_file(tmpfile, user + "\n"))
+                            break;
+                    }
+                }
+                if (rename(tmpfile.c_str(), file.c_str()))
+                    error("renaming ", file);
+            }
+            custom_log("resign", M_OK);
+        }
+    }
+    return 1;
 }
 
 #ifdef WWW
@@ -659,38 +654,38 @@ resign(         /* ARGUMENTS:             */
 /* SEE IF A HOSTNAME ENDS WITH A SPECIFIED DOMAIN NAME                        */
 /******************************************************************************/
 static bool
-matchhost(      /* ARGUMENTS: */
+matchhost(                        /* ARGUMENTS: */
     const std::string_view &spec, /* Domain name allowed     */
     const std::string_view &host  /* Origin host to validate */
 )
 {
-	const auto tail = host.substr(host.size() - spec.size(), host.size());
-	return str::eq(spec, tail);
+    const auto tail = host.substr(host.size() - spec.size(), host.size());
+    return str::eq(spec, tail);
 }
 /******************************************************************************/
 /* SEE IF AN ORIGIN IP ADDRESS MATCHES A SPECIFIED ADDRESS PREFIX             */
 /******************************************************************************/
 static bool
-matchaddr(         /* ARGUMENTS:                        */
+matchaddr(                      /* ARGUMENTS:                        */
     const std::string &specstr, /* IP prefix allowed              */
     const std::string &addrstr  /* Origin IP addr to validate     */
 )
 {
-	uint32_t subnetaddr, subnetmask, hostaddr;
-	int masklen = 0;
+    uint32_t subnetaddr, subnetmask, hostaddr;
+    int masklen = 0;
 
-	hostaddr = ntohl(inet_addr(addrstr.c_str()));
-	const auto field = str::splits(specstr, "/");
-	assert(!field.empty());
-	const auto num = str::split(field[0], ".");
-	if (field.size() > 1)
-		masklen = str::toi(field[1]);
-	else
-		masklen = 8 * num.size();
-	subnetmask = 0xFFFFFFFF << (32 - masklen);
-	subnetaddr = inet_network(field[0].c_str()) << (32 - 8 * num.size());
+    hostaddr = ntohl(inet_addr(addrstr.c_str()));
+    const auto field = str::splits(specstr, "/");
+    assert(!field.empty());
+    const auto num = str::split(field[0], ".");
+    if (field.size() > 1)
+        masklen = str::toi(field[1]);
+    else
+        masklen = 8 * num.size();
+    subnetmask = 0xFFFFFFFF << (32 - masklen);
+    subnetaddr = inet_network(field[0].c_str()) << (32 - 8 * num.size());
 
-	return (hostaddr & subnetmask) == (subnetaddr & subnetmask);
+    return (hostaddr & subnetmask) == (subnetaddr & subnetmask);
 }
 
 /* ARGUMENTS:           */
@@ -698,21 +693,21 @@ matchaddr(         /* ARGUMENTS:                        */
 bool
 is_validorigin(int idx)
 {
-	const auto originlist = grab_file(conflist[idx].location,
-	    "originlist", GF_WORD | GF_IGNCMT);
-	if (originlist.empty())
-		return true;
-	for (const auto &origin: originlist) {
-		if (std::isdigit(origin[0])) { /* Check IP address */
-			if (matchaddr(origin.c_str(), expand("remoteaddr", DM_VAR)))
-				return true;
-		} else { /* Check hostname */
-			if (matchhost(origin.c_str(), expand("remotehost", DM_VAR)))
-				return true;
-		}
-	}
+    const auto originlist =
+        grab_file(conflist[idx].location, "originlist", GF_WORD | GF_IGNCMT);
+    if (originlist.empty())
+        return true;
+    for (const auto &origin : originlist) {
+        if (std::isdigit(origin[0])) { /* Check IP address */
+            if (matchaddr(origin.c_str(), expand("remoteaddr", DM_VAR)))
+                return true;
+        } else { /* Check hostname */
+            if (matchhost(origin.c_str(), expand("remotehost", DM_VAR)))
+                return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 #endif
 
@@ -721,18 +716,18 @@ is_validorigin(int idx)
 bool
 check_password(int idx)
 {
-	const auto &conf = conflist[idx];
-	const auto lines = grab_file(conf.location, "secret", 0);
-	if (lines.empty())
-		return false;
-	const auto &password = lines[0];
-	const auto prompt = str::concat({"Password for ", compress(conf.name), ": "});
-	bool ok = str::eq(getpass(prompt.c_str()), password);
-	if (!ok)
-		std::println("Invalid password.");
-	return ok;
+    const auto &conf = conflist[idx];
+    const auto lines = grab_file(conf.location, "secret", 0);
+    if (lines.empty())
+        return false;
+    const auto &password = lines[0];
+    const auto prompt =
+        str::concat({"Password for ", compress(conf.name), ": "});
+    bool ok = str::eq(getpass(prompt.c_str()), password);
+    if (!ok)
+        std::println("Invalid password.");
+    return ok;
 }
-
 
 /******************************************************************************/
 /* Describe a conference: "describe <conf>"                                   */
@@ -743,12 +738,12 @@ describe(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc != 2) {
-		std::println("usage: describe <{}>", conference());
-		return 1;
-	}
-	std::println("{}", get_desc(argv[1]));
-	return 1;
+    if (argc != 2) {
+        std::println("usage: describe <{}>", conference());
+        return 1;
+    }
+    std::println("{}", get_desc(argv[1]));
+    return 1;
 }
 /******************************************************************************/
 /* GET INFORMATION ON CONFERENCE PARTICIPANTS                                 */
@@ -759,177 +754,178 @@ participants(   /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	FILE *fp;
-	std::vector<std::string> ulist;
-	struct stat st;
-	bool all = false;
-	bool dump = false;
-	bool reset = false;
-	auto tuid = uid;
-	auto tparttime = st_glob.parttime;
-	std::string tlogin(login);
-	std::string tfullname(st_glob.fullname);
-	std::string twork(work);
-	std::string tpartdir(partdir);
-	std::string temail(email);
+    FILE *fp;
+    std::vector<std::string> ulist;
+    struct stat st;
+    bool all = false;
+    bool dump = false;
+    bool reset = false;
+    auto tuid = uid;
+    auto tparttime = st_glob.parttime;
+    std::string tlogin(login);
+    std::string tfullname(st_glob.fullname);
+    std::string twork(work);
+    std::string tpartdir(partdir);
+    std::string temail(email);
 
-	std::string file, file2;
+    std::string file, file2;
 
-	/* Save user info */
-	st_glob.count = 0;
+    /* Save user info */
+    st_glob.count = 0;
 
-	if (argc > 1) { /* User list specified */
-		ulist.insert(ulist.begin(), argv + 1, argv + argc);
-	} else {
-		file = conflist[confidx].location + "/ulist";
-		ulist = grab_recursive_list(conflist[confidx].location, "ulist");
-		if (ulist.empty()) {
-			all = true;
-			setpwent();
-		} else if (is_auto_ulist(confidx)) {
-			dump = true;
-			file2 = conflist[confidx].location + "/ulist.tmp";
-		}
-	}
+    if (argc > 1) { /* User list specified */
+        ulist.insert(ulist.begin(), argv + 1, argv + argc);
+    } else {
+        file = conflist[confidx].location + "/ulist";
+        ulist = grab_recursive_list(conflist[confidx].location, "ulist");
+        if (ulist.empty()) {
+            all = true;
+            setpwent();
+        } else if (is_auto_ulist(confidx)) {
+            dump = true;
+            file2 = conflist[confidx].location + "/ulist.tmp";
+        }
+    }
 
-	open_pipe();
+    open_pipe();
 
-	if (status & S_EXECUTE)
-		fp = 0;
-	else if (status & S_PAGER)
-		fp = st_glob.outp;
-	else
-		fp = stdout;
+    if (status & S_EXECUTE)
+        fp = 0;
+    else if (status & S_PAGER)
+        fp = st_glob.outp;
+    else
+        fp = stdout;
 
-	/* Process items */
-	sepinit(IS_START);
-	confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
+    /* Process items */
+    sepinit(IS_START);
+    confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
 
-	for (auto j = 0uz; !(status & S_INT) && (all || j < ulist.size()); j++) {
-		if (all) {
-			struct passwd *pwd;
-			if ((pwd = getpwent()) == NULL)
-				break;
+    for (auto j = 0uz; !(status & S_INT) && (all || j < ulist.size()); j++) {
+        if (all) {
+            struct passwd *pwd;
+            if ((pwd = getpwent()) == NULL)
+                break;
 
-			uid = pwd->pw_uid;
-			login= pwd->pw_name;
+            uid = pwd->pw_uid;
+            login = pwd->pw_name;
 
-			const auto gecos =
-			    str::split(pwd->pw_gecos, expand("gecos", DM_VAR), false);
-			st_glob.fullname.clear();
-			if (!gecos.empty())
-				st_glob.fullname = gecos[0];
-			home = pwd->pw_dir;
-		} else {
-			if (j >= ulist.size())
-				break;
-			if (isdigit(ulist[j][0])) {
-				uid = str::toi(ulist[j]); /* search by uid */
-				login.clear();
-			} else {
-				uid = 0;
-				login = ulist[j]; /* search by login */
-			}
-			if (!get_user(&uid, login, st_glob.fullname, home, email)) {
-				std::println(" User {} not found", ulist[j]);
-				if (dump)
-					ulist[j].clear();
-				continue;
-			}
-		}
+            const auto gecos =
+                str::split(pwd->pw_gecos, expand("gecos", DM_VAR), false);
+            st_glob.fullname.clear();
+            if (!gecos.empty())
+                st_glob.fullname = gecos[0];
+            home = pwd->pw_dir;
+        } else {
+            if (j >= ulist.size())
+                break;
+            if (isdigit(ulist[j][0])) {
+                uid = str::toi(ulist[j]); /* search by uid */
+                login.clear();
+            } else {
+                uid = 0;
+                login = ulist[j]; /* search by login */
+            }
+            if (!get_user(&uid, login, st_glob.fullname, home, email)) {
+                std::println(" User {} not found", ulist[j]);
+                if (dump)
+                    ulist[j].clear();
+                continue;
+            }
+        }
 
-		const auto config = get_config(confidx);
-		if (config.size() <= CF_PARTFILE)
-			return 1;
+        const auto config = get_config(confidx);
+        if (config.size() <= CF_PARTFILE)
+            return 1;
 
-		work = home + "/.cfdir";
-		partdir = get_partdir(login);
+        work = home + "/.cfdir";
+        partdir = get_partdir(login);
 
-		auto partfile = str::concat({partdir, "/", config[CF_PARTFILE]});
-		if (stat(partfile.c_str(), &st) < 0) {
-			work = home;
-			partfile = str::concat({partdir, "/", config[CF_PARTFILE]});
-			if (stat(partfile.c_str(), &st) < 0) {
-				/* someone resigned or deleted a part file */
-				if (dump) {
-					ulist[j].clear();
-					reset = true;
-				}
-				std::string msg = str::concat({"User ", login, " not a member\n"});
-				wfputs(msg, fp);
-				continue;
-			}
-		}
-		st_glob.parttime = st.st_mtime;
-		st_glob.count++;
-		sepinit(IS_ITEM);
-		confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
+        auto partfile = str::concat({partdir, "/", config[CF_PARTFILE]});
+        if (stat(partfile.c_str(), &st) < 0) {
+            work = home;
+            partfile = str::concat({partdir, "/", config[CF_PARTFILE]});
+            if (stat(partfile.c_str(), &st) < 0) {
+                /* someone resigned or deleted a part file */
+                if (dump) {
+                    ulist[j].clear();
+                    reset = true;
+                }
+                std::string msg =
+                    str::concat({"User ", login, " not a member\n"});
+                wfputs(msg, fp);
+                continue;
+            }
+        }
+        st_glob.parttime = st.st_mtime;
+        st_glob.count++;
+        sepinit(IS_ITEM);
+        confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
 
-		if (all) {
-			std::string msg = str::concat({login, "\n"});
-			write_file(file, msg);
-		}
-	}
+        if (all) {
+            std::string msg = str::concat({login, "\n"});
+            write_file(file, msg);
+        }
+    }
 
-	sepinit(IS_CFIDX);
-	confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
+    sepinit(IS_CFIDX);
+    confsep(expand("partmsg", DM_VAR), confidx, &st_glob, part, 0);
 
-	if (reset) { /* reset ulist file */
-		for (const auto &u : ulist) {
-			if (u.empty())
-				continue;
-			std::string line = u + "\n";
-			if (!write_file(file2, line)) {
-				reset = false;
-				break;
-			}
-		}
-	}
-	if (reset)
-		if (rename(file2.c_str(), file.c_str()))
-			error("renaming ", file);
+    if (reset) { /* reset ulist file */
+        for (const auto &u : ulist) {
+            if (u.empty())
+                continue;
+            std::string line = u + "\n";
+            if (!write_file(file2, line)) {
+                reset = false;
+                break;
+            }
+        }
+    }
+    if (reset)
+        if (rename(file2.c_str(), file.c_str()))
+            error("renaming ", file);
 
-	if (all)
-		endpwent();
+    if (all)
+        endpwent();
 
-	/* Restore user info */
-	uid = tuid;
-	login = tlogin;
-	if (!get_user(&uid, login, st_glob.fullname, home, email)) {
-		error("reading ", "user entry");
-		endbbs(2);
-	}
-	st_glob.fullname = tfullname;
-	st_glob.parttime = tparttime;
-	work = twork;
-	partdir = tpartdir;
+    /* Restore user info */
+    uid = tuid;
+    login = tlogin;
+    if (!get_user(&uid, login, st_glob.fullname, home, email)) {
+        error("reading ", "user entry");
+        endbbs(2);
+    }
+    st_glob.fullname = tfullname;
+    st_glob.parttime = tparttime;
+    work = twork;
+    partdir = tpartdir;
 
-	return 1;
+    return 1;
 }
 
 void
 ylog(int idx, const std::string_view &str)
 {
-	time_t t;
-	time(&t);
-	std::string timestamp(ctime(&t) + 4);
-	timestamp.erase(20);
-	const auto msg = std::format("{} {} {}\n", timestamp, login, str);
-	const auto file = conflist[idx].location + "/log";
-	write_file(file, msg);
+    time_t t;
+    time(&t);
+    std::string timestamp(ctime(&t) + 4);
+    timestamp.erase(20);
+    const auto msg = std::format("{} {} {}\n", timestamp, login, str);
+    const auto file = conflist[idx].location + "/log";
+    write_file(file, msg);
 }
 
 const char *
 nextconf(void)
 {
-	auto i = 1z;
-	for (const auto &cfname: cflist) {
-		auto idx = get_idx(cfname, conflist);
-		if (idx == confidx)
-			return i < cflist.size() ? cflist[i].c_str() : "";
-		i++;
-	}
-	return "";
+    auto i = 1z;
+    for (const auto &cfname : cflist) {
+        auto idx = get_idx(cfname, conflist);
+        if (idx == confidx)
+            return i < cflist.size() ? cflist[i].c_str() : "";
+        i++;
+    }
+    return "";
 }
 
 /* find the next conference in conference list with new items in it,
@@ -939,107 +935,106 @@ nextconf(void)
 static const char *
 findnewconf(int wrapped)
 {
-	/* LOCAL VARIABLES:       */
-	short idx;
-	partentry_t part2[MAX_ITEMS];
-	sumentry_t sum2[MAX_ITEMS];
-	status_t st;
-	struct stat stt;
-	int cp = 0;
-	size_t nextconference = current + 1;
+    /* LOCAL VARIABLES:       */
+    short idx;
+    partentry_t part2[MAX_ITEMS];
+    sumentry_t sum2[MAX_ITEMS];
+    status_t st;
+    struct stat stt;
+    int cp = 0;
+    size_t nextconference = current + 1;
 
-	refresh_list(); /* make sure .cflist is current */
-	for (; nextconference < cflist.size() && !(status & S_INT);
-	     nextconference++) {
-		idx = get_idx(cflist[nextconference], conflist);
-		if (idx == nidx) {
-			if ((flags & O_QUIET) == 0)
-				std::println("Cannot access {} {}.",
-				    conference(), cflist[nextconference]);
-			continue;
-		}
-		const auto config = get_config(idx);
-		if (config.empty()) {
-			if ((flags & O_QUIET) == 0)
-				std::println("Cannot access {} {}.",
-				    conference(), cflist[nextconference]);
-			continue;
-		}
-		/* Check security */
-		cp = check_acl(JOIN_RIGHT, idx);
-		if (!cp) {
-			if (!(flags & O_QUIET)) {
-				std::println("You are not allowed to access the {} {}.",
-				    compress(conflist[joinidx].name), conference());
-			}
-			continue;
-		}
-		/* don't segfault if in no conf */
-		if (confidx >= 0 &&
-		    str::eq(conflist[idx].location, conflist[confidx].location))
-		{
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			if (st_glob.i_newresp || st_glob.i_brandnew) {
-				return cflist[nextconference].c_str();
-			}
-		} else {
-			read_part(config[CF_PARTFILE], part2, &st,
-			    idx); /* Read in partfile */
-			const auto partfile = str::join("/",
-			    {partdir, config[CF_PARTFILE]});
-			st.parttime = (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
-			st.c_security = security_type(config, idx);
+    refresh_list(); /* make sure .cflist is current */
+    for (; nextconference < cflist.size() && !(status & S_INT);
+        nextconference++) {
+        idx = get_idx(cflist[nextconference], conflist);
+        if (idx == nidx) {
+            if ((flags & O_QUIET) == 0)
+                std::println("Cannot access {} {}.", conference(),
+                    cflist[nextconference]);
+            continue;
+        }
+        const auto config = get_config(idx);
+        if (config.empty()) {
+            if ((flags & O_QUIET) == 0)
+                std::println("Cannot access {} {}.", conference(),
+                    cflist[nextconference]);
+            continue;
+        }
+        /* Check security */
+        cp = check_acl(JOIN_RIGHT, idx);
+        if (!cp) {
+            if (!(flags & O_QUIET)) {
+                std::println("You are not allowed to access the {} {}.",
+                    compress(conflist[joinidx].name), conference());
+            }
+            continue;
+        }
+        /* don't segfault if in no conf */
+        if (confidx >= 0 &&
+            str::eq(conflist[idx].location, conflist[confidx].location)) {
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            if (st_glob.i_newresp || st_glob.i_brandnew) {
+                return cflist[nextconference].c_str();
+            }
+        } else {
+            read_part(
+                config[CF_PARTFILE], part2, &st, idx); /* Read in partfile */
+            const auto partfile =
+                str::join("/", {partdir, config[CF_PARTFILE]});
+            st.parttime = (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
+            st.c_security = security_type(config, idx);
 #ifdef NEWS
-			st.c_article = 0;
+            st.c_article = 0;
 #endif
-			get_status(&st, sum2, part2, idx); /* Read in sumfile */
-			st.sumtime = 0;
-			if (st.i_newresp || st.i_brandnew) {
-				return cflist[nextconference].c_str();
-			}
-		}
-		if (!(flags & O_QUIET))
-			std::println("No new {}s in {}.", topic(), cflist[nextconference]);
-	}
-	if (!(flags & O_QUIET)) {
-		std::println("No more {}s left.", conference());
-	}
-	if (!wrapped) /* Found end of list, wrap to begining and
-	               * check again */
-		return findnewconf(1);
+            get_status(&st, sum2, part2, idx); /* Read in sumfile */
+            st.sumtime = 0;
+            if (st.i_newresp || st.i_brandnew) {
+                return cflist[nextconference].c_str();
+            }
+        }
+        if (!(flags & O_QUIET))
+            std::println("No new {}s in {}.", topic(), cflist[nextconference]);
+    }
+    if (!(flags & O_QUIET)) {
+        std::println("No more {}s left.", conference());
+    }
+    if (!wrapped) /* Found end of list, wrap to begining and
+                   * check again */
+        return findnewconf(1);
 
-	/* No conference with new items left in the conference list */
-	return "";
+    /* No conference with new items left in the conference list */
+    return "";
 }
 
 const char *
 nextnewconf(void)
 {
-	return findnewconf(0);
+    return findnewconf(0);
 }
 
 const char *
 prevconf(void)
 {
-	auto i = nidx;
-	for (const auto &cfname: cflist) {
-		auto idx = get_idx(cfname, conflist);
-		if (idx == confidx)
-			return i < cflist.size() ? cflist[i].c_str() : "";
-		i++;
-	}
-	return "";
+    auto i = nidx;
+    for (const auto &cfname : cflist) {
+        auto idx = get_idx(cfname, conflist);
+        if (idx == confidx)
+            return i < cflist.size() ? cflist[i].c_str() : "";
+        i++;
+    }
+    return "";
 }
 
 /* Get short description of a conference based on confidx */
 const char *
 get_desc(const std::string_view &name)
 {
-	for (auto i = 0; i < desclist.size(); ++i) {
-		if (match(name, desclist[i].name))
-			return desclist[i].location.c_str();
-	}
-	return desclist[0].location.c_str(); /* use the default */
+    for (auto i = 0; i < desclist.size(); ++i) {
+        if (match(name, desclist[i].name))
+            return desclist[i].location.c_str();
+    }
+    return desclist[0].location.c_str(); /* use the default */
 }
 
 /******************************************************************************/
@@ -1051,113 +1046,110 @@ show_conf_index(/* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	unsigned int sec;
-	size_t count = 0;
-	size_t argidx = 1;
-	partentry_t part2[MAX_ITEMS], *part3;
-	sumentry_t sum2[MAX_ITEMS];
-	status_t *st, st_temp;
-	struct stat stt;
-	long force = 0;
+    unsigned int sec;
+    size_t count = 0;
+    size_t argidx = 1;
+    partentry_t part2[MAX_ITEMS], *part3;
+    sumentry_t sum2[MAX_ITEMS];
+    status_t *st, st_temp;
+    struct stat stt;
+    long force = 0;
 
-	std::vector<std::string> args;
-	for (int i = 0; i < argc; i++)
-		args.push_back(argv[i]);
+    std::vector<std::string> args;
+    for (int i = 0; i < argc; i++) args.push_back(argv[i]);
 
-	/* Check for before/since dates */
-	st_glob.since = st_glob.before = 0;
-	if (argc > argidx) {
-		if (match(argv[argidx], "si_nce") ||
-		    match(argv[argidx], "S=")) {
-			st_glob.since = since(args, &argidx);
-			argidx++;
-		} else if (match(argv[argidx], "before") ||
-		           match(argv[argidx], "B=")) {
-			st_glob.before = since(args, &argidx);
-			argidx++;
-		}
-	}
-	sepinit(IS_START);
-	for (auto i = 1uz; i < desclist.size() && (status & S_INT) == 0; i++) {
-		if (str::eq(desclist[i].name, "group")) {
-			st_glob.string = desclist[i].location;
-			confsep(expand("groupindexmsg", DM_VAR), -1, &st_glob, part, 0);
-		} else {
-			auto idx = get_idx(desclist[i].name, conflist);
+    /* Check for before/since dates */
+    st_glob.since = st_glob.before = 0;
+    if (argc > argidx) {
+        if (match(argv[argidx], "si_nce") || match(argv[argidx], "S=")) {
+            st_glob.since = since(args, &argidx);
+            argidx++;
+        } else if (match(argv[argidx], "before") || match(argv[argidx], "B=")) {
+            st_glob.before = since(args, &argidx);
+            argidx++;
+        }
+    }
+    sepinit(IS_START);
+    for (auto i = 1uz; i < desclist.size() && (status & S_INT) == 0; i++) {
+        if (str::eq(desclist[i].name, "group")) {
+            st_glob.string = desclist[i].location;
+            confsep(expand("groupindexmsg", DM_VAR), -1, &st_glob, part, 0);
+        } else {
+            auto idx = get_idx(desclist[i].name, conflist);
 
-			/* The following code was copied from check() */
-			if (idx < 0) {
-				error("reading config for ", desclist[i].name);
-				continue;
-			}
-			const auto config = get_config(idx);
-			if (config.empty()) {
-				error("reading config for ", desclist[i].name);
-				continue;
-			}
+            /* The following code was copied from check() */
+            if (idx < 0) {
+                error("reading config for ", desclist[i].name);
+                continue;
+            }
+            const auto config = get_config(idx);
+            if (config.empty()) {
+                error("reading config for ", desclist[i].name);
+                continue;
+            }
 
-			/* Pass security checks */
-			if (!check_acl(JOIN_RIGHT, idx))
-				continue;
-			if (!check_acl(RESPOND_RIGHT, idx))
-				force |= O_READONLY;
+            /* Pass security checks */
+            if (!check_acl(JOIN_RIGHT, idx))
+                continue;
+            if (!check_acl(RESPOND_RIGHT, idx))
+                force |= O_READONLY;
 
-			sec = security_type(config, idx);
+            sec = security_type(config, idx);
 
-			if (confidx >= 0 &&
-			    str::eq(conflist[idx].location, conflist[confidx].location))
-			{
-				refresh_sum(0, confidx, sum, part, &st_glob);
-				st = &st_glob;
-				part3 = part;
-			} else {
-				st = &st_temp;
+            if (confidx >= 0 &&
+                str::eq(conflist[idx].location, conflist[confidx].location)) {
+                refresh_sum(0, confidx, sum, part, &st_glob);
+                st = &st_glob;
+                part3 = part;
+            } else {
+                st = &st_temp;
 #ifdef NEWS
-				st->c_article = 0;
+                st->c_article = 0;
 #endif
-				/* Read in partfile */
-				read_part(config[CF_PARTFILE], part2, st, idx);
+                /* Read in partfile */
+                read_part(config[CF_PARTFILE], part2, st, idx);
 
-				/* Initialize c_status */
-				st->c_status = 0;
-				if (is_fairwitness(idx))
-					st->c_status |= CS_FW;
-				else
-					st->c_status &= ~CS_FW;
-				if ((flags | force) & O_OBSERVE)
-					st->c_status |= CS_OBSERVER;
-				else
-					st->c_status &= ~CS_OBSERVER;
-				if ((flags | force) & O_READONLY)
-					st->c_status |= CS_NORESPONSE;
-				else
-					st->c_status &= ~CS_NORESPONSE;
+                /* Initialize c_status */
+                st->c_status = 0;
+                if (is_fairwitness(idx))
+                    st->c_status |= CS_FW;
+                else
+                    st->c_status &= ~CS_FW;
+                if ((flags | force) & O_OBSERVE)
+                    st->c_status |= CS_OBSERVER;
+                else
+                    st->c_status &= ~CS_OBSERVER;
+                if ((flags | force) & O_READONLY)
+                    st->c_status |= CS_NORESPONSE;
+                else
+                    st->c_status &= ~CS_NORESPONSE;
 
-				const auto partfile = str::join("/", {partdir, config[CF_PARTFILE]});
-				st->parttime = (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
-				st->c_security = security_type(config, idx);
+                const auto partfile =
+                    str::join("/", {partdir, config[CF_PARTFILE]});
+                st->parttime =
+                    (stat(partfile.c_str(), &stt)) ? 0 : stt.st_mtime;
+                st->c_security = security_type(config, idx);
 
-				/* Read in sumfile */
-				get_status(st, sum2, part2, idx);
-				part3 = part2;
-			}
-			st->c_security = sec;
+                /* Read in sumfile */
+                get_status(st, sum2, part2, idx);
+                part3 = part2;
+            }
+            st->c_security = sec;
 
-			if ((!st_glob.before || st->sumtime < st_glob.before) &&
-			    (st_glob.since <= st->sumtime)) {
-				st->string = desclist[i].location;
-				st->count = (++count);
-				sepinit(IS_ITEM);
-				if (argc < 2 && current == i)
-					sepinit(IS_CFIDX);
-				/* End of code copied from check */
-				def_macro("indexconfname", DM_VAR,
-				    compress(conflist[idx].name));
-				confsep(expand("confindexmsg", DM_VAR), idx, st,
-				    part3, 0);
-			}
-		}
-		st_glob.string.clear();
-	}
-	return 1;
+            if ((!st_glob.before || st->sumtime < st_glob.before) &&
+                (st_glob.since <= st->sumtime)) {
+                st->string = desclist[i].location;
+                st->count = (++count);
+                sepinit(IS_ITEM);
+                if (argc < 2 && current == i)
+                    sepinit(IS_CFIDX);
+                /* End of code copied from check */
+                def_macro(
+                    "indexconfname", DM_VAR, compress(conflist[idx].name));
+                confsep(expand("confindexmsg", DM_VAR), idx, st, part3, 0);
+            }
+        }
+        st_glob.string.clear();
+    }
+    return 1;
 }

--- a/dates.cc
+++ b/dates.cc
@@ -7,157 +7,151 @@
 
 #include "lib.h"
 
-static const char *month[] = {
-    "jan_uary", "feb_ruary", "mar_ch", "apr_il", "may",
-    "jun_e", "jul_y", "aug_ust", "sep_tember", "oct_ober", "nov_ember",
-    "dec_ember"
-};
+static const char *month[] = {"jan_uary", "feb_ruary", "mar_ch", "apr_il",
+    "may", "jun_e", "jul_y", "aug_ust", "sep_tember", "oct_ober", "nov_ember",
+    "dec_ember"};
 
 void
 get_num(int *a, const char **ptr)
 {
-	while (isdigit(**ptr)) {
-		*a = *a * 10 + **ptr - '0';
-		(*ptr)++;
-	}
+    while (isdigit(**ptr)) {
+        *a = *a * 10 + **ptr - '0';
+        (*ptr)++;
+    }
 }
 
 void
 get_str(int *m, const char **ptr)
 {
-	int i, l;
-	char buff[64];
+    int i, l;
+    char buff[64];
 
-	const char *p = *ptr;
-	for (l = 0; isalpha(p[l]) && l < sizeof(buff) - 1; l++)
-		buff[l] = p[l];
-	buff[l] = 0;
+    const char *p = *ptr;
+    for (l = 0; isalpha(p[l]) && l < sizeof(buff) - 1; l++) buff[l] = p[l];
+    buff[l] = 0;
 
-	for (i = 0; i < 12; i++) {
-		if (match(buff, month[i])) {
-			*m = i + 1;
-			*ptr += l;
-		}
-	}
+    for (i = 0; i < 12; i++) {
+        if (match(buff, month[i])) {
+            *m = i + 1;
+            *ptr += l;
+        }
+    }
 }
 
 void
 get_time(struct tm *tm, const char **ptr)
 {
-	tm->tm_hour = 0;
-	get_num(&(tm->tm_hour), ptr);
-	if (**ptr == ':') {
-		(*ptr)++;
-		tm->tm_min = 0;
-		get_num(&(tm->tm_min), ptr);
-	} else
-		tm->tm_min = 0;
-	if (**ptr == ':') {
-		(*ptr)++;
-		tm->tm_sec = 0;
-		get_num(&(tm->tm_sec), ptr);
-	} else
-		tm->tm_sec = 0;
-	while (**ptr == ' ') (*ptr)++;
-	if (tolower(**ptr) == 'a' || tolower(**ptr) == 'm')
-		tm->tm_hour %= 12;
-	if (tolower(**ptr) == 'p' || tolower(**ptr) == 'n')
-		tm->tm_hour = (tm->tm_hour % 12) + 12;
+    tm->tm_hour = 0;
+    get_num(&(tm->tm_hour), ptr);
+    if (**ptr == ':') {
+        (*ptr)++;
+        tm->tm_min = 0;
+        get_num(&(tm->tm_min), ptr);
+    } else
+        tm->tm_min = 0;
+    if (**ptr == ':') {
+        (*ptr)++;
+        tm->tm_sec = 0;
+        get_num(&(tm->tm_sec), ptr);
+    } else
+        tm->tm_sec = 0;
+    while (**ptr == ' ') (*ptr)++;
+    if (tolower(**ptr) == 'a' || tolower(**ptr) == 'm')
+        tm->tm_hour %= 12;
+    if (tolower(**ptr) == 'p' || tolower(**ptr) == 'n')
+        tm->tm_hour = (tm->tm_hour % 12) + 12;
 }
 
 /* Take a string, return time_t value */
 const char *
 do_getdate(time_t *tt, const char *str)
 {
-	static const char *wkdy[] = {
-	    "Sun, ", "Mon, ", "Tue, ", "Wed, ", "Thu, ", "Fri, ", "Sat, ",
-	    "Sun ", "Mon ", "Tue ", "Wed ", "Thu ", "Fri ", "Sat "
-	};
+    static const char *wkdy[] = {"Sun, ", "Mon, ", "Tue, ", "Wed, ", "Thu, ",
+        "Fri, ", "Sat, ", "Sun ", "Mon ", "Tue ", "Wed ", "Thu ", "Fri ",
+        "Sat "};
 
-	struct tm tm;
-	time_t t;
-	int i, sgn;
-	int a = 0, b = 0, c = 0, m = 0;
+    struct tm tm;
+    time_t t;
+    int i, sgn;
+    int a = 0, b = 0, c = 0, m = 0;
 
-	time(&t); /* get current time */
-	memcpy(&tm, localtime(&t), sizeof(tm));
-	tm.tm_sec = tm.tm_min = tm.tm_hour = 0; /* ok on grex */
+    time(&t); /* get current time */
+    memcpy(&tm, localtime(&t), sizeof(tm));
+    tm.tm_sec = tm.tm_min = tm.tm_hour = 0; /* ok on grex */
 
-	auto ptr = str;
-	while (*ptr == ' ')
-		ptr++; /* skip leading spaces */
+    auto ptr = str;
+    while (*ptr == ' ') ptr++; /* skip leading spaces */
 
-	for (i = 0; i < 7; i++) {
-		if (!strncmp(wkdy[i], ptr, strlen(wkdy[i])))
-			ptr += strlen(wkdy[i]);
-	}
-	if (*ptr == '+' || *ptr == '-') {
-		sgn = (*ptr == '+') ? 1 : -1;
-		ptr++;
-		i = 0;
-		while (isdigit(*ptr)) {
-			i = i * 10 + (*ptr - '0');
-			ptr++;
-		}
-		*tt = mktime(&tm) + sgn * i * 24 * 60 * 60;
-	} else {
-		/* Leading (timestamp) */
-		if (*ptr == '(') { /* ) */
-			ptr++;
-			get_time(&tm, &ptr);
-			while (*ptr && *ptr != ')') ptr++;
-			if (*ptr == ')')
-				ptr++;
-			while (isspace(*ptr)) ptr++;
-		}
+    for (i = 0; i < 7; i++) {
+        if (!strncmp(wkdy[i], ptr, strlen(wkdy[i])))
+            ptr += strlen(wkdy[i]);
+    }
+    if (*ptr == '+' || *ptr == '-') {
+        sgn = (*ptr == '+') ? 1 : -1;
+        ptr++;
+        i = 0;
+        while (isdigit(*ptr)) {
+            i = i * 10 + (*ptr - '0');
+            ptr++;
+        }
+        *tt = mktime(&tm) + sgn * i * 24 * 60 * 60;
+    } else {
+        /* Leading (timestamp) */
+        if (*ptr == '(') { /* ) */
+            ptr++;
+            get_time(&tm, &ptr);
+            while (*ptr && *ptr != ')') ptr++;
+            if (*ptr == ')')
+                ptr++;
+            while (isspace(*ptr)) ptr++;
+        }
 
-		/* Get date */
-		if (isdigit(*ptr))
-			get_num(&a, &ptr);
-		else
-			get_str(&m, &ptr);
-		while (*ptr == ' ' || *ptr == '/' || *ptr == '-') ptr++;
-		if (isdigit(*ptr))
-			get_num(&b, &ptr);
-		else
-			get_str(&m, &ptr);
-		while (*ptr == ' ' || *ptr == '/' || *ptr == '-' || *ptr == ',')
-			ptr++;
-		if (isdigit(*ptr))
-			get_num(&c, &ptr);
-		if (c > 1900)
-			c -= 1900;
-		if (c)
-			tm.tm_year = c;
+        /* Get date */
+        if (isdigit(*ptr))
+            get_num(&a, &ptr);
+        else
+            get_str(&m, &ptr);
+        while (*ptr == ' ' || *ptr == '/' || *ptr == '-') ptr++;
+        if (isdigit(*ptr))
+            get_num(&b, &ptr);
+        else
+            get_str(&m, &ptr);
+        while (*ptr == ' ' || *ptr == '/' || *ptr == '-' || *ptr == ',') ptr++;
+        if (isdigit(*ptr))
+            get_num(&c, &ptr);
+        if (c > 1900)
+            c -= 1900;
+        if (c)
+            tm.tm_year = c;
 
-		/* Assign values to date structure */
-		if (m) {
-			tm.tm_mon = m - 1;
-			if (a)
-				tm.tm_mday = a;
-			else if (b)
-				tm.tm_mday = b;
-		} else if (a * b) {
-			tm.tm_mon = a - 1;
-			tm.tm_mday = b;
-		}
+        /* Assign values to date structure */
+        if (m) {
+            tm.tm_mon = m - 1;
+            if (a)
+                tm.tm_mday = a;
+            else if (b)
+                tm.tm_mday = b;
+        } else if (a * b) {
+            tm.tm_mon = a - 1;
+            tm.tm_mday = b;
+        }
 
-		/* Trailing (timestamp) */
-		while (isspace(*ptr)) ptr++;
-		if (*ptr == '(') { /* ) */
-			ptr++;
-			get_time(&tm, &ptr);
-			while (*ptr && *ptr != ')') ptr++;
-			if (*ptr == ')')
-				ptr++;
+        /* Trailing (timestamp) */
+        while (isspace(*ptr)) ptr++;
+        if (*ptr == '(') { /* ) */
+            ptr++;
+            get_time(&tm, &ptr);
+            while (*ptr && *ptr != ')') ptr++;
+            if (*ptr == ')')
+                ptr++;
 
-			/* Trailing timestamp */
-		} else if (isdigit(*ptr))
-			get_time(&tm, &ptr);
-		/* do we need to advance ptr? */
+            /* Trailing timestamp */
+        } else if (isdigit(*ptr))
+            get_time(&tm, &ptr);
+        /* do we need to advance ptr? */
 
-		*tt = mktime(&tm);
-		memcpy(&tm, localtime(tt), sizeof(tm));
-	}
-	return ptr;
+        *tt = mktime(&tm);
+        memcpy(&tm, localtime(tt), sizeof(tm));
+    }
+    return ptr;
 }

--- a/driver.cc
+++ b/driver.cc
@@ -49,44 +49,44 @@
 #ifdef WWW
 unsigned long ticket = 0;
 #endif
-flag_t flags = 0;		// user settable parameter flags
-unsigned char mode = M_OK;	// input mode (which prompt)
-flag_t status = 0;		// system status flags
-flag_t debug = 0;		// debug flags
+flag_t flags = 0;          // user settable parameter flags
+unsigned char mode = M_OK; // input mode (which prompt)
+flag_t status = 0;         // system status flags
+flag_t debug = 0;          // debug flags
 
 // Conference info
-int current = -1;		// current index to cflist
-int confidx = -1;		// current index to conflist
+int current = -1; // current index to cflist
+int confidx = -1; // current index to conflist
 int defidx = -1;
-int joinidx = -1;		// current index to conflist
-std::string confname;		// name of current conference
+int joinidx = -1;     // current index to conflist
+std::string confname; // name of current conference
 std::vector<std::string> cflist;
-std::string cfliststr;		// cflist in a string
-std::vector<std::string> fw;	// List of FW's for current conf
-partentry_t part[MAX_ITEMS];    // User participation info
+std::string cfliststr;       // cflist in a string
+std::vector<std::string> fw; // List of FW's for current conf
+partentry_t part[MAX_ITEMS]; // User participation info
 /* System info */
-std::string bbsdir;		// Directory for bbs files
-std::string helpdir;		// Directory for help files
-std::vector<assoc_t> conflist;	// System table of conferences
-std::vector<assoc_t> desclist;	// System table of conference descriptions
-std::string hostname;           // System host name
+std::string bbsdir;            // Directory for bbs files
+std::string helpdir;           // Directory for help files
+std::vector<assoc_t> conflist; // System table of conferences
+std::vector<assoc_t> desclist; // System table of conference descriptions
+std::string hostname;          // System host name
 
 // Info on the user
-uid_t uid;			// User's UID
-std::string login;		// User's login
-std::string fullname;		// User's fullname from passwd
-std::string email;		// User's email address
-std::string home;		// User's home directory
-std::string work;		// User's work directory
-std::string partdir;		// User's participation file dir
-int cgi_item;			// single item # in cgi mode
-int cgi_resp;			// single resp # in cgi mode
+uid_t uid;            // User's UID
+std::string login;    // User's login
+std::string fullname; // User's fullname from passwd
+std::string email;    // User's email address
+std::string home;     // User's home directory
+std::string work;     // User's work directory
+std::string partdir;  // User's participation file dir
+int cgi_item;         // single item # in cgi mode
+int cgi_resp;         // single resp # in cgi mode
 
 // Item statistics
-status_t st_glob;		// statistics on current conference
-status_t st_new;		// statistics on new conference to join
-sumentry_t sum[MAX_ITEMS];	// items in current conference
-response_t re[MAX_RESPONSES];	// responses to current item
+status_t st_glob;             // statistics on current conference
+status_t st_new;              // statistics on new conference to join
+sumentry_t sum[MAX_ITEMS];    // items in current conference
+response_t re[MAX_RESPONSES]; // responses to current item
 
 // Variables global to this module only
 static char *cmdbuf = NULL;
@@ -103,143 +103,142 @@ stdin_t saved_stdin[STDIN_STACK_SIZE]; // dup'ed fds when pushed
 void
 push_stdin(FILE *fp, int type)
 {
-	int old_fd, i;
-	FILE *old_fp;
+    int old_fd, i;
+    FILE *old_fp;
 
-	if (!fp || fileno(fp) < 1) {
-		std::println("Invalid fp passed to push_stdin()!");
-		return;
-	}
-	if (stdin_stack_top + 1 >= STDIN_STACK_SIZE) {
-		error("out of stdin stack space");
-		endbbs(1);
-	}
-	orig_stdin[stdin_stack_top + 1].type = type;
-	orig_stdin[stdin_stack_top + 1].fp = fp;
-	orig_stdin[stdin_stack_top + 1].fd = fileno(fp);
+    if (!fp || fileno(fp) < 1) {
+        std::println("Invalid fp passed to push_stdin()!");
+        return;
+    }
+    if (stdin_stack_top + 1 >= STDIN_STACK_SIZE) {
+        error("out of stdin stack space");
+        endbbs(1);
+    }
+    orig_stdin[stdin_stack_top + 1].type = type;
+    orig_stdin[stdin_stack_top + 1].fp = fp;
+    orig_stdin[stdin_stack_top + 1].fd = fileno(fp);
 
-	old_fd = dup(0);
-	old_fp = st_glob.inp;
-	/* close stdin */
-	close(0);
-	i = dup(fileno(fp));
-	if (i)
-		std::println("Dup error, i={} fd={} old={}", i, fileno(fp), old_fd);
-	st_glob.inp = fdopen(0, "r");
-	saved_stdin[stdin_stack_top].type = orig_stdin[stdin_stack_top].type;
-	saved_stdin[stdin_stack_top].fp = old_fp;
-	saved_stdin[stdin_stack_top].fd = old_fd;
-	if (debug & DB_IOREDIR) {
-		std::println("orig_stdin[{}]={}   saved_stdin[{}]={}",
-		    stdin_stack_top + 1, orig_stdin[stdin_stack_top + 1].fd,
-		    stdin_stack_top, saved_stdin[stdin_stack_top].fd);
-	}
-	stdin_stack_top++;
+    old_fd = dup(0);
+    old_fp = st_glob.inp;
+    /* close stdin */
+    close(0);
+    i = dup(fileno(fp));
+    if (i)
+        std::println("Dup error, i={} fd={} old={}", i, fileno(fp), old_fd);
+    st_glob.inp = fdopen(0, "r");
+    saved_stdin[stdin_stack_top].type = orig_stdin[stdin_stack_top].type;
+    saved_stdin[stdin_stack_top].fp = old_fp;
+    saved_stdin[stdin_stack_top].fd = old_fd;
+    if (debug & DB_IOREDIR) {
+        std::println("orig_stdin[{}]={}   saved_stdin[{}]={}",
+            stdin_stack_top + 1, orig_stdin[stdin_stack_top + 1].fd,
+            stdin_stack_top, saved_stdin[stdin_stack_top].fd);
+    }
+    stdin_stack_top++;
 }
 
 void
 pop_stdin(void)
 {
-	if (stdin_stack_top <= 0) {
-		error("tried to pop off null stdin stack");
-		endbbs(1);
-	}
-	/* close stdin */
-	switch (orig_stdin[stdin_stack_top].type & STD_TYPE) {
-	case STD_FILE:
-		mclose(orig_stdin[stdin_stack_top].fp);
-		break;
-	case STD_SFILE:
-		smclose(orig_stdin[stdin_stack_top].fp);
-		break;
-	case STD_SPIPE:
-		spclose(orig_stdin[stdin_stack_top].fp);
-		break;
-	}
-	close(0);
+    if (stdin_stack_top <= 0) {
+        error("tried to pop off null stdin stack");
+        endbbs(1);
+    }
+    /* close stdin */
+    switch (orig_stdin[stdin_stack_top].type & STD_TYPE) {
+    case STD_FILE:
+        mclose(orig_stdin[stdin_stack_top].fp);
+        break;
+    case STD_SFILE:
+        smclose(orig_stdin[stdin_stack_top].fp);
+        break;
+    case STD_SPIPE:
+        spclose(orig_stdin[stdin_stack_top].fp);
+        break;
+    }
+    close(0);
 
-	auto fd = saved_stdin[--stdin_stack_top].fd;
-	if (debug & DB_IOREDIR)
-		std::println("restoring {} as stdin", fd);
-	dup(fd);
-	st_glob.inp = fdopen(0, "r");
-	close(fd);
-	if (saved_stdin[stdin_stack_top].fp)
-		st_glob.inp = saved_stdin[stdin_stack_top].fp;
+    auto fd = saved_stdin[--stdin_stack_top].fd;
+    if (debug & DB_IOREDIR)
+        std::println("restoring {} as stdin", fd);
+    dup(fd);
+    st_glob.inp = fdopen(0, "r");
+    close(fd);
+    if (saved_stdin[stdin_stack_top].fp)
+        st_glob.inp = saved_stdin[stdin_stack_top].fp;
 
-	clearerr(st_glob.inp);
+    clearerr(st_glob.inp);
 }
 
 void
 open_pipe(void)
 {
-	if (status & S_REDIRECT)
-		return;
+    if (status & S_REDIRECT)
+        return;
 
-	/* Need to check if pager exists */
-	if (!(status & S_PAGER)) {
-		if (pipebuf.empty())
-			pipebuf = expand("pager", DM_VAR);
-		if (!pipebuf.empty()) {
-			/* Compress it a bit */
-			auto pager = std::string(strimw(pipebuf));
-			if (pager.front() == '"') {
-				pager.erase(0, 1);
-				if (!pager.empty() && pager.back() == '"')
-					pager.pop_back();
-			}
-			if (pager.front() == '\'') {
-				pager.erase(0, 1);
-				if (!pager.empty() && pager.back() == '\'')
-					pager.pop_back();
-			}
-			if (!(flags & O_BUFFER))
-				pager.clear();
-			if (!pager.empty()) {
-				st_glob.outp = spopen(pager);
-				if (st_glob.outp == NULL)
-					pager.clear();
-				else
-					status |= S_PAGER;
-			}
-			if (pager.empty())
-				st_glob.outp = stdout;
+    /* Need to check if pager exists */
+    if (!(status & S_PAGER)) {
+        if (pipebuf.empty())
+            pipebuf = expand("pager", DM_VAR);
+        if (!pipebuf.empty()) {
+            /* Compress it a bit */
+            auto pager = std::string(strimw(pipebuf));
+            if (pager.front() == '"') {
+                pager.erase(0, 1);
+                if (!pager.empty() && pager.back() == '"')
+                    pager.pop_back();
+            }
+            if (pager.front() == '\'') {
+                pager.erase(0, 1);
+                if (!pager.empty() && pager.back() == '\'')
+                    pager.pop_back();
+            }
+            if (!(flags & O_BUFFER))
+                pager.clear();
+            if (!pager.empty()) {
+                st_glob.outp = spopen(pager);
+                if (st_glob.outp == NULL)
+                    pager.clear();
+                else
+                    status |= S_PAGER;
+            }
+            if (pager.empty())
+                st_glob.outp = stdout;
 
-		} else
-			st_glob.outp = stdout;
-	}
+        } else
+            st_glob.outp = stdout;
+    }
 }
 
 // Print a prompt for an input mode.
 void
 print_prompt(int mod)
 {
-	const char *str = NULL;
-	if (flags & O_QUIET)
-		return;
+    const char *str = NULL;
+    if (flags & O_QUIET)
+        return;
 
-	switch (mod) {
-	case M_OK: /* In a conference or not? */
-		str = (confidx < 0) ? "noconfp" : "prompt";
-		break;
-	case M_RFP:
-		str = (!check_acl(RESPOND_RIGHT, confidx)) ? "obvprompt"
-		                                           : "rfpprompt";
-		break;
-	case M_TEXT:
-		str = "text";
-		break;
-	case M_JOQ:
-		str = "joqprompt";
-		break;
-	case M_EDB:
-		str = "edbprompt";
-		break;
-	}
-	if (debug & DB_DRIVER)
-		std::println("!{}!", str);
-	/* expand seps & print */
-	confsep(expand(str, DM_VAR), confidx, &st_glob, part, 1);
+    switch (mod) {
+    case M_OK: /* In a conference or not? */
+        str = (confidx < 0) ? "noconfp" : "prompt";
+        break;
+    case M_RFP:
+        str = (!check_acl(RESPOND_RIGHT, confidx)) ? "obvprompt" : "rfpprompt";
+        break;
+    case M_TEXT:
+        str = "text";
+        break;
+    case M_JOQ:
+        str = "joqprompt";
+        break;
+    case M_EDB:
+        str = "edbprompt";
+        break;
+    }
+    if (debug & DB_DRIVER)
+        std::println("!{}!", str);
+    /* expand seps & print */
+    confsep(expand(str, DM_VAR), confidx, &st_glob, part, 1);
 }
 
 // COMMAND LOOP: PRINT PROMPT & GET RESPONSE
@@ -250,129 +249,128 @@ print_prompt(int mod)
 bool
 get_command(const std::string_view &def, int lvl)
 {
-	char *inbuff, *inb;
-	bool ok = true;
+    char *inbuff, *inb;
+    bool ok = true;
 
-	status &= ~S_INT; /* Clear interrupt */
-	if (status & S_PAGER)
-		spclose(st_glob.outp);
+    status &= ~S_INT; /* Clear interrupt */
+    if (status & S_PAGER)
+        spclose(st_glob.outp);
 
-	inbuff = cmdbuf;
-	if (inbuff == NULL) {
-		int c;
-		/* Pop up stdin stack until we're not sitting at EOF */
-		while (orig_stdin[stdin_stack_top].type != STD_TTY &&
-		       ((c = getc(st_glob.inp)) == EOF) &&
-		       (stdin_stack_top > 0 + (orig_stdin[0].type == STD_SKIP)))
-			pop_stdin();
-		if (orig_stdin[stdin_stack_top].type != STD_TTY && c != EOF)
-			ungetc(c, st_glob.inp);
+    inbuff = cmdbuf;
+    if (inbuff == NULL) {
+        int c;
+        /* Pop up stdin stack until we're not sitting at EOF */
+        while (orig_stdin[stdin_stack_top].type != STD_TTY &&
+               ((c = getc(st_glob.inp)) == EOF) &&
+               (stdin_stack_top > 0 + (orig_stdin[0].type == STD_SKIP)))
+            pop_stdin();
+        if (orig_stdin[stdin_stack_top].type != STD_TTY && c != EOF)
+            ungetc(c, st_glob.inp);
 
-		if (stdin_stack_top < lvl) {
-			return 0;
-		}
+        if (stdin_stack_top < lvl) {
+            return 0;
+        }
 
-		/* If taking input from the keyboard, print a prompt */
-		if (isatty(fileno(st_glob.inp)))
-			print_prompt(mode);
+        /* If taking input from the keyboard, print a prompt */
+        if (isatty(fileno(st_glob.inp)))
+            print_prompt(mode);
 
-		if (mode == M_OK)
-			status &= ~S_STOP;
-		inbuff = xgets(st_glob.inp, lvl);
-		ok = inbuff != NULL;
-		if (ok && orig_stdin[stdin_stack_top].type != STD_TTY &&
-		    (flags & O_VERBOSE)) {
-			std::println("command: {}", inbuff);
-			fflush(stdout);
-		}
-	}
-	if (cmdbuf != NULL || ok) {
-		/* Strip leading & trailing spaces */
-		inb = trim(inbuff);
+        if (mode == M_OK)
+            status &= ~S_STOP;
+        inbuff = xgets(st_glob.inp, lvl);
+        ok = inbuff != NULL;
+        if (ok && orig_stdin[stdin_stack_top].type != STD_TTY &&
+            (flags & O_VERBOSE)) {
+            std::println("command: {}", inbuff);
+            fflush(stdout);
+        }
+    }
+    if (cmdbuf != NULL || ok) {
+        /* Strip leading & trailing spaces */
+        inb = trim(inbuff);
 
-		/* ignore blank lines in batch mode */
-		if (*inb == '\0') {
-			if ((status & S_BATCH) != 0)
-				ok = true;
-			else
-				ok = command(std::string(def), 0);
-		} else
-			ok = command(inb, 0);
-	}
-	free(inbuff);
+        /* ignore blank lines in batch mode */
+        if (*inb == '\0') {
+            if ((status & S_BATCH) != 0)
+                ok = true;
+            else
+                ok = command(std::string(def), 0);
+        } else
+            ok = command(inb, 0);
+    }
+    free(inbuff);
 
-	return ok;
+    return ok;
 }
 
 // Clean up memory and exit.  Takes exit status.
 void
 endbbs(int ret)
 {
-	int i;
+    int i;
 
-	if (status & S_PAGER)
-		spclose(st_glob.outp);
+    if (status & S_PAGER)
+        spclose(st_glob.outp);
 
-	if (debug & DB_DRIVER)
-		std::println("endbbs:");
-	if (confidx >= 0)
-		leave(0, (char **)0); /* leave current conference */
+    if (debug & DB_DRIVER)
+        std::println("endbbs:");
+    if (confidx >= 0)
+        leave(0, (char **)0); /* leave current conference */
 
-	/* Must close stdins after leave() since leave opens /usr/bbs/rc for
-	 * stdin */
-	while (stdin_stack_top > 0)
-		pop_stdin();
+    /* Must close stdins after leave() since leave opens /usr/bbs/rc for
+     * stdin */
+    while (stdin_stack_top > 0) pop_stdin();
 
-	/* Free config */
-	free_config();
+    /* Free config */
+    free_config();
 
-	for (i = 0; i < MAX_RESPONSES; i++) {
-		re[i].login.clear();
-		re[i].fullname.clear();
+    for (i = 0; i < MAX_RESPONSES; i++) {
+        re[i].login.clear();
+        re[i].fullname.clear();
 #ifdef NEWS
-		re[i].mid.clear();
+        re[i].mid.clear();
 #endif
-	}
+    }
 
-	clear_cache(); /* throw out stat cache */
-	undefine(~0);  /* undefine all macros */
-	pipebuf.clear();
-	free(cmdbuf);
-	free(retbuf);
-	mcheck(); /* verify that files are closed */
+    clear_cache(); /* throw out stat cache */
+    undefine(~0);  /* undefine all macros */
+    pipebuf.clear();
+    free(cmdbuf);
+    free(retbuf);
+    mcheck(); /* verify that files are closed */
 
-	exit(ret);
+    exit(ret);
 }
 
 // Opens the BBS cluster.  Takes BBS and help directories.
 void
 open_cluster(const std::string &bdir, const std::string &hdir)
 {
-	/* Free up space, etc */
-	conflist.clear();
-	desclist.clear();
-	defidx = -1;
+    /* Free up space, etc */
+    conflist.clear();
+    desclist.clear();
+    defidx = -1;
 
-	/* Read in $BBS/conflist */
-	bbsdir = bdir;
-	helpdir = hdir;
-	if (helpdir.empty())
-		helpdir = bbsdir + "/help";
-	conflist = grab_list(bbsdir, "conflist", 0);
-	desclist = grab_list(bbsdir, "desclist", 0);
-	if (conflist.empty())
-		endbbs(2);
+    /* Read in $BBS/conflist */
+    bbsdir = bdir;
+    helpdir = hdir;
+    if (helpdir.empty())
+        helpdir = bbsdir + "/help";
+    conflist = grab_list(bbsdir, "conflist", 0);
+    desclist = grab_list(bbsdir, "desclist", 0);
+    if (conflist.empty())
+        endbbs(2);
 
-	for (auto i = 1uz; i < conflist.size(); i++) {
-		if (str::eq(conflist[0].location, conflist[i].location) ||
-		    match(conflist[0].location, conflist[i].name))
-			defidx = i;
-	}
-	if (defidx < 0)
-		std::println("Warning: bad default conference");
+    for (auto i = 1uz; i < conflist.size(); i++) {
+        if (str::eq(conflist[0].location, conflist[i].location) ||
+            match(conflist[0].location, conflist[i].name))
+            defidx = i;
+    }
+    if (defidx < 0)
+        std::println("Warning: bad default conference");
 
-	/* Source system rc file */
-	source(bbsdir, "rc", STD_SUPERSANE, SL_OWNER);
+    /* Source system rc file */
+    source(bbsdir, "rc", STD_SUPERSANE, SL_OWNER);
 }
 
 static int int_on = 1;
@@ -380,29 +378,29 @@ static int int_on = 1;
 void
 ints_on(void)
 {
-	struct sigaction vec;
-	sigaction(SIGINT, NULL, &vec);
-	vec.sa_flags &= ~SA_RESTART;
-	sigaction(SIGINT, &vec, NULL);
-	int_on = 1;
+    struct sigaction vec;
+    sigaction(SIGINT, NULL, &vec);
+    vec.sa_flags &= ~SA_RESTART;
+    sigaction(SIGINT, &vec, NULL);
+    int_on = 1;
 }
 
 void
 ints_off(void)
 {
-	struct sigaction vec;
-	sigaction(SIGINT, NULL, &vec);
-	vec.sa_flags |= SA_RESTART;
-	sigaction(SIGINT, &vec, NULL);
-	int_on = 0;
+    struct sigaction vec;
+    sigaction(SIGINT, NULL, &vec);
+    vec.sa_flags |= SA_RESTART;
+    sigaction(SIGINT, &vec, NULL);
+    int_on = 0;
 }
 
 void
 handle_alarm(int sig)
 {
-	(void)sig;
-	error("out of time");
-	exit(1);
+    (void)sig;
+    error("out of time");
+    exit(1);
 }
 
 /******************************************************************************/
@@ -420,225 +418,225 @@ Description: Sets up global variables, i.e. uid, login, envars,
 void
 init(int argc, char **argv)
 {
-	short c, o, i;
-	extern char *optarg;
-	extern int optind, opterr;
-	char xfile[MAX_LINE_LENGTH];
-	char syshostname[_POSIX_HOST_NAME_MAX];
-	char *mail;
-	int forcejoin = 0;
-	assoc_t *defconf;
+    short c, o, i;
+    extern char *optarg;
+    extern int optind, opterr;
+    char xfile[MAX_LINE_LENGTH];
+    char syshostname[_POSIX_HOST_NAME_MAX];
+    char *mail;
+    int forcejoin = 0;
+    assoc_t *defconf;
 
-	orig_stdin[0].type = STD_TTY;
+    orig_stdin[0].type = STD_TTY;
 
-	if (gethostname(syshostname, sizeof(syshostname)) != 0)
-		error("getting host name");
-	hostname = syshostname;
+    if (gethostname(syshostname, sizeof(syshostname)) != 0)
+        error("getting host name");
+    hostname = syshostname;
 
-	/* If hostname is not fully qualified, see what we can do to get it */
-	if (hostname.find('.') == std::string::npos) {
-		FILE *fp;
-		if ((fp = fopen("/etc/resolv.conf", "r")) != NULL) {
-			char *buff, field[80], value[80];
-			while ((buff = xgets(fp, 0)) != NULL) {
-				int nfields = sscanf(buff, "%s%s", field, value);
-				free(buff);
-				if (nfields == 2 && str::eq(field, "domain")) {
-					hostname.append(".");
-					hostname.append(value);
-					break;
-				}
-			}
-			fclose(fp);
-		}
-	}
-	str::lowercase(hostname); /* convert upper to lower case */
+    /* If hostname is not fully qualified, see what we can do to get it */
+    if (hostname.find('.') == std::string::npos) {
+        FILE *fp;
+        if ((fp = fopen("/etc/resolv.conf", "r")) != NULL) {
+            char *buff, field[80], value[80];
+            while ((buff = xgets(fp, 0)) != NULL) {
+                int nfields = sscanf(buff, "%s%s", field, value);
+                free(buff);
+                if (nfields == 2 && str::eq(field, "domain")) {
+                    hostname.append(".");
+                    hostname.append(value);
+                    break;
+                }
+            }
+            fclose(fp);
+        }
+    }
+    str::lowercase(hostname); /* convert upper to lower case */
 
-	read_config();
+    read_config();
 
-	signal(SIGINT, handle_int);
-	signal(SIGPIPE, handle_pipe);
-	signal(SIGALRM, handle_alarm);
-	if (getuid() == get_nobody_uid())
-		alarm(600); /* web process will abort after 10 minutes */
-	ints_off();
+    signal(SIGINT, handle_int);
+    signal(SIGPIPE, handle_pipe);
+    signal(SIGALRM, handle_alarm);
+    if (getuid() == get_nobody_uid())
+        alarm(600); /* web process will abort after 10 minutes */
+    ints_off();
 
-	/* Initialize options */
-	for (const auto &opt : option)
-		if (opt.dflt)
-			flags |= opt.mask;
-	for (const auto &dopt : debug_opt)
-		if (dopt.dflt)
-			debug |= dopt.mask;
+    /* Initialize options */
+    for (const auto &opt : option)
+        if (opt.dflt)
+            flags |= opt.mask;
+    for (const auto &dopt : debug_opt)
+        if (dopt.dflt)
+            debug |= dopt.mask;
 
-	/* Set up user variables */
-	evalbuf[0] = '\0';
-	pipebuf.clear();
-	free(cmdbuf);
-	cmdbuf = NULL;
-	st_glob.c_status = 0;
+    /* Set up user variables */
+    evalbuf[0] = '\0';
+    pipebuf.clear();
+    free(cmdbuf);
+    cmdbuf = NULL;
+    st_glob.c_status = 0;
 #ifdef NEWS
-	st_glob.c_article = 0;
+    st_glob.c_article = 0;
 #endif
-	st_glob.inp = stdin;
+    st_glob.inp = stdin;
 
-	/* Get current user info */
-	uid = 0;
-	login.clear();
-	if (!get_user(&uid, login, st_glob.fullname, home, email)) {
-		error("reading ", "user entry");
-		endbbs(2);
-	}
-	fullname = st_glob.fullname;
-	if (str::eq(login, "nobody"))
-		status |= S_NOAUTH;
+    /* Get current user info */
+    uid = 0;
+    login.clear();
+    if (!get_user(&uid, login, st_glob.fullname, home, email)) {
+        error("reading ", "user entry");
+        endbbs(2);
+    }
+    fullname = st_glob.fullname;
+    if (str::eq(login, "nobody"))
+        status |= S_NOAUTH;
 
-	/* Process command line options here */
-	if (!uid || uid == geteuid()) {
-		std::println("login {} -- invoking bbs -{}",
-		    login, (uid) ? "n" : "no");
-		flags &= ~(O_SOURCE); /* for security */
-		if (!uid)
-			flags |= O_OBSERVE | O_READONLY;
-	}
-	confname.clear();
-	xfile[0] = '\0';
-	while ((c = getopt(argc, argv, options)) != -1) {
-		o = strchr(options, c) - options;
-		if (o >= 0 && o < 8)
-			flags ^= option[o].mask;
-		else if (c == 'j') {
-			confname = optarg;
-			forcejoin = O_AUTOJOIN;
-		} else if (c == 'x') {
-			strcpy(xfile, optarg);
-		}
-		if (c == 'o')  // -o does observer and readonly
-			flags ^= O_READONLY;
-	}
+    /* Process command line options here */
+    if (!uid || uid == geteuid()) {
+        std::println("login {} -- invoking bbs -{}", login, (uid) ? "n" : "no");
+        flags &= ~(O_SOURCE); /* for security */
+        if (!uid)
+            flags |= O_OBSERVE | O_READONLY;
+    }
+    confname.clear();
+    xfile[0] = '\0';
+    while ((c = getopt(argc, argv, options)) != -1) {
+        o = strchr(options, c) - options;
+        if (o >= 0 && o < 8)
+            flags ^= option[o].mask;
+        else if (c == 'j') {
+            confname = optarg;
+            forcejoin = O_AUTOJOIN;
+        } else if (c == 'x') {
+            strcpy(xfile, optarg);
+        }
+        if (c == 'o') // -o does observer and readonly
+            flags ^= O_READONLY;
+    }
 #ifdef INCLUDE_EXTRA_COMMANDS
-	if ((flags & O_CGIBIN) ||
-	    str::eq(argv[0] + strlen(argv[0]) - 8, "yapp-cgi")) {
-		flags = (flags & ~O_BUFFER) | O_QUIET | O_CGIBIN | O_OBSERVE;
-		argv += optind;
-		argc -= optind;
-		if (argc < 1) {
-			confname.clear();
-			flags &= ~O_DEFAULT;
-		} else
-			confname = argv[0];
-		if (argc < 2)
-			cgi_item = -1;
-		else
-			cgi_item = atoi(argv[1]);
-		if (argc < 3)
-			cgi_resp = -1;
-		else
-			cgi_resp = atoi(argv[2]);
-	} else
+    if ((flags & O_CGIBIN) ||
+        str::eq(argv[0] + strlen(argv[0]) - 8, "yapp-cgi")) {
+        flags = (flags & ~O_BUFFER) | O_QUIET | O_CGIBIN | O_OBSERVE;
+        argv += optind;
+        argc -= optind;
+        if (argc < 1) {
+            confname.clear();
+            flags &= ~O_DEFAULT;
+        } else
+            confname = argv[0];
+        if (argc < 2)
+            cgi_item = -1;
+        else
+            cgi_item = atoi(argv[1]);
+        if (argc < 3)
+            cgi_resp = -1;
+        else
+            cgi_resp = atoi(argv[2]);
+    } else
 #endif
-	if (optind < argc)
-		confname = argv[argc - 1];
+        if (optind < argc)
+        confname = argv[argc - 1];
 
-	for (i = 0; i < MAX_RESPONSES; i++) {
-		re[i].fullname.clear();
-		re[i].login.clear();
+    for (i = 0; i < MAX_RESPONSES; i++) {
+        re[i].fullname.clear();
+        re[i].login.clear();
 #ifdef NEWS
-		re[i].mid.clear();
-		re[i].article = 0;
+        re[i].mid.clear();
+        re[i].article = 0;
 #endif
-	}
+    }
 
-	/* Set up user customizations */
-	def_macro("today", DM_PARAM, "+0");
-	mail = getenv("SHELL");
-	if (mail)
-		def_macro("shell", DM_VAR | DM_ENVAR, mail);
-	mail = getenv("EDITOR");
-	if (mail)
-		def_macro("editor", DM_VAR | DM_ENVAR, mail);
-	mail = getenv("MESG");
-	if (mail)
-		def_macro("mesg", DM_VAR | DM_ENVAR, mail);
-	urlset(); /* do QUERY_STRING sets */
+    /* Set up user customizations */
+    def_macro("today", DM_PARAM, "+0");
+    mail = getenv("SHELL");
+    if (mail)
+        def_macro("shell", DM_VAR | DM_ENVAR, mail);
+    mail = getenv("EDITOR");
+    if (mail)
+        def_macro("editor", DM_VAR | DM_ENVAR, mail);
+    mail = getenv("MESG");
+    if (mail)
+        def_macro("mesg", DM_VAR | DM_ENVAR, mail);
+    urlset(); /* do QUERY_STRING sets */
 
-	/* Read in /usr/bbs/conflist */
-	open_cluster(get_conf_param("bbsdir", BBSDIR), get_conf_param("helpdir", ""));
+    /* Read in /usr/bbs/conflist */
+    open_cluster(
+        get_conf_param("bbsdir", BBSDIR), get_conf_param("helpdir", ""));
 
-	/* Print identification */
-	if (!(flags & O_QUIET))
-		command("display version", 0);
+    /* Print identification */
+    if (!(flags & O_QUIET))
+        command("display version", 0);
 
-	/* Source .cfonce, etc */
-	login_user();
+    /* Source .cfonce, etc */
+    login_user();
 
-	defconf = NULL;
-	if (defidx >= 0) {
-		defconf = &conflist[defidx];
-	}
+    defconf = NULL;
+    if (defidx >= 0) {
+        defconf = &conflist[defidx];
+    }
 
-	/* Join initial conference */
-	if (debug & DB_DRIVER && defconf != NULL)
-		std::cout << "Default: " << defidx << " " << defconf->name << std::endl;
-	if (flags & O_INCORPORATE) {
-		/* Only accept -i from root, daemon, and Yapp owner */
-		if (!uid || uid == 1 || uid == geteuid()) {
-			endbbs(!incorporate(0, sum, part, &st_glob, -1));
-		}
-		endbbs(2);
-	} else if (!(flags & O_DEFAULT) || defconf == NULL) {
-		current = -1;
-		st_glob.i_current = 0; /* No current item */
-	} else if (!confname.empty())
-		join(confname, forcejoin, 0);
-	else if (!cflist.empty()) {
-		join(cflist[current = 0], O_AUTOJOIN, 0);
-	} else {
-		/* force join */
-		join(compress(defconf->name), O_AUTOJOIN, 0);
-	}
+    /* Join initial conference */
+    if (debug & DB_DRIVER && defconf != NULL)
+        std::cout << "Default: " << defidx << " " << defconf->name << std::endl;
+    if (flags & O_INCORPORATE) {
+        /* Only accept -i from root, daemon, and Yapp owner */
+        if (!uid || uid == 1 || uid == geteuid()) {
+            endbbs(!incorporate(0, sum, part, &st_glob, -1));
+        }
+        endbbs(2);
+    } else if (!(flags & O_DEFAULT) || defconf == NULL) {
+        current = -1;
+        st_glob.i_current = 0; /* No current item */
+    } else if (!confname.empty())
+        join(confname, forcejoin, 0);
+    else if (!cflist.empty()) {
+        join(cflist[current = 0], O_AUTOJOIN, 0);
+    } else {
+        /* force join */
+        join(compress(defconf->name), O_AUTOJOIN, 0);
+    }
 
 #ifdef INCLUDE_EXTRA_COMMANDS
-	/* CGI stuff */
-	if (flags & O_CGIBIN) {
-		source(bbsdir, "cgi_cfonce", 0, SL_OWNER);
-		if (!confname.empty()) { /* GET CONFERENCE LIST             */
-			command("list", 0);
-		} else if (cgi_item < 0) { /* GET ITEM INDEX FOR A CONF       */
-			command("browse all", 0);
-		} else if (cgi_resp < 0) {
-			/* GET RESPONSE INDEX FOR AN ITEM? */
-			command(std::format("read {} pass", cgi_item), 0);
-		} else { /* RETRIEVE RESPONSE */
-			st_glob.i_current = cgi_item;
-			st_glob.r_first = st_glob.r_last = cgi_resp;
-			show_header();
-			show_range();
-		}
-		endbbs(0);
-	}
+    /* CGI stuff */
+    if (flags & O_CGIBIN) {
+        source(bbsdir, "cgi_cfonce", 0, SL_OWNER);
+        if (!confname.empty()) { /* GET CONFERENCE LIST             */
+            command("list", 0);
+        } else if (cgi_item < 0) { /* GET ITEM INDEX FOR A CONF       */
+            command("browse all", 0);
+        } else if (cgi_resp < 0) {
+            /* GET RESPONSE INDEX FOR AN ITEM? */
+            command(std::format("read {} pass", cgi_item), 0);
+        } else { /* RETRIEVE RESPONSE */
+            st_glob.i_current = cgi_item;
+            st_glob.r_first = st_glob.r_last = cgi_resp;
+            show_header();
+            show_range();
+        }
+        endbbs(0);
+    }
 #endif
 
-	/* Batch mode */
-	if (*xfile) {
-		/* When popping stdin, don't wait for input at real_stdin */
-		orig_stdin[0].type = STD_SKIP;
-		def_macro("batchfile", DM_VAR, xfile);
-		{
-			/* reopen xfile as stdin */
-			FILE *fp = mopen(xfile, O_R);
-			if (!fp) {
-				std::println("Couldn't open {}", xfile);
-				endbbs(0);
-			}
-			if (debug & DB_IOREDIR)
-				std::println("Redirecting input from {} (fd {})",
-				    xfile, fileno(fp));
-			push_stdin(fp, STD_FILE); /* real_stdin =
-			                           * new_stdin(fp); */
-		}
-		status |= S_BATCH; /* set to ignore blank lines */
-	}
+    /* Batch mode */
+    if (*xfile) {
+        /* When popping stdin, don't wait for input at real_stdin */
+        orig_stdin[0].type = STD_SKIP;
+        def_macro("batchfile", DM_VAR, xfile);
+        {
+            /* reopen xfile as stdin */
+            FILE *fp = mopen(xfile, O_R);
+            if (!fp) {
+                std::println("Couldn't open {}", xfile);
+                endbbs(0);
+            }
+            if (debug & DB_IOREDIR)
+                std::println(
+                    "Redirecting input from {} (fd {})", xfile, fileno(fp));
+            push_stdin(fp, STD_FILE); /* real_stdin =
+                                       * new_stdin(fp); */
+        }
+        status |= S_BATCH; /* set to ignore blank lines */
+    }
 }
 
 /******************************************************************************/
@@ -655,39 +653,38 @@ Description: Executes commands in a file, does NOT grab_file since it
  close it upon EOF.
 *******************************************************************************/
 char
-source(
-    const std::string &dir,	 /* IN : Directory containing file        */
+source(const std::string &dir,   /* IN : Directory containing file        */
     const std::string &filename, /* IN : Filename of commands to execute  */
-    int fl,			 /* IN : Extra flags to set during exec   */
-    int sec			 /* IN : open file as user or as cfadm?   */
+    int fl,                      /* IN : Extra flags to set during exec   */
+    int sec                      /* IN : open file as user or as cfadm?   */
 )
 {
-	std::string path(dir);
-	if (!filename.empty()) {
-		path.append("/");
-		path.append(filename);
-	}
+    std::string path(dir);
+    if (!filename.empty()) {
+        path.append("/");
+        path.append(filename);
+    }
 
-	if (debug & DB_DRIVER)
-		std::println("source: {}", path);
-	FILE *fp = (sec == SL_OWNER) ? mopen(path, O_R | O_SILENT) : smopenr(path, O_R | O_SILENT);
-	if (fp == nullptr)
-		return 0;
+    if (debug & DB_DRIVER)
+        std::println("source: {}", path);
+    FILE *fp = (sec == SL_OWNER) ? mopen(path, O_R | O_SILENT)
+                                 : smopenr(path, O_R | O_SILENT);
+    if (fp == nullptr)
+        return 0;
 
-	/* Save standard input */
-	if (!fileno(fp))
-		std::println("save error 1");
-	if (debug & DB_IOREDIR)
-		std::println("Redirecting input from {} (fd {})", path, fileno(fp));
-	push_stdin(fp, STD_FILE | fl);
+    /* Save standard input */
+    if (!fileno(fp))
+        std::println("save error 1");
+    if (debug & DB_IOREDIR)
+        std::println("Redirecting input from {} (fd {})", path, fileno(fp));
+    push_stdin(fp, STD_FILE | fl);
 
-	/* Execute commands until we pop back to the previous level */
-	{
-		int lvl = stdin_stack_top;
-		while (stdin_stack_top >= lvl) get_command("", lvl);
-	}
-	return 1;
-
+    /* Execute commands until we pop back to the previous level */
+    {
+        int lvl = stdin_stack_top;
+        while (stdin_stack_top >= lvl) get_command("", lvl);
+    }
+    return 1;
 }
 
 static int fd_stack[3] = {-1, -1, -1};
@@ -696,23 +693,23 @@ static int fd_top = 0;
 void
 push_fd(int fd)
 {
-	if (fd_top >= 3)
-		error("pushing ", "fd");
-	else
-		fd_stack[fd_top++] = fd;
+    if (fd_top >= 3)
+        error("pushing ", "fd");
+    else
+        fd_stack[fd_top++] = fd;
 }
 
 int
 pop_fd(void)
 {
-	int i;
-	if (fd_top > 0) {
-		fd_top--;
-		i = fd_stack[fd_top];
-		fd_stack[fd_top] = -1;
-		return i;
-	}
-	return -1;
+    int i;
+    if (fd_top > 0) {
+        fd_top--;
+        i = fd_stack[fd_top];
+        fd_stack[fd_top] = -1;
+        return i;
+    }
+    return -1;
 }
 
 /*
@@ -723,27 +720,27 @@ pop_fd(void)
 std::string
 expand_history(const std::string &mac, const std::string_view &orig_args)
 {
-	static constexpr auto ws = " \t\r\n\f\v";
+    static constexpr auto ws = " \t\r\n\f\v";
 
-	// Skip leading whitespace in origargs
-	auto oargs = orig_args;
-	if (auto i = oargs.find_first_not_of(ws); i != std::string_view::npos)
-		oargs.remove_prefix(i);
+    // Skip leading whitespace in origargs
+    auto oargs = orig_args;
+    if (auto i = oargs.find_first_not_of(ws); i != std::string_view::npos)
+        oargs.remove_prefix(i);
 
-	auto s = 0uz;
-	auto e = mac.find("!*");
-	if (e == std::string_view::npos)
-		return mac + std::string(oargs);
-	std::string out;
-	while (e != std::string_view::npos) {
-		out.append(mac.substr(s, e));
-		out.append(oargs);
-		s = e + 2;
-		e = mac.find("!*", s);
-	}
-	out.append(mac.substr(s));
+    auto s = 0uz;
+    auto e = mac.find("!*");
+    if (e == std::string_view::npos)
+        return mac + std::string(oargs);
+    std::string out;
+    while (e != std::string_view::npos) {
+        out.append(mac.substr(s, e));
+        out.append(oargs);
+        s = e + 2;
+        e = mac.find("!*", s);
+    }
+    out.append(mac.substr(s));
 
-	return out;
+    return out;
 }
 /******************************************************************************/
 /* PROCESS COMMAND LINE ARGUMENTS                                             */
@@ -763,697 +760,678 @@ Description: For all command modes, this processes a user command.
 char
 command(const std::string &stro, int lvl)
 {
-	int argc = 0; /* Number of arguments */
-	int i, skip = 0;
-	char *argv[MAX_ARGS], cmddel, bufdel;
-	const char *Eptr;
-	char state = 1, ok = 1, *newstr = NULL, *tmpstr;
-	char *cmd = NULL;
-	/* Redirection information */
-	int saved_fd[3];
-	int is_pipe[3];
-	FILE *curr_fp[3];
-	int prev_redir = (status & S_REDIRECT);
-	int prev_nostdin = (status & S_NOSTDIN);
-	int prev_top = fd_top;
-	std::string wordfile;
+    int argc = 0; /* Number of arguments */
+    int i, skip = 0;
+    char *argv[MAX_ARGS], cmddel, bufdel;
+    const char *Eptr;
+    char state = 1, ok = 1, *newstr = NULL, *tmpstr;
+    char *cmd = NULL;
+    /* Redirection information */
+    int saved_fd[3];
+    int is_pipe[3];
+    FILE *curr_fp[3];
+    int prev_redir = (status & S_REDIRECT);
+    int prev_nostdin = (status & S_NOSTDIN);
+    int prev_top = fd_top;
+    std::string wordfile;
 
-	/* FreeBSD needs the second line below and NOT the first, or we see
-	 * duplicate footers in the read command.  HP-UX, on the other hand
-	 * has a broken freopen() and needs to re-seek */
+    /* FreeBSD needs the second line below and NOT the first, or we see
+     * duplicate footers in the read command.  HP-UX, on the other hand
+     * has a broken freopen() and needs to re-seek */
 
-	/* Helpcmd section */
-	const char *str = stro.c_str();
-	if (mode == M_OK && stro.empty() && !(status & S_BATCH) &&
-	    isatty(fileno(st_glob.inp))) {
-		const auto helpcmd = expand("helpcmd", DM_VAR);
-		if (!helpcmd.empty()) {
-			str = helpcmd.c_str();
-		}
-	}
-	for (i = 0; i < 3; i++) {
-		saved_fd[i] = -1;
-		is_pipe[i] = 0;
-	}
+    /* Helpcmd section */
+    const char *str = stro.c_str();
+    if (mode == M_OK && stro.empty() && !(status & S_BATCH) &&
+        isatty(fileno(st_glob.inp))) {
+        const auto helpcmd = expand("helpcmd", DM_VAR);
+        if (!helpcmd.empty()) {
+            str = helpcmd.c_str();
+        }
+    }
+    for (i = 0; i < 3; i++) {
+        saved_fd[i] = -1;
+        is_pipe[i] = 0;
+    }
 
-	if (!str || !*str)
-		return 1;
+    if (!str || !*str)
+        return 1;
 
-	if (debug & DB_DRIVER)
-		std::println("command: '{}' level: {}", str, lvl);
-	if (lvl > CMD_DEPTH) {
-		std::println("Too many expansions.");
-		return 0;
-	}
-	const char *Sptr = str;
-	while (isspace(*Sptr)) Sptr++; /* skip whitespace */
+    if (debug & DB_DRIVER)
+        std::println("command: '{}' level: {}", str, lvl);
+    if (lvl > CMD_DEPTH) {
+        std::println("Too many expansions.");
+        return 0;
+    }
+    const char *Sptr = str;
+    while (isspace(*Sptr)) Sptr++; /* skip whitespace */
 
-	/* Skip if inside false condition, but we have to parse args to find
-	 * ';' for start of next command */
-	if (!test_if() && strncmp("endif", Sptr, 5) &&
-	    strncmp("else", Sptr, 4) && strncmp("if ", Sptr, 3))
-		skip = 1;
+    /* Skip if inside false condition, but we have to parse args to find
+     * ';' for start of next command */
+    if (!test_if() && strncmp("endif", Sptr, 5) && strncmp("else", Sptr, 4) &&
+        strncmp("if ", Sptr, 3))
+        skip = 1;
 
-	/* Process shell escape */
-	if (str[0] == '!') {
-		if (!skip) {
-			unix_cmd(str + 1);
-			std::println("!");
-		}
-		return 1;
-	}
+    /* Process shell escape */
+    if (str[0] == '!') {
+        if (!skip) {
+            unix_cmd(str + 1);
+            std::println("!");
+        }
+        return 1;
+    }
 
-	/* And comments */
-	if (*Sptr == '#')
-		return 1;
+    /* And comments */
+    if (*Sptr == '#')
+        return 1;
 
-	cmddel = expand("cmddel", DM_VAR)[0];
-	bufdel = expand("bufdel", DM_VAR)[0];
+    cmddel = expand("cmddel", DM_VAR)[0];
+    bufdel = expand("bufdel", DM_VAR)[0];
 
-	/* Get arguments using a state machine for lexical analysis */
-	pipebuf.clear();
-	free(cmdbuf);
-	cmdbuf = NULL;
-	while (state && argc < MAX_ARGS) {
-		switch (state) {
-		case 1: /* between words */
-			while (isspace(*Sptr)) Sptr++;
-			if (*Sptr == cmddel) {
-				Sptr++;
-				state = 0;
-			} else if (*Sptr == bufdel) {
-				Eptr = ++Sptr;
-				state = 6;
-			} else if (*Sptr == '|') {
-				Eptr = ++Sptr;
-				state = 7;
-			} else if (*Sptr == '(') {
-				Eptr = Sptr;
-				state = 10;
-			} else if (*Sptr == '>') {
-				Eptr = ++Sptr;
-				state = 9;
-			} else if (*Sptr == '<') {
-				Eptr = ++Sptr;
-				state = 12;
-			} else if (*Sptr == '\'') {
-				Eptr = ++Sptr;
-				state = 4;
-			} else if (*Sptr == '`') {
-				Eptr = ++Sptr;
-				state = 8;
-			} else if (*Sptr == '\"') {
-				Eptr = Sptr;
-				state = 3;
-			} else if (*Sptr == '%') {
-				Eptr = ++Sptr;
-				state = 11;
-			} else if (*Sptr == '\\') {
-				Eptr = Sptr;
-				state = 5;
-			} else if (*Sptr) {
-				Eptr = Sptr;
-				state = 2;
-			} else
-				state = 0;
-			break;
+    /* Get arguments using a state machine for lexical analysis */
+    pipebuf.clear();
+    free(cmdbuf);
+    cmdbuf = NULL;
+    while (state && argc < MAX_ARGS) {
+        switch (state) {
+        case 1: /* between words */
+            while (isspace(*Sptr)) Sptr++;
+            if (*Sptr == cmddel) {
+                Sptr++;
+                state = 0;
+            } else if (*Sptr == bufdel) {
+                Eptr = ++Sptr;
+                state = 6;
+            } else if (*Sptr == '|') {
+                Eptr = ++Sptr;
+                state = 7;
+            } else if (*Sptr == '(') {
+                Eptr = Sptr;
+                state = 10;
+            } else if (*Sptr == '>') {
+                Eptr = ++Sptr;
+                state = 9;
+            } else if (*Sptr == '<') {
+                Eptr = ++Sptr;
+                state = 12;
+            } else if (*Sptr == '\'') {
+                Eptr = ++Sptr;
+                state = 4;
+            } else if (*Sptr == '`') {
+                Eptr = ++Sptr;
+                state = 8;
+            } else if (*Sptr == '\"') {
+                Eptr = Sptr;
+                state = 3;
+            } else if (*Sptr == '%') {
+                Eptr = ++Sptr;
+                state = 11;
+            } else if (*Sptr == '\\') {
+                Eptr = Sptr;
+                state = 5;
+            } else if (*Sptr) {
+                Eptr = Sptr;
+                state = 2;
+            } else
+                state = 0;
+            break;
 
-		case 2: /* normal word */
-			while (*Eptr && !isspace(*Eptr) && *Eptr != cmddel &&
-			       *Eptr != bufdel && !strchr("|`'>\\\"", *Eptr) &&
-			       !(Eptr > Sptr &&
-			           *(Eptr - 1) == '=') /* '=' terminates word */
-			       && (argc || *Sptr == '-' || isdigit(*Sptr) ||
-			              !isdigit(*Eptr)))
-				Eptr++;
+        case 2: /* normal word */
+            while (
+                *Eptr && !isspace(*Eptr) && *Eptr != cmddel &&
+                *Eptr != bufdel && !strchr("|`'>\\\"", *Eptr) &&
+                !(Eptr > Sptr && *(Eptr - 1) == '=') /* '=' terminates word */
+                && (argc || *Sptr == '-' || isdigit(*Sptr) || !isdigit(*Eptr)))
+                Eptr++;
 
-			argv[argc++] = estrndup(Sptr, Eptr - Sptr);
-			Sptr = Eptr;
+            argv[argc++] = estrndup(Sptr, Eptr - Sptr);
+            Sptr = Eptr;
 
-			if (argc == 1) {
-				auto cmd2 = expand(argv[0], (mode == M_RFP) ? DM_RFP : DM_OK);
-				if (!cmd2.empty()) {
-					auto tmp = expand_history(cmd2, Eptr);
+            if (argc == 1) {
+                auto cmd2 = expand(argv[0], (mode == M_RFP) ? DM_RFP : DM_OK);
+                if (!cmd2.empty()) {
+                    auto tmp = expand_history(cmd2, Eptr);
 
-					/* Undo first argument */
-					free(argv[0]);
-					argv[0] = NULL;
-					argc = 0;
+                    /* Undo first argument */
+                    free(argv[0]);
+                    argv[0] = NULL;
+                    argc = 0;
 
-					/* Store cmd for later freeing */
-					free(cmd);
-					cmd = estrdup(tmp.c_str());
-					Sptr = cmd; /* Parse cmd instead */
-				}
-			}
-			state = 1;
-			break;
+                    /* Store cmd for later freeing */
+                    free(cmd);
+                    cmd = estrdup(tmp.c_str());
+                    Sptr = cmd; /* Parse cmd instead */
+                }
+            }
+            state = 1;
+            break;
 
-		case 3: /* "stuff" */
-		{
-			int quot = 0;
-			char *p;
-			const char *q;
+        case 3: /* "stuff" */
+        {
+            int quot = 0;
+            char *p;
+            const char *q;
 
-			/* First expand backtick commands */
-			for (Eptr = Sptr + 1;
-			     *Eptr && (*Eptr != '\"' || *(Eptr - 1) == '\\');
-			     Eptr++) {
-				if (*Eptr == '`' && *(Eptr - 1) != '\\') {
-					const char *Cptr = Eptr + 1;
-					/* Find end of command */
-					do {
-						Eptr++;
-					} while (*Eptr && *Eptr != '`');
+            /* First expand backtick commands */
+            for (Eptr = Sptr + 1;
+                *Eptr && (*Eptr != '\"' || *(Eptr - 1) == '\\'); Eptr++) {
+                if (*Eptr == '`' && *(Eptr - 1) != '\\') {
+                    const char *Cptr = Eptr + 1;
+                    /* Find end of command */
+                    do {
+                        Eptr++;
+                    } while (*Eptr && *Eptr != '`');
 
-					free(cmd);
-					cmd = estrndup(Cptr, Eptr - Cptr);
-					if (*Eptr)
-						Eptr++; /* Set Eptr to
-						         * next char
-						         * after end `
-						         */
+                    free(cmd);
+                    cmd = estrndup(Cptr, Eptr - Cptr);
+                    if (*Eptr)
+                        Eptr++; /* Set Eptr to
+                                 * next char
+                                 * after end `
+                                 */
 
-					status |= S_EXECUTE;
-					evalbuf[0] = '\0';
-					command(cmd, lvl + 1);
-					status &= ~S_EXECUTE;
-					free(cmd);
-					cmd = NULL;
+                    status |= S_EXECUTE;
+                    evalbuf[0] = '\0';
+                    command(cmd, lvl + 1);
+                    status &= ~S_EXECUTE;
+                    free(cmd);
+                    cmd = NULL;
 
-					/* We want to end up with Sptr
-					 * pointing to a buffer which
-					 * contains the inital text,
-					 * followed by the output,
-					 * followed by whatever was
-					 * left in the original
-					 * buffer. */
-					/* before */
-					std::string sa(Sptr, Cptr - Sptr - 1);
-					q = evalbuf;
-					while (*q) {
-						if (*q == '\n' || *q == '\r') {
-							q++;
-						} else if (*q == '"' &&
-						           (q == evalbuf || q[-1] != '\\')) {
-							/* escape quotes */
-							sa.push_back('\\');
-							sa.push_back(*q++);
-						} else
-							sa.push_back(*q++);
-					}
-					sa.append(Eptr);
-					free(newstr);
-					Sptr = newstr = estrdup(sa.c_str());
-				}
-			}
+                    /* We want to end up with Sptr
+                     * pointing to a buffer which
+                     * contains the inital text,
+                     * followed by the output,
+                     * followed by whatever was
+                     * left in the original
+                     * buffer. */
+                    /* before */
+                    std::string sa(Sptr, Cptr - Sptr - 1);
+                    q = evalbuf;
+                    while (*q) {
+                        if (*q == '\n' || *q == '\r') {
+                            q++;
+                        } else if (*q == '"' &&
+                                   (q == evalbuf || q[-1] != '\\')) {
+                            /* escape quotes */
+                            sa.push_back('\\');
+                            sa.push_back(*q++);
+                        } else
+                            sa.push_back(*q++);
+                    }
+                    sa.append(Eptr);
+                    free(newstr);
+                    Sptr = newstr = estrdup(sa.c_str());
+                }
+            }
 
-			/* Count occurrences of \" and set Eptr to end of string */
-			Eptr = Sptr; /* reset to start of buffer after " */
-			do {
-				Eptr++;
-				if (*Eptr == '\"' && *(Eptr - 1) == '\\')
-					quot++;
-			} while (*Eptr && (*Eptr != '\"' || *(Eptr - 1) == '\\'));
+            /* Count occurrences of \" and set Eptr to end of string */
+            Eptr = Sptr; /* reset to start of buffer after " */
+            do {
+                Eptr++;
+                if (*Eptr == '\"' && *(Eptr - 1) == '\\')
+                    quot++;
+            } while (*Eptr && (*Eptr != '\"' || *(Eptr - 1) == '\\'));
 
-			/* Include the quotes in the arg */
-			argv[argc] = (char *)emalloc(Eptr - Sptr + 2 - quot);
-			p = argv[argc];
-			q = Sptr;
-			while (q <= Eptr) {
-				if (*q == '\\' && q[1] == '"')
-					q++;
-				*p++ = *q++;
-			}
-			*p = '\0';
-			argc++;
+            /* Include the quotes in the arg */
+            argv[argc] = (char *)emalloc(Eptr - Sptr + 2 - quot);
+            p = argv[argc];
+            q = Sptr;
+            while (q <= Eptr) {
+                if (*q == '\\' && q[1] == '"')
+                    q++;
+                *p++ = *q++;
+            }
+            *p = '\0';
+            argc++;
 
-			if (*Eptr)
-				Eptr++;
-			Sptr = Eptr;
-			state = 1;
-			break;
-		}
+            if (*Eptr)
+                Eptr++;
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
 
+        case 4: /* 'stuff' */
+        {
+            int quot = 0;
+            char *p;
+            const char *q;
+            while (*Eptr && (*Eptr != '\'' || *(Eptr - 1) == '\\')) {
+                Eptr++;
+                if (*Eptr == '\'' && *(Eptr - 1) == '\\')
+                    quot++;
+            }
+            argv[argc] = (char *)emalloc(Eptr - Sptr + 2 - quot);
+            p = argv[argc];
+            q = Sptr;
+            while (q < Eptr) {
+                if (*q == '\\' && q[1] == '\'')
+                    q++;
+                *p++ = *q++;
+            }
+            *p = '\0';
+            argc++;
 
-		case 4: /* 'stuff' */
-			{
-				int quot = 0;
-				char *p;
-				const char *q;
-				while (*Eptr &&
-				       (*Eptr != '\'' || *(Eptr - 1) == '\\')) {
-					Eptr++;
-					if (*Eptr == '\'' && *(Eptr - 1) == '\\')
-						quot++;
-				}
-				argv[argc] = (char *)emalloc(Eptr - Sptr + 2 - quot);
-				p = argv[argc];
-				q = Sptr;
-				while (q < Eptr) {
-					if (*q == '\\' && q[1] == '\'')
-						q++;
-					*p++ = *q++;
-				}
-				*p = '\0';
-				argc++;
+            if (*Eptr)
+                Eptr++;
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
 
-				if (*Eptr)
-					Eptr++;
-				Sptr = Eptr;
-				state = 1;
-				break;
-			}
+        case 5: /* \\ */
+            argv[argc] = estrdup("\\");
+            Sptr = Eptr + 1;
+            state = 1;
+            break;
 
-		case 5: /* \\ */
-			argv[argc] = estrdup("\\");
-			Sptr = Eptr + 1;
-			state = 1;
-			break;
+        case 6: /* ,stuff */
+            do {
+                Eptr++;
+            } while (*Eptr && *Eptr != cmddel);
+            free(cmdbuf);
+            cmdbuf = estrndup(Sptr, Eptr - Sptr);
+            Sptr = Eptr;
+            state = 1;
+            break;
 
-		case 6: /* ,stuff */
-			do {
-				Eptr++;
-			} while (*Eptr && *Eptr != cmddel);
-			free(cmdbuf);
-			cmdbuf = estrndup(Sptr, Eptr - Sptr);
-			Sptr = Eptr;
-			state = 1;
-			break;
-
-		case 7: /* | stuff */
-		{       /* Also |& */
+        case 7: /* | stuff */
+        {       /* Also |& */
 #define OP_STDOUT 0x00
 #define OP_STDERR 0x01
-			int op = OP_STDOUT;
-			char pcmd[MAX_LINE_LENGTH], *str;
-			if (*Eptr == '&') {
-				op |= OP_STDERR;
-				Eptr++;
-			}
-			i = (op & OP_STDERR) ? 2 : 1;
+            int op = OP_STDOUT;
+            char pcmd[MAX_LINE_LENGTH], *str;
+            if (*Eptr == '&') {
+                op |= OP_STDERR;
+                Eptr++;
+            }
+            i = (op & OP_STDERR) ? 2 : 1;
 
-			/* Skip whitespace */
-			while (isspace(*Eptr)) Eptr++;
+            /* Skip whitespace */
+            while (isspace(*Eptr)) Eptr++;
 
-			/* Get pcmd */
-			str = pcmd;
-			while (*Eptr && *Eptr != cmddel && *Eptr != bufdel) {
-				*str++ = *Eptr++;
-			}
-			*str = '\0';
+            /* Get pcmd */
+            str = pcmd;
+            while (*Eptr && *Eptr != cmddel && *Eptr != bufdel) {
+                *str++ = *Eptr++;
+            }
+            *str = '\0';
 
-			if (!skip) {
+            if (!skip) {
 
-				/* Expand command if sep */
-				if (pcmd[0] == '%') {
-					const char *f, *s;
-					s = pcmd + 1;
-					f = get_sep(&s);
-					strcpy(pcmd, f);
-				}
+                /* Expand command if sep */
+                if (pcmd[0] == '%') {
+                    const char *f, *s;
+                    s = pcmd + 1;
+                    f = get_sep(&s);
+                    strcpy(pcmd, f);
+                }
 
-				/* Open the pipe */
-				if (sdpopen((status & S_EXECUTE) ? &pipe_input
-				                                 : NULL,
-				        &curr_fp[i], pcmd)) {
-					is_pipe[i] = 1;
+                /* Open the pipe */
+                if (sdpopen((status & S_EXECUTE) ? &pipe_input : NULL,
+                        &curr_fp[i], pcmd)) {
+                    is_pipe[i] = 1;
 
-					/* Close the old std file
-					 * descriptor */
-					saved_fd[i] = dup(i);
-					if (debug & DB_PIPE) {
-						std::println(stderr,
-						    "saved fd {} in fd {}",
-						    i, saved_fd[i]);
-						fflush(stderr);
-					}
-					close(i);
+                    /* Close the old std file
+                     * descriptor */
+                    saved_fd[i] = dup(i);
+                    if (debug & DB_PIPE) {
+                        std::println(
+                            stderr, "saved fd {} in fd {}", i, saved_fd[i]);
+                        fflush(stderr);
+                    }
+                    close(i);
 
-					/* Open the new std file
-					 * descriptor (as USER) */
-					dup(fileno(curr_fp[i]));
-					if (debug & DB_PIPE) {
-						std::println(stderr,
-						    "installed fd {} as new fd {}",
-						    fileno(curr_fp[i]), i);
-						fflush(stderr);
-					}
+                    /* Open the new std file
+                     * descriptor (as USER) */
+                    dup(fileno(curr_fp[i]));
+                    if (debug & DB_PIPE) {
+                        std::println(stderr, "installed fd {} as new fd {}",
+                            fileno(curr_fp[i]), i);
+                        fflush(stderr);
+                    }
 
-					/* Push i on the "stack" */
-					push_fd(i);
-					status |= S_REDIRECT;
-				}
-			}
-			Sptr = Eptr;
-			state = 1;
-			break;
-		}
+                    /* Push i on the "stack" */
+                    push_fd(i);
+                    status |= S_REDIRECT;
+                }
+            }
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
 
-		case 8: /* `command` */
-			do {
-				Eptr++;
-			} while (*Eptr && *Eptr != '`');
+        case 8: /* `command` */
+            do {
+                Eptr++;
+            } while (*Eptr && *Eptr != '`');
 
-			if (!skip) {
-				auto old = cmd;
-				cmd = estrndup(cmd, Eptr - Sptr);
-				free(old);
-				if (*Eptr)
-					Eptr++; /* Set Eptr to next char
-					         * after end ` */
+            if (!skip) {
+                auto old = cmd;
+                cmd = estrndup(cmd, Eptr - Sptr);
+                free(old);
+                if (*Eptr)
+                    Eptr++; /* Set Eptr to next char
+                             * after end ` */
 
-				status |= S_EXECUTE;
-				evalbuf[0] = '\0';
-				command(cmd, lvl + 1);
-				status &= ~S_EXECUTE;
-				free(cmd);
-				cmd = NULL;
+                status |= S_EXECUTE;
+                evalbuf[0] = '\0';
+                command(cmd, lvl + 1);
+                status &= ~S_EXECUTE;
+                free(cmd);
+                cmd = NULL;
 
-				/* evalbuf should now contain all the
-				 * output even if obtained via a pipe */
+                /* evalbuf should now contain all the
+                 * output even if obtained via a pipe */
 
-				/* We want to end up with Sptr pointing
-				 * to a buffer which contains the
-				 * output, followed by whatever was left
-				 * in the original buffer.  This way,
-				 * the output will be split into fields
-				 * as well, as sh does */
-				tmpstr = (char *)emalloc(strlen(evalbuf) + strlen(Eptr) + 1);
-				strcpy(tmpstr, evalbuf);
-				strcat(tmpstr, Eptr);
-				free(newstr);
-				Sptr = newstr = tmpstr;
-			} else
-				Sptr = Eptr;
-			state = 1;
-			break;
+                /* We want to end up with Sptr pointing
+                 * to a buffer which contains the
+                 * output, followed by whatever was left
+                 * in the original buffer.  This way,
+                 * the output will be split into fields
+                 * as well, as sh does */
+                tmpstr = (char *)emalloc(strlen(evalbuf) + strlen(Eptr) + 1);
+                strcpy(tmpstr, evalbuf);
+                strcat(tmpstr, Eptr);
+                free(newstr);
+                Sptr = newstr = tmpstr;
+            } else
+                Sptr = Eptr;
+            state = 1;
+            break;
 
-		case 9: /* > file */
-		{       /* Also >>, >&, >>& */
+        case 9: /* > file */
+        {       /* Also >>, >&, >>& */
 #define OP_STDOUT 0x00
 #define OP_STDERR 0x01
 #define OP_APPEND 0x10
-			int op = OP_STDOUT;
-			int fd = 1; /* stdout */
-			std::string filename;
+            int op = OP_STDOUT;
+            int fd = 1; /* stdout */
+            std::string filename;
 
-			/* Get actual operator */
-			if (*Eptr == '>') {
-				op |= OP_APPEND;
-				Eptr++;
-			}
-			if (*Eptr == '&') {
-				op |= OP_STDERR;
-				fd = 2; /* stderr */
-				Eptr++;
-			}
+            /* Get actual operator */
+            if (*Eptr == '>') {
+                op |= OP_APPEND;
+                Eptr++;
+            }
+            if (*Eptr == '&') {
+                op |= OP_STDERR;
+                fd = 2; /* stderr */
+                Eptr++;
+            }
 
-			/* Skip whitespace */
-			while (isspace(*Eptr))
-				Eptr++;
+            /* Skip whitespace */
+            while (isspace(*Eptr)) Eptr++;
 
-			/* Get filename */
-			while (*Eptr != '\0' &&
-			   *Eptr != cmddel &&
-			   *Eptr != bufdel &&
-			   *Eptr != ' ')
-			{
-				filename.push_back(*Eptr++);
-			}
+            /* Get filename */
+            while (*Eptr != '\0' && *Eptr != cmddel && *Eptr != bufdel &&
+                   *Eptr != ' ') {
+                filename.push_back(*Eptr++);
+            }
 
-			if (!skip) {
+            if (!skip) {
 
-				/* Expand filename if sep */
-				if (filename[0] == '%') {
-					const char *s = filename.c_str() + 1;
-					filename = get_sep(&s);
-				}
+                /* Expand filename if sep */
+                if (filename[0] == '%') {
+                    const char *s = filename.c_str() + 1;
+                    filename = get_sep(&s);
+                }
 
-				/* Open the file */
-				curr_fp[fd] = smopenw(filename,
-				    (op & OP_APPEND) ? O_A : O_W);
-				if (!curr_fp[fd]) {
-					error("redirecting output to ", filename);
-				} else {
-					is_pipe[fd] =
-					    0; /* just a normal file */
+                /* Open the file */
+                curr_fp[fd] = smopenw(filename, (op & OP_APPEND) ? O_A : O_W);
+                if (!curr_fp[fd]) {
+                    error("redirecting output to ", filename);
+                } else {
+                    is_pipe[fd] = 0; /* just a normal file */
 
-					/* Close the old std file
-					 * descriptor */
-					saved_fd[fd] = dup(fd);
-					close(fd);
+                    /* Close the old std file
+                     * descriptor */
+                    saved_fd[fd] = dup(fd);
+                    close(fd);
 
-					dup(fileno(curr_fp[fd]));
-					push_fd(fd);
+                    dup(fileno(curr_fp[fd]));
+                    push_fd(fd);
 
-					status |= S_REDIRECT;
-				}
-			}
-			Sptr = Eptr;
-			state = 1;
-			break;
-		}
+                    status |= S_REDIRECT;
+                }
+            }
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
 
-		case 10: /* (stuff) */
-			do {
-				Eptr++;
-			} while (
-			    *Eptr && (*Eptr != ')' || *(Eptr - 1) == '\\'));
-			argv[argc] = estrndup(Sptr, Eptr - Sptr + 1);
-			if (*Eptr)
-				Eptr++;
-			Sptr = Eptr;
-			state = 1;
-			break;
+        case 10: /* (stuff) */
+            do {
+                Eptr++;
+            } while (*Eptr && (*Eptr != ')' || *(Eptr - 1) == '\\'));
+            argv[argc] = estrndup(Sptr, Eptr - Sptr + 1);
+            if (*Eptr)
+                Eptr++;
+            Sptr = Eptr;
+            state = 1;
+            break;
 
-		case 11: /* %separator stuff */
-		{
-			const char *str = get_sep(&Eptr);
+        case 11: /* %separator stuff */
+        {
+            const char *str = get_sep(&Eptr);
 
-			/* only make an arg if * something there */
-			if (str && *str) {
-				argv[argc++] = estrdup(str);
-			}
-			Sptr = Eptr;
-			state = 1;
-			break;
-		}
+            /* only make an arg if * something there */
+            if (str && *str) {
+                argv[argc++] = estrdup(str);
+            }
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
 
-		case 12: /* < file, << word */
-		{
-			std::string filename;
-			std::string word;
+        case 12: /* < file, << word */
+        {
+            std::string filename;
+            std::string word;
 #define OP_FILEIN 0x00
 #define OP_WORDIN 0x01
-			int op = OP_FILEIN;
-			/* Get actual operator */
-			if (*Eptr == '<') {
-				op |= OP_WORDIN;
-				Eptr++;
-			}
+            int op = OP_FILEIN;
+            /* Get actual operator */
+            if (*Eptr == '<') {
+                op |= OP_WORDIN;
+                Eptr++;
+            }
 
-			/* Skip whitespace */
-			while (isspace(*Eptr))
-				Eptr++;
+            /* Skip whitespace */
+            while (isspace(*Eptr)) Eptr++;
 
-			/* Get word */
-			while (*Eptr != '\0' &&
-			    *Eptr != cmddel &&
-			    *Eptr != bufdel &&
-			    *Eptr != ' ')
-			{
-				word.push_back(*Eptr++);
-			}
+            /* Get word */
+            while (*Eptr != '\0' && *Eptr != cmddel && *Eptr != bufdel &&
+                   *Eptr != ' ') {
+                word.push_back(*Eptr++);
+            }
 
-			if (op & OP_WORDIN) { /* << word */
-				char *buff = NULL;
-				/* Save lines in a temp file until we
-				 * see word or EOF */
-				wordfile = std::format("/tmp/word.{}", getpid());
-				FILE *fp = smopenw(wordfile, O_W);
-				while ((buff = xgets(st_glob.inp,
-				            stdin_stack_top)) != NULL) {
-					if (str::eq(buff, word))
-						break;
-					std::println(fp, "{}", buff);
-					free(buff);
-					buff = NULL;
-				}
-				if (buff)
-					free(buff);
-				smclose(fp);
+            if (op & OP_WORDIN) { /* << word */
+                char *buff = NULL;
+                /* Save lines in a temp file until we
+                 * see word or EOF */
+                wordfile = std::format("/tmp/word.{}", getpid());
+                FILE *fp = smopenw(wordfile, O_W);
+                while ((buff = xgets(st_glob.inp, stdin_stack_top)) != NULL) {
+                    if (str::eq(buff, word))
+                        break;
+                    std::println(fp, "{}", buff);
+                    free(buff);
+                    buff = NULL;
+                }
+                if (buff)
+                    free(buff);
+                smclose(fp);
 
-				filename = wordfile;
-			} else { /* < file */
-				filename = word;
+                filename = wordfile;
+            } else { /* < file */
+                filename = word;
 
-				/* Expand filename if sep */
-				if (filename[0] == '%') {
-					const char *f, *str;
-					str = filename.c_str() + 1;
-					f = get_sep(&str);
-					filename = f;
-				}
-			}
+                /* Expand filename if sep */
+                if (filename[0] == '%') {
+                    const char *f, *str;
+                    str = filename.c_str() + 1;
+                    f = get_sep(&str);
+                    filename = f;
+                }
+            }
 
-			if (!skip) {
+            if (!skip) {
 
-				/* Open the file */
-				curr_fp[0] = smopenr(filename, O_R);
-				if (!curr_fp[0])
-					std::println("smopenr returned null");
-				is_pipe[0] = 0;
+                /* Open the file */
+                curr_fp[0] = smopenr(filename, O_R);
+                if (!curr_fp[0])
+                    std::println("smopenr returned null");
+                is_pipe[0] = 0;
 
-				if (debug & DB_IOREDIR)
-					std::println("Redirecting input from {} (fd {})",
-					    filename, fileno(curr_fp[0]));
-				push_stdin(curr_fp[0], STD_FILE);
+                if (debug & DB_IOREDIR)
+                    std::println("Redirecting input from {} (fd {})", filename,
+                        fileno(curr_fp[0]));
+                push_stdin(curr_fp[0], STD_FILE);
 
+                /* We don't want to set S_REDIRECT
+                 * here since we want the pager to be
+                 * used when we're only redirecting
+                 * input. This is used by (for
+                 * example) the change htmlheader
+                 * script to filter HTML text from
+                 * within a template. */
+                status |= S_NOSTDIN;
+            }
+            Sptr = Eptr;
+            state = 1;
+            break;
+        }
+        }
+    }
+    if (argc && !skip) {
+        /* Execute command */
+        switch (mode) {
+        case M_OK:
+            ok = ok_cmd_dispatch(argc, argv);
+            break;
+        case M_JOQ:
+            ok = joq_cmd_dispatch(argc, argv);
+            break;
+        case M_TEXT:
+            ok = text_cmd_dispatch(argc, argv);
+            break;
+        case M_RFP:
+            ok = rfp_cmd_dispatch(argc, argv);
+            break;
+        case M_EDB:
+            ok = edb_cmd_dispatch(argc, argv);
+            break;
+        default:
+            std::println("Unknown mode {}\n", mode);
+            break;
+        }
 
-				/* We don't want to set S_REDIRECT
-				 * here since we want the pager to be
-				 * used when we're only redirecting
-				 * input. This is used by (for
-				 * example) the change htmlheader
-				 * script to filter HTML text from
-				 * within a template. */
-				status |= S_NOSTDIN;
-			}
-			Sptr = Eptr;
-			state = 1;
-			break;
-		}
-		}
-	}
-	if (argc && !skip) {
-		/* Execute command */
-		switch (mode) {
-		case M_OK:
-			ok = ok_cmd_dispatch(argc, argv);
-			break;
-		case M_JOQ:
-			ok = joq_cmd_dispatch(argc, argv);
-			break;
-		case M_TEXT:
-			ok = text_cmd_dispatch(argc, argv);
-			break;
-		case M_RFP:
-			ok = rfp_cmd_dispatch(argc, argv);
-			break;
-		case M_EDB:
-			ok = edb_cmd_dispatch(argc, argv);
-			break;
-		default:
-			std::println("Unknown mode {}\n", mode);
-			break;
-		}
+    } else
+        ok = 1; /* don't abort on null command */
 
-	} else
-		ok = 1; /* don't abort on null command */
+    /* Free args */
+    for (i = 0; i < argc; i++) free(argv[i]);
 
-	/* Free args */
-	for (i = 0; i < argc; i++)
-		free(argv[i]);
+    /* Now restore original file descriptor state */
+    while (fd_top > prev_top) {
+        i = pop_fd();
+        close(i);
 
-	/* Now restore original file descriptor state */
-	while (fd_top > prev_top) {
-		i = pop_fd();
-		close(i);
+        /* Remove temporary file for "<< word" syntax */
+        if (!i && !wordfile.empty()) {
+            rm(wordfile, SL_USER);
+            wordfile.clear();
+        }
+        if (is_pipe[i]) {
+            sdpclose(pipe_input, curr_fp[i]);
+            pipe_input = NULL;
+        } else
+            smclose(curr_fp[i]);
 
-		/* Remove temporary file for "<< word" syntax */
-		if (!i && !wordfile.empty()) {
-			rm(wordfile, SL_USER);
-			wordfile.clear();
-		}
-		if (is_pipe[i]) {
-			sdpclose(pipe_input, curr_fp[i]);
-			pipe_input = NULL;
-		} else
-			smclose(curr_fp[i]);
+        /* Restore saved file descriptor */
+        dup(saved_fd[i]);
+        close(saved_fd[i]);
+        if (debug & DB_PIPE) {
+            std::println(stderr, "Restored fd {} to fd {}", saved_fd[i], i);
+            fflush(stderr);
+        }
 
-		/* Restore saved file descriptor */
-		dup(saved_fd[i]);
-		close(saved_fd[i]);
-		if (debug & DB_PIPE) {
-			std::println(stderr, "Restored fd {} to fd {}", saved_fd[i], i);
-			fflush(stderr);
-		}
+        /* Clear saved info */
+        saved_fd[i] = -1;
+        is_pipe[i] = 0;
+    }
+    if (!prev_redir)
+        status &= ~S_REDIRECT;
+    if (!prev_nostdin)
+        status &= ~S_NOSTDIN;
 
-		/* Clear saved info */
-		saved_fd[i] = -1;
-		is_pipe[i] = 0;
-	}
-	if (!prev_redir)
-		status &= ~S_REDIRECT;
-	if (!prev_nostdin)
-		status &= ~S_NOSTDIN;
-
-	/* Do next ; cmd unless EOF or command says to halt (ok==2) */
-	if (ok == 1 && *Sptr && !(status & S_STOP)) {
-		/* 2/2/96: this was lvl+1 below, but it broke 'if' nesting
-		 * since commands after the ';' appeared to be a level deeper,
-		 * so 'else' and 'endif' couldn't appear after a ';' */
-		ok = command(Sptr, lvl);
-	}
-	free(newstr);
-	free(cmd);
-	return ok;
+    /* Do next ; cmd unless EOF or command says to halt (ok==2) */
+    if (ok == 1 && *Sptr && !(status & S_STOP)) {
+        /* 2/2/96: this was lvl+1 below, but it broke 'if' nesting
+         * since commands after the ';' appeared to be a level deeper,
+         * so 'else' and 'endif' couldn't appear after a ';' */
+        ok = command(Sptr, lvl);
+    }
+    free(newstr);
+    free(cmd);
+    return ok;
 }
 
 /* Commands available at the Ok: prompt only */
 static dispatch_t ok_cmd[] = {
-    { "i_tem", do_read, },
-    { "r_ead", do_read, },
-    { "pr_int", do_read, },
-    { "e_nter", enter, },
-    { "s_can", do_read, },
-    { "b_rowse", do_read, },
+    {"i_tem", do_read},
+    {"r_ead", do_read},
+    {"pr_int", do_read},
+    {"e_nter", enter},
+    {"s_can", do_read},
+    {"b_rowse", do_read},
     /* j_oin */
-    { "le_ave", leave, },
-    { "n_ext", do_next, },
-    { "che_ck", check, },
-    { "rem_ember", remember, },
-    { "forget", forget, },
-    { "unfor_get", remember, },
-    { "k_ill", do_kill, },
-    { "retitle", retitle, },
-    { "freeze", freeze, },
-    { "thaw", freeze, },
+    {"le_ave", leave},
+    {"n_ext", do_next},
+    {"che_ck", check},
+    {"rem_ember", remember},
+    {"forget", forget},
+    {"unfor_get", remember},
+    {"k_ill", do_kill},
+    {"retitle", retitle},
+    {"freeze", freeze},
+    {"thaw", freeze},
     /* sync_hronous */
     /* async_hronous */
-    { "retire", freeze, },
-    { "unretire", freeze, },
-    { "f_ind", do_find, },
-    { "l_ocate", do_find, },
-    { "seen", fixseen, },
-    { "fix_seen", fixseen, },
-    { "fixto", fixto, },
-    { "re_spond", respond, },
+    {"retire", freeze},
+    {
+     "unretire", freeze,
+     },
+    {"f_ind", do_find},
+    {"l_ocate", do_find},
+    {"seen", fixseen},
+    {"fix_seen", fixseen},
+    {"fixto", fixto},
+    {"re_spond", respond},
     /* lpr_int */
-    { "li_nkfrom", linkfrom, },
-    { "abort", leave, },
+    {"li_nkfrom", linkfrom},
+    {"abort", leave},
     /* ex_it q_uit st_op good_bye log_off log_out h_elp exp_lain sy_stem unix
      * al_ias def_ine una_lias und_efine ec_ho echoe echon echoen echone so_urce
      * m_ail t_ransmit sen_dmail chat write d_isplay que_ry */
-    { "p_articipants", participants, },
-    { "desc_ribe", describe, },
+    {"p_articipants", participants},
+    {"desc_ribe", describe},
     /* w_hoison am_superuser */
-    { "resign", resign, },
+    {"resign", resign},
     /* chd_ir uma_sk sh_ell f_iles dir_ectory ty_pe e_dit cdate da_te t_est
      * clu_ster
      */
-    { "ps_eudonym", respond, },
-    { "list", check, },
-    { "index", show_conf_index, },
+    {"ps_eudonym", respond},
+    {"list", check},
+    {"index", show_conf_index},
 #ifdef WWW
 #ifdef INCLUDE_EXTRA_COMMANDS
-    { "authenticate", authenticate, },
+    {"authenticate", authenticate},
 #endif
 #endif
-    { "cfcreate", cfcreate, },
-    { "cfdelete", cfdelete, },
-    { 0, 0 },
+    {"cfcreate", cfcreate},
+    {"cfdelete", cfdelete},
+    {0, 0},
 };
 /******************************************************************************/
 /* DISPATCH CONTROL TO APPROPRIATE MISC. COMMAND FUNCTION                     */
@@ -1464,23 +1442,22 @@ ok_cmd_dispatch(/* ARGUMENTS:                 */
     char **argv /* Argument list           */
 )
 {
-	int i;
-	for (i = 0; ok_cmd[i].name; i++)
-		if (match(argv[0], ok_cmd[i].name))
-			return ok_cmd[i].func(argc, argv);
+    int i;
+    for (i = 0; ok_cmd[i].name; i++)
+        if (match(argv[0], ok_cmd[i].name))
+            return ok_cmd[i].func(argc, argv);
 
-	/* Command dispatch */
-	if (match(argv[0], "j_oin")) {
-		if (argc == 2)
-			join(argv[1], 0, 0);
-		else if (confidx >= 0) {
-			confsep(expand("joinmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		} else
-			std::println("Not in a {}!", conference());
-	} else
-		return misc_cmd_dispatch(argc, argv);
-	return 1;
+    /* Command dispatch */
+    if (match(argv[0], "j_oin")) {
+        if (argc == 2)
+            join(argv[1], 0, 0);
+        else if (confidx >= 0) {
+            confsep(expand("joinmsg", DM_VAR), confidx, &st_glob, part, 0);
+        } else
+            std::println("Not in a {}!", conference());
+    } else
+        return misc_cmd_dispatch(argc, argv);
+    return 1;
 }
 /******************************************************************************/
 /* PROCESS A GENERIC SIGNAL (if enabled)                                      */
@@ -1488,11 +1465,11 @@ ok_cmd_dispatch(/* ARGUMENTS:                 */
 void
 handle_other(int sig)
 {
-	if (status & S_PIPE)
-		std::println("{} Pipe interrupt {}!", getpid(), sig);
-	else
-		std::println("{} Interrupt {}!", getpid(), sig);
-	status |= S_INT;
+    if (status & S_PIPE)
+        std::println("{} Pipe interrupt {}!", getpid(), sig);
+    else
+        std::println("{} Interrupt {}!", getpid(), sig);
+    status |= S_INT;
 }
 /******************************************************************************/
 /* PROCESS A USER INTERRUPT SIGNAL                                            */
@@ -1500,12 +1477,12 @@ handle_other(int sig)
 void
 handle_int(int sig) /* ARGUMENTS: (none)  */
 {
-	(void)sig;
-	if (!(status & S_PIPE)) {
-		std::println("Interrupt!");
-		status |= S_INT;
-	}
-	signal(SIGINT, handle_int);
+    (void)sig;
+    if (!(status & S_PIPE)) {
+        std::println("Interrupt!");
+        status |= S_INT;
+    }
+    signal(SIGINT, handle_int);
 }
 /******************************************************************************/
 /* PROCESS AN INTERRUPT CAUSED BY A PIPE ABORTING                             */
@@ -1513,9 +1490,9 @@ handle_int(int sig) /* ARGUMENTS: (none)  */
 void
 handle_pipe(int sig)
 {
-	(void)sig;
-	if (status & S_PAGER)
-		std::println("Pipe interrupt?\n");
-	signal(SIGPIPE, handle_pipe);
-	status |= S_INT;
+    (void)sig;
+    if (status & S_PAGER)
+        std::println("Pipe interrupt?\n");
+    signal(SIGPIPE, handle_pipe);
+    status |= S_INT;
 }

--- a/edbuf.cc
+++ b/edbuf.cc
@@ -45,103 +45,103 @@ cfbufr_open(/* ARGUMENTS: */
     int flg /* File open type (r,w, etc) */
 )
 {
-	const auto path = str::concat({work, "/cf.buffer"});
-	if ((file = smopenw(path.c_str(), flg)) == NULL)
-		return 0;
-	if (!(flags & O_QUIET))
-		std::println(R"(Type "." to exit or ":help".)");
-	return 1;
+    const auto path = str::concat({work, "/cf.buffer"});
+    if ((file = smopenw(path.c_str(), flg)) == NULL)
+        return 0;
+    if (!(flags & O_QUIET))
+        std::println(R"(Type "." to exit or ":help".)");
+    return 1;
 }
 /******************************************************************************/
 char
-text_loop(		// ARGUMENTS: (none)
-    bool is_new,	// True if we should start from scratch, false
-			// if modifying
-    const char *label	// What to ask for ("text", "response", etc)
+text_loop(            // ARGUMENTS: (none)
+    bool is_new,      // True if we should start from scratch, false
+                      // if modifying
+    const char *label // What to ask for ("text", "response", etc)
 )
 {
-	bool ok = true;
+    bool ok = true;
 
-	if (flags & O_EDALWAYS)
-		return edit(work, "cf.buffer", 0);
+    if (flags & O_EDALWAYS)
+        return edit(work, "cf.buffer", 0);
 
-	post = 0;
+    post = 0;
 
-	if (is_new) {
-		struct stat st{};
-		const auto fromname = str::concat({work, "/cf.buffer"});
-		if (stat(fromname.c_str(), &st) == 0) { /* cf.buffer exists */
-			const auto toname = std::format("{}/cbf.{}", work, getpid());
-			if (copy_file(fromname, toname, SL_USER))
-				error("renaming cf.buffer to ", toname);
-		}
-	}
-	if (!cfbufr_open(is_new ? O_WPLUS : O_APLUS))
-		return 0; /* "w+" */
-	if (!(flags & O_QUIET)) {
-		if (is_new) {
-			text_print(0, NULL);
-			std::println("Enter {}:", label);
-		} else {
-			std::println("(Continue your {} entry)", label);
-		}
-	}
-	oldmode = mode;
-	mode = M_TEXT;
-	while (mode == M_TEXT && ok) {
-		/* For optimization purposes, we do not allow seps in TEXT
-		 * mode prompt.  This could be changed back if confsep would
-		 * dump out most strings quickly without accessing the disk. */
-		if (!(flags & O_QUIET))
-			wputs(TEXT);
+    if (is_new) {
+        struct stat st{};
+        const auto fromname = str::concat({work, "/cf.buffer"});
+        if (stat(fromname.c_str(), &st) == 0) { /* cf.buffer exists */
+            const auto toname = std::format("{}/cbf.{}", work, getpid());
+            if (copy_file(fromname, toname, SL_USER))
+                error("renaming cf.buffer to ", toname);
+        }
+    }
+    if (!cfbufr_open(is_new ? O_WPLUS : O_APLUS))
+        return 0; /* "w+" */
+    if (!(flags & O_QUIET)) {
+        if (is_new) {
+            text_print(0, NULL);
+            std::println("Enter {}:", label);
+        } else {
+            std::println("(Continue your {} entry)", label);
+        }
+    }
+    oldmode = mode;
+    mode = M_TEXT;
+    while (mode == M_TEXT && ok) {
+        /* For optimization purposes, we do not allow seps in TEXT
+         * mode prompt.  This could be changed back if confsep would
+         * dump out most strings quickly without accessing the disk. */
+        if (!(flags & O_QUIET))
+            wputs(TEXT);
 
-		std::string line;
-		ok = ngets(line, st_glob.inp);
-		if (ok && (status & S_INT)) {
-			status &= ~S_INT; /* Clear interrupt */
-			ok = !get_yes(std::format("Abort {}? ", label), true);
-			if (!ok)
-				post = -1;
-		}
+        std::string line;
+        ok = ngets(line, st_glob.inp);
+        if (ok && (status & S_INT)) {
+            status &= ~S_INT; /* Clear interrupt */
+            ok = !get_yes(std::format("Abort {}? ", label), true);
+            if (!ok)
+                post = -1;
+        }
 
-		if (!ok) {
-			std::println("");
-			mode = oldmode; /* Ctrl-D same as "." */
-			post++;         /* post on ^D or .  don't post on ^C */
-		} else if (!line.empty() && line[0] == ':') {
-			if (line.size() > 1)
-				ok = command(line.c_str() + 1, 0);
-			else
-				ok = command("e", 0);
-		} else if ((flags & O_DOT) && str::eq(line, ".")) {
-			mode = oldmode; /* done */
-			post = 1;
-		} else { /* Add to file buffer */
-			std::println(file, "{}", line);
-			if (ferror(stdout))
-				ok = 0;
-			else
-				fflush(file);
-		}
-	}
-	smclose(file);
-	return post;
+        if (!ok) {
+            std::println("");
+            mode = oldmode; /* Ctrl-D same as "." */
+            post++;         /* post on ^D or .  don't post on ^C */
+        } else if (!line.empty() && line[0] == ':') {
+            if (line.size() > 1)
+                ok = command(line.c_str() + 1, 0);
+            else
+                ok = command("e", 0);
+        } else if ((flags & O_DOT) && str::eq(line, ".")) {
+            mode = oldmode; /* done */
+            post = 1;
+        } else { /* Add to file buffer */
+            std::println(file, "{}", line);
+            if (ferror(stdout))
+                ok = 0;
+            else
+                fflush(file);
+        }
+    }
+    smclose(file);
+    return post;
 }
 /* Commands available while in text entry mode */
 static dispatch_t text_cmd[] = {
-    { "q_uit", text_abort, },
-    { "c_ommand", text_done, },
-    { "ok", text_done, },
-    { "p_rint", text_print, },
-    { "e_dit", text_edit, },
-    { "v_isual", text_edit, },
-    { "h_elp", help, },
-    { "?", help, },
-    { "cl_ear", text_clear, },
-    { "em_pty", text_clear, },
-    { "r_ead", text_read, },
-    { "w_rite", text_write, },
-    { 0, 0 },
+    {"q_uit",    text_abort},
+    {"c_ommand", text_done },
+    {"ok",       text_done },
+    {"p_rint",   text_print},
+    {"e_dit",    text_edit },
+    {"v_isual",  text_edit },
+    {"h_elp",    help      },
+    {"?",        help      },
+    {"cl_ear",   text_clear},
+    {"em_pty",   text_clear},
+    {"r_ead",    text_read },
+    {"w_rite",   text_write},
+    {0,          0         },
 };
 /******************************************************************************/
 /* DISPATCH CONTROL TO APPROPRIATE TEXT COMMAND FUNCTION                      */
@@ -152,22 +152,22 @@ text_cmd_dispatch(/* ARGUMENTS:                  */
     char **argv   /* Argument list            */
 )
 {
-	int i;
-	for (i = 0; text_cmd[i].name; i++)
-		if (match(argv[0], text_cmd[i].name))
-			return text_cmd[i].func(argc, argv);
+    int i;
+    for (i = 0; text_cmd[i].name; i++)
+        if (match(argv[0], text_cmd[i].name))
+            return text_cmd[i].func(argc, argv);
 
-	/* Command dispatch */
-	if (match(argv[0], "d_one")       /* same as . on a new line */
-	    || match(argv[0], "st_op")    /* ? */
-	    || match(argv[0], "ex_it")) { /* ? */
-		mode = oldmode;
-		post = 1; /* mark as done */
-	} else {
-		std::println("Don't understand that!\n");
-		text_abort(argc, argv);
-	}
-	return 1;
+    /* Command dispatch */
+    if (match(argv[0], "d_one")       /* same as . on a new line */
+        || match(argv[0], "st_op")    /* ? */
+        || match(argv[0], "ex_it")) { /* ? */
+        mode = oldmode;
+        post = 1; /* mark as done */
+    } else {
+        std::println("Don't understand that!\n");
+        text_abort(argc, argv);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* READ TEXT FROM A FILE INTO THE BUFFER                                      */
@@ -178,25 +178,24 @@ text_read(      /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	/* PicoSpan puts spaces into the filename, we don't */
-	if (argc != 2) {
-		std::println("Syntax: r filename");
-		return 1;
-	}
+    /* PicoSpan puts spaces into the filename, we don't */
+    if (argc != 2) {
+        std::println("Syntax: r filename");
+        return 1;
+    }
 
-	/* This is done inside the secure portion writing to the cf.buffer
-	 * file, so it's already secure */
-	if ((flags & O_QUIET) == 0)
-		std::println("Reading {}", argv[1]);
-	FILE *fp = mopen(argv[1], O_R);
-	if (fp == NULL)
-		return 1;
-	std::string line;
-	while (ngets(line, fp))
-		std::println(file, "{}", line);
-	mclose(fp);
+    /* This is done inside the secure portion writing to the cf.buffer
+     * file, so it's already secure */
+    if ((flags & O_QUIET) == 0)
+        std::println("Reading {}", argv[1]);
+    FILE *fp = mopen(argv[1], O_R);
+    if (fp == NULL)
+        return 1;
+    std::string line;
+    while (ngets(line, fp)) std::println(file, "{}", line);
+    mclose(fp);
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* WRITE TEXT IN BUFFER OUT TO A FILE                                         */
@@ -207,36 +206,35 @@ text_write(     /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	FILE *fp;
+    FILE *fp;
 
-	/* PicoSpan puts spaces into the filename, we don't */
-	if (argc != 2) {
-		std::println("Syntax: w filename");
-		return 1;
-	}
+    /* PicoSpan puts spaces into the filename, we don't */
+    if (argc != 2) {
+        std::println("Syntax: w filename");
+        return 1;
+    }
 
-	/* This is done inside the secure portion writing to the cf.buffer
-	 * file, so is already secure */
-	std::println("Writing {}", argv[1]);
-	if ((fp = mopen(argv[1], O_W)) == NULL) { /* use normal umask */
-		return 1;
-	}
+    /* This is done inside the secure portion writing to the cf.buffer
+     * file, so is already secure */
+    std::println("Writing {}", argv[1]);
+    if ((fp = mopen(argv[1], O_W)) == NULL) { /* use normal umask */
+        return 1;
+    }
 
-	smclose(file);
-	const auto filename = str::concat({work, "/cf.buffer"});
-	if ((file = smopenr(filename, O_R)) == NULL)
-		return 0;
+    smclose(file);
+    const auto filename = str::concat({work, "/cf.buffer"});
+    if ((file = smopenr(filename, O_R)) == NULL)
+        return 0;
 
-	std::string buff;
-	while (ngets(buff, file))
-		std::println(fp, "{}", buff);
-	mclose(fp);
+    std::string buff;
+    while (ngets(buff, file)) std::println(fp, "{}", buff);
+    mclose(fp);
 
-	smclose(file);
-	if ((file = smopenw(filename, O_APLUS)) == NULL)
-		return 0;
+    smclose(file);
+    if ((file = smopenw(filename, O_APLUS)) == NULL)
+        return 0;
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* DUMP TEXT IN BUFFER AND START OVER                                         */
@@ -247,15 +245,14 @@ text_clear(     /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	mclose(file);
-	if (!(flags & O_QUIET))
-		std::println("Enter your {}:",
-		    (oldmode == M_OK) ? "text" : "response");
-	if (!cfbufr_open(O_WPLUS)) /* "w+" */
-		mode = oldmode;    /* abort */
-	else
-		mode = M_TEXT;
-	return 1;
+    mclose(file);
+    if (!(flags & O_QUIET))
+        std::println("Enter your {}:", (oldmode == M_OK) ? "text" : "response");
+    if (!cfbufr_open(O_WPLUS)) /* "w+" */
+        mode = oldmode;        /* abort */
+    else
+        mode = M_TEXT;
+    return 1;
 }
 /******************************************************************************/
 /* REPRINT CURRENT CONTENTS OF BUFFER                                         */
@@ -266,24 +263,24 @@ text_print(     /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	/* XXX */
-	smclose(file);
+    /* XXX */
+    smclose(file);
 
-	const auto filename = str::concat({work, "/cf.buffer"});
-	if ((file = smopenr(filename, O_R)) == NULL)
-		return 0;
+    const auto filename = str::concat({work, "/cf.buffer"});
+    if ((file = smopenr(filename, O_R)) == NULL)
+        return 0;
 
-	/*
-	   fseek(file,0L,0);
-	*/
-	std::string buff;
-	while (ngets(buff, file) && (status & S_INT) == 0)
-		std::println(" {}", buff);
-	smclose(file);
+    /*
+       fseek(file,0L,0);
+    */
+    std::string buff;
+    while (ngets(buff, file) && (status & S_INT) == 0)
+        std::println(" {}", buff);
+    smclose(file);
 
-	if ((file = smopenw(filename, O_APLUS)) == NULL)
-		return 0;
-	return 1;
+    if ((file = smopenw(filename, O_APLUS)) == NULL)
+        return 0;
+    return 1;
 }
 /******************************************************************************/
 /* INVOKE UNIX EDITOR ON THE BUFFER                                           */
@@ -294,19 +291,18 @@ text_edit(      /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	int visual = (argv[0][0] == 'v'); /* 'v_isual' check */
-	if (mode == M_TEXT &&
-	    str::eq(expand((visual) ? "visual" : "editor", DM_VAR), "builtin")) {
-		if (!(flags & O_QUIET))
-			std::println("Already in builtin editor.");
-	} else {
-		mclose(file);
-		edit(work, "cf.buffer", visual);
-		std::println("(Continue your {} entry)",
-		    (resp) ? "response" : "text");
-		cfbufr_open(O_APLUS); /* a+ */
-	}
-	return 1;
+    int visual = (argv[0][0] == 'v'); /* 'v_isual' check */
+    if (mode == M_TEXT &&
+        str::eq(expand((visual) ? "visual" : "editor", DM_VAR), "builtin")) {
+        if (!(flags & O_QUIET))
+            std::println("Already in builtin editor.");
+    } else {
+        mclose(file);
+        edit(work, "cf.buffer", visual);
+        std::println("(Continue your {} entry)", (resp) ? "response" : "text");
+        cfbufr_open(O_APLUS); /* a+ */
+    }
+    return 1;
 }
 /******************************************************************************/
 /* ABORT TEXT ENTRY MODE                                                      */
@@ -317,9 +313,9 @@ text_abort(     /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	if (get_yes("Ok to abandon text? ", true))
-		mode = oldmode;
-	return 1;
+    if (get_yes("Ok to abandon text? ", true))
+        mode = oldmode;
+    return 1;
 }
 /******************************************************************************/
 /* END TEXT ENTRY MODE AND POST IT                                            */
@@ -330,11 +326,10 @@ text_done(      /* ARGUMENTS:          */
     char **argv /* Argument list       */
 )
 {
-	/* Main EDB cmd loop */
-	mode = M_EDB;
-	while (mode == M_EDB && get_command("", 0))
-		;
-	return 1;
+    /* Main EDB cmd loop */
+    mode = M_EDB;
+    while (mode == M_EDB && get_command("", 0));
+    return 1;
 }
 /******************************************************************************/
 /* FIGURE OUT WHAT TO DO WHEN ESCAPING OUT OF TEXT MODE                       */
@@ -345,27 +340,27 @@ edb_cmd_dispatch(/* ARGUMENTS:          */
     char **argv  /* Argument list       */
 )
 {
-	/* Command dispatch */
-	if (match(argv[0], "n_on") || match(argv[0], "nop_e")) {
-		/* std::println("Response aborted!  Returning to current {}.",
-		 * topic()); */
-		mode = oldmode;
-	} else if (match(argv[0], "y_es") || match(argv[0], "ok")) {
-		post = 1;
-		mode = oldmode;
-	} else if (match(argv[0], "ed_it"))
-		text_edit(argc, argv);
-	else if (match(argv[0], "ag_ain") || match(argv[0], "c_ontinue")) {
-		mode = M_TEXT;
-		if (!(flags & O_QUIET)) {
-			std::println("(Continue your text entry)");
-			std::println(R"(Type "." to exit or ":help".)");
-		}
-	} else if (match(argv[0], "pr_int"))
-		text_print(argc, argv);
-	else if (match(argv[0], "em_pty") || match(argv[0], "cl_ear"))
-		text_clear(argc, argv);
-	else
-		return misc_cmd_dispatch(argc, argv);
-	return 1;
+    /* Command dispatch */
+    if (match(argv[0], "n_on") || match(argv[0], "nop_e")) {
+        /* std::println("Response aborted!  Returning to current {}.",
+         * topic()); */
+        mode = oldmode;
+    } else if (match(argv[0], "y_es") || match(argv[0], "ok")) {
+        post = 1;
+        mode = oldmode;
+    } else if (match(argv[0], "ed_it"))
+        text_edit(argc, argv);
+    else if (match(argv[0], "ag_ain") || match(argv[0], "c_ontinue")) {
+        mode = M_TEXT;
+        if (!(flags & O_QUIET)) {
+            std::println("(Continue your text entry)");
+            std::println(R"(Type "." to exit or ":help".)");
+        }
+    } else if (match(argv[0], "pr_int"))
+        text_print(argc, argv);
+    else if (match(argv[0], "em_pty") || match(argv[0], "cl_ear"))
+        text_clear(argc, argv);
+    else
+        return misc_cmd_dispatch(argc, argv);
+    return 1;
 }

--- a/edit.cc
+++ b/edit.cc
@@ -75,38 +75,37 @@
 char *
 spaces(int n)
 {
-	static char spc[MAX_LINE_LENGTH], init = 0;
-	if (!init) {
-		memset(spc, ' ', sizeof(spc) - 1);
-		spc[sizeof(spc) - 1] = '\0';
-		init = 1;
-	}
-	return (n >= 0) ? spc + sizeof(spc) - 1 - n : spc + sizeof(spc) - 1;
+    static char spc[MAX_LINE_LENGTH], init = 0;
+    if (!init) {
+        memset(spc, ' ', sizeof(spc) - 1);
+        spc[sizeof(spc) - 1] = '\0';
+        init = 1;
+    }
+    return (n >= 0) ? spc + sizeof(spc) - 1 - n : spc + sizeof(spc) - 1;
 }
 
-namespace {
+namespace
+{
 int
-dump_file(
-    const std::string &dir,	 /* IN: Directory to put file in    */
-    const std::string &filename, /* IN: Filename to write text into */
-    const std::vector<std::string> &text,     		 /* IN: Text to write out           */
-    int mod          		 /* IN: File open mode              */
+dump_file(const std::string &dir,         /* IN: Directory to put file in    */
+    const std::string &filename,          /* IN: Filename to write text into */
+    const std::vector<std::string> &text, /* IN: Text to write out           */
+    int mod                               /* IN: File open mode              */
 )
 {
-	std::string path(dir);
-	if (!filename.empty()) {
-		path.append("/");
-		path.append(filename);
-	}
-	FILE *fp = mopen(path, mod);
-	if (fp == NULL)
-		return 0;
-	for (const auto &line : text)
-		std::println(fp, "{}", line);
-	mclose(fp);
-	return 1;
+    std::string path(dir);
+    if (!filename.empty()) {
+        path.append("/");
+        path.append(filename);
+    }
+    FILE *fp = mopen(path, mod);
+    if (fp == NULL)
+        return 0;
+    for (const auto &line : text) std::println(fp, "{}", line);
+    mclose(fp);
+    return 1;
 }
-}
+} // namespace
 /*
  * Change subject of st_glob.i_current item in confidx conference
  * We ONLY allow this if the offsets don't change (i.e., new subject fits
@@ -116,102 +115,103 @@ dump_file(
 int
 retitle(int argc, char **argv)
 {
-	char act[MAX_ITEMS];
+    char act[MAX_ITEMS];
 
-	rangeinit(&st_glob, act);
+    rangeinit(&st_glob, act);
 
-	if (argc < 2) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
-		if (!act[j - 1] || !sum[j - 1].flags)
-			continue;
+    /* Process items */
+    for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
+        j++) {
+        if (!act[j - 1] || !sum[j - 1].flags)
+            continue;
 
-		/* Check for permission */
-		if (!(st_glob.c_status & CS_FW) && !is_enterer(j)) {
-			std::println("You can't do that!");
-			continue;
-		}
-		if (!(flags & O_QUIET)) {
-			std::println("Old subject was:\n> {}",
-			    get_subj(confidx, j - 1, sum));
-			std::println("Enter new {} or return to keep old", subject());
-			std::print("? ");
-			std::fflush(stdout);
-		}
-		std::string sub;
-		ngets(sub, st_glob.inp); /* st_glob.inp */
-		if (sub.empty())
-			return 1; /* keep old */
+        /* Check for permission */
+        if (!(st_glob.c_status & CS_FW) && !is_enterer(j)) {
+            std::println("You can't do that!");
+            continue;
+        }
+        if (!(flags & O_QUIET)) {
+            std::println(
+                "Old subject was:\n> {}", get_subj(confidx, j - 1, sum));
+            std::println("Enter new {} or return to keep old", subject());
+            std::print("? ");
+            std::fflush(stdout);
+        }
+        std::string sub;
+        ngets(sub, st_glob.inp); /* st_glob.inp */
+        if (sub.empty())
+            return 1; /* keep old */
 
-		/* Expand seps in subject IF first character is % */
-		if (sub[0] == '%') {
-			const char *str, *f;
-			str = sub.c_str() + 1;
-			f = get_sep(&str);
-			sub = f;
-		}
+        /* Expand seps in subject IF first character is % */
+        if (sub[0] == '%') {
+            const char *str, *f;
+            str = sub.c_str() + 1;
+            f = get_sep(&str);
+            sub = f;
+        }
 
-		/* Determine length of old subject */
-		const auto itemfile = std::format("{}/_{}", conflist[confidx].location, j);
-		const auto header = grab_file(itemfile, "", GF_HEADER);
-		if (header.size() < 2)
-			continue;
-		/* Do some error checking, should never happen */
-		auto len = header[1].size() - 2;
-		if (len > MAX_LINE_LENGTH) {
-			error("subject too long in ", itemfile);
-			return 1;
-		}
+        /* Determine length of old subject */
+        const auto itemfile =
+            std::format("{}/_{}", conflist[confidx].location, j);
+        const auto header = grab_file(itemfile, "", GF_HEADER);
+        if (header.size() < 2)
+            continue;
+        /* Do some error checking, should never happen */
+        auto len = header[1].size() - 2;
+        if (len > MAX_LINE_LENGTH) {
+            error("subject too long in ", itemfile);
+            return 1;
+        }
 
-		/* Truncate if necessary */
-		if (sub.size() > len) {
-			sub.erase(len);
-			if (!(flags & O_QUIET))
-				std::print("Truncated subject to: {}", sub);
-		}
+        /* Truncate if necessary */
+        if (sub.size() > len) {
+            sub.erase(len);
+            if (!(flags & O_QUIET))
+                std::print("Truncated subject to: {}", sub);
+        }
 
-		/* Store in memory */
-		store_subj(confidx, j - 1, sub);
+        /* Store in memory */
+        store_subj(confidx, j - 1, sub);
 
-		/* Store into item file */
-		FILE *fp = mopen(itemfile, O_RPLUS);
-		if (fp == NULL) {
-			custom_log("retitle", M_RFP);
-			continue;
-		}
-		if (fseek(fp, 10L, 0)) {
-			error("fseeking in ", itemfile);
-			mclose(fp);
-			continue;
-		}
-		if (len - sub.size() < MAX_LINE_LENGTH) {
-			std::println(fp, "{}{}", sub, spaces(len - sub.size()));
-			mclose(fp);
-			continue;
-		}
-		int spaces_added;
-		int spaces_to_add = len - sub.size();
-		/* Add new text */
-		std::print(fp, "{}", sub);
-		for (spaces_added = 0;
-		     spaces_to_add - spaces_added >= MAX_LINE_LENGTH;
-		     spaces_added += (MAX_LINE_LENGTH - 1)) {
-			std::print(fp, "{}", spaces(MAX_LINE_LENGTH - 1));
-		}
-		/* Add any remaining spaces */
-		std::println(fp, "{}", spaces(spaces_to_add - spaces_added));
-		mclose(fp);
+        /* Store into item file */
+        FILE *fp = mopen(itemfile, O_RPLUS);
+        if (fp == NULL) {
+            custom_log("retitle", M_RFP);
+            continue;
+        }
+        if (fseek(fp, 10L, 0)) {
+            error("fseeking in ", itemfile);
+            mclose(fp);
+            continue;
+        }
+        if (len - sub.size() < MAX_LINE_LENGTH) {
+            std::println(fp, "{}{}", sub, spaces(len - sub.size()));
+            mclose(fp);
+            continue;
+        }
+        int spaces_added;
+        int spaces_to_add = len - sub.size();
+        /* Add new text */
+        std::print(fp, "{}", sub);
+        for (spaces_added = 0; spaces_to_add - spaces_added >= MAX_LINE_LENGTH;
+            spaces_added += (MAX_LINE_LENGTH - 1)) {
+            std::print(fp, "{}", spaces(MAX_LINE_LENGTH - 1));
+        }
+        /* Add any remaining spaces */
+        std::println(fp, "{}", spaces(spaces_to_add - spaces_added));
+        mclose(fp);
 #ifdef SUBJFILE
-		XXX /* Fill this in if we ever use SUBJFILE */
+        XXX /* Fill this in if we ever use SUBJFILE */
 #endif
-		custom_log("retitle", M_RFP);
-	}
-	return 1;
+            custom_log("retitle", M_RFP);
+    }
+    return 1;
 }
 /******************************************************************************
  * EDIT A RESPONSE IN THE CURRENT ITEM                                        *
@@ -224,241 +224,228 @@ retitle(int argc, char **argv)
 /* Number of arguments      */
 /* Argument list            */
 int
-modify(
-    int argc,
-    char **argv
-)
+modify(int argc, char **argv)
 {
-	char buff[MAX_LINE_LENGTH];
-	int i, j, n, oldlen, newlen;
-	int cpid, wpid;
-	int statusp, ok;
-	extern FILE *ext_fp;
+    char buff[MAX_LINE_LENGTH];
+    int i, j, n, oldlen, newlen;
+    int cpid, wpid;
+    int statusp, ok;
+    extern FILE *ext_fp;
 
-	if (st_glob.c_security & CT_EMAIL) {
-		wputs("Can't modify in an email conference!\n");
-		return 1;
-	}
+    if (st_glob.c_security & CT_EMAIL) {
+        wputs("Can't modify in an email conference!\n");
+        return 1;
+    }
 #ifdef NEWS
-	if (st_glob.c_security & CT_NEWS) {
-		wputs("Can't modify in a news conference!\n");
-		return 1;
-	}
+    if (st_glob.c_security & CT_NEWS) {
+        wputs("Can't modify in a news conference!\n");
+        return 1;
+    }
 #endif
 
-	/* Validate arguments */
-	if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
-		wputs("You must specify a response number.\n");
-		return 1;
-	} else if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
+    /* Validate arguments */
+    if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
+        wputs("You must specify a response number.\n");
+        return 1;
+    } else if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
 
-	/* Check for permission to modify (only the author can modify) */
-	if (!re[i].date)
-		get_resp(ext_fp, &(re[i]), GR_HEADER, i);
-	/*
-	 * Only match logins if coming from or entered from web.  Slightly
-	 * dangerous, but it's better than not letting the author edit
-	 */
-	if (uid == get_nobody_uid() || re[i].uid == get_nobody_uid())
-		ok = str::eq(login, re[i].login);
-	else
-		ok = (uid == re[i].uid);
-	if (!ok)
-	{
-		std::println("You don't have permission to affect response {}.", i);
-		return 1;
-	}
-	if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
-		wputs(std::format("Cannot modify frozen %ss!\n", topic()));
-		return 1;
-	}
-	if (re[i].flags & RF_SCRIBBLED) {
-		wputs("Cannot modify a scribbled response!\n");
-		return 1;
-	}
-	if (re[i].offset < 0) {
-		wputs("Offset error.\n"); /* should never happen */
-		return 1;
-	}
+    /* Check for permission to modify (only the author can modify) */
+    if (!re[i].date)
+        get_resp(ext_fp, &(re[i]), GR_HEADER, i);
+    /*
+     * Only match logins if coming from or entered from web.  Slightly
+     * dangerous, but it's better than not letting the author edit
+     */
+    if (uid == get_nobody_uid() || re[i].uid == get_nobody_uid())
+        ok = str::eq(login, re[i].login);
+    else
+        ok = (uid == re[i].uid);
+    if (!ok) {
+        std::println("You don't have permission to affect response {}.", i);
+        return 1;
+    }
+    if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
+        wputs(std::format("Cannot modify frozen %ss!\n", topic()));
+        return 1;
+    }
+    if (re[i].flags & RF_SCRIBBLED) {
+        wputs("Cannot modify a scribbled response!\n");
+        return 1;
+    }
+    if (re[i].offset < 0) {
+        wputs("Offset error.\n"); /* should never happen */
+        return 1;
+    }
 
-	/* Get old text */
-	const auto item_path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	FILE *fp = mopen(item_path, O_R);
-	if (fp == NULL)
-		return 1;
-	get_resp(fp, &(re[i]), GR_ALL, i);
-	mclose(fp);
+    /* Get old text */
+    const auto item_path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    FILE *fp = mopen(item_path, O_R);
+    if (fp == NULL)
+        return 1;
+    get_resp(fp, &(re[i]), GR_ALL, i);
+    mclose(fp);
 
-	/* Fork & setuid down when creating cf.buffer */
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    /* Fork & setuid down when creating cf.buffer */
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		while ((wpid = wait(&statusp)) != cpid && wpid != -1)
-			;
-	} else { /* child */
-		if (setuid(getuid()))
-			error("setuid", "");
-		setgid(getgid());
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return -1; /* error: couldn't fork */
+        while ((wpid = wait(&statusp)) != cpid && wpid != -1);
+    } else { /* child */
+        if (setuid(getuid()))
+            error("setuid", "");
+        setgid(getgid());
 
-		/* Save to cf.buffer */
-		dump_file(work, "cf.buffer", re[i].text, O_W);
+        /* Save to cf.buffer */
+        dump_file(work, "cf.buffer", re[i].text, O_W);
 
-		exit(0);
-	}
+        exit(0);
+    }
 
-	/* Get new text */
-	std::vector<std::string> text;
-	if (!text_loop(0, "text") ||
-	    ((text = grab_file(work, "cf.buffer", GF_NOHEADER)), text.empty())) {
-		re[i].text.clear();
-		return 1;
-	}
+    /* Get new text */
+    std::vector<std::string> text;
+    if (!text_loop(0, "text") ||
+        ((text = grab_file(work, "cf.buffer", GF_NOHEADER)), text.empty())) {
+        re[i].text.clear();
+        return 1;
+    }
 
-	/* Write old text to censorlog */
-	const auto path = str::concat({bbsdir, "/censored"});
-	if ((fp = mopen(path, O_A | O_PRIVATE)) != NULL) {
-		std::println(fp, ",C {} {} {} resp {} rflg {} {},{} {} date {}",
-		    conflist[confidx].location, topic(), st_glob.i_current, i,
-		    RF_CENSORED | RF_SCRIBBLED, login, uid,
-		    get_date(time((time_t *)0), 0),
-		    fullname_in_conference(&st_glob));
-		std::println(fp, ",R{:04X}", re[i].flags);
-		std::println(fp, ",U{},{}", re[i].uid, re[i].login);
-		std::println(fp, ",A{}", re[i].fullname);
-		std::println(fp, ",D{:08X}", re[i].date);
-		std::println(fp, ",T");
-		for (const auto &line: re[i].text)
-			std::println(fp, "{}", line);
-		std::println(fp, ",E");
-		mclose(fp);
-	}
+    /* Write old text to censorlog */
+    const auto path = str::concat({bbsdir, "/censored"});
+    if ((fp = mopen(path, O_A | O_PRIVATE)) != NULL) {
+        std::println(fp, ",C {} {} {} resp {} rflg {} {},{} {} date {}",
+            conflist[confidx].location, topic(), st_glob.i_current, i,
+            RF_CENSORED | RF_SCRIBBLED, login, uid,
+            get_date(time((time_t *)0), 0), fullname_in_conference(&st_glob));
+        std::println(fp, ",R{:04X}", re[i].flags);
+        std::println(fp, ",U{},{}", re[i].uid, re[i].login);
+        std::println(fp, ",A{}", re[i].fullname);
+        std::println(fp, ",D{:08X}", re[i].date);
+        std::println(fp, ",T");
+        for (const auto &line : re[i].text) std::println(fp, "{}", line);
+        std::println(fp, ",E");
+        mclose(fp);
+    }
 
-	/* Escape the new text if needed, and see if it fits into the old space */
-	oldlen = (re[i].endoff - 3) - re[i].textoff;
-	n = text.size();
-	for (newlen = 0, j = 0; j < n; j++) {
-		if (text[j][0] == ',') {
-			text[j].insert(0, ",,");
-		}
-		newlen += text[j].size() + 1; /* count 1 for the newline */
-	}
+    /* Escape the new text if needed, and see if it fits into the old space */
+    oldlen = (re[i].endoff - 3) - re[i].textoff;
+    n = text.size();
+    for (newlen = 0, j = 0; j < n; j++) {
+        if (text[j][0] == ',') {
+            text[j].insert(0, ",,");
+        }
+        newlen += text[j].size() + 1; /* count 1 for the newline */
+    }
 
-	/* Overwrite the old text with either scribbling or with the new text */
-	if ((fp = mopen(buff, O_RPLUS)) != NULL) {
-		int is_at_end = 0;
-		/* If it's the last response, the space can be extended */
-		fseek(fp, 0L, SEEK_END);
-		if (ftell(fp) == re[i].endoff) {
-			oldlen = newlen +
-			    str::toi(get_conf_param("padding", PADDING));
-			is_at_end = 1;
-		}
+    /* Overwrite the old text with either scribbling or with the new text */
+    if ((fp = mopen(buff, O_RPLUS)) != NULL) {
+        int is_at_end = 0;
+        /* If it's the last response, the space can be extended */
+        fseek(fp, 0L, SEEK_END);
+        if (ftell(fp) == re[i].endoff) {
+            oldlen = newlen + str::toi(get_conf_param("padding", PADDING));
+            is_at_end = 1;
+        }
 
-		/* Append if the new text is longer */
-		if (newlen > oldlen) {
-			fseek(fp, re[i].offset, 0);
-			std::println(fp, ",R{:04}", RF_CENSORED | RF_SCRIBBLED);
-			fseek(fp, re[i].textoff, 0);
-			const auto over = std::format("{} {} {} ",
-			    login,
-			    get_date(time((time_t *)0), 0),
-			    fullname_in_conference(&st_glob));
-			const auto len = over.size();
-			for (j = oldlen; j > 76; j -= 76) {
-				for (size_t k = 0; k < 75; k++)
-					std::print(fp, "{:c}", over[k % len]);
-				std::println(fp, "");
-			}
-			for (size_t k = 0; k < j - 1; k++)
-				std::println(fp, "{:c}", over[k % len]);
-			std::println(fp, "");
-			std::println(fp, ",E");
-		} else {
-			/* Replace if the new text fits in the old space */
-			int k;
-			/* Write new timestamp */
-			for (k = 14; k > 7; k--) {
-				int c;
-				fseek(fp, re[i].textoff - k, 0);
-				c = getc(fp);
-				if (c == ',')
-					break;
-			}
-			if (k == 7) {
-				const auto errmsg = std::format("{} #{}.{}",
-				    compress(conflist[confidx].name).c_str(),
-				    st_glob.i_current, i);
-				error("lost date in ", errmsg);
-			} else {
-				fseek(fp, re[i].textoff - k, 0);
-				std::println(fp, ",D{:08X}", time(NULL));
-			}
+        /* Append if the new text is longer */
+        if (newlen > oldlen) {
+            fseek(fp, re[i].offset, 0);
+            std::println(fp, ",R{:04}", RF_CENSORED | RF_SCRIBBLED);
+            fseek(fp, re[i].textoff, 0);
+            const auto over =
+                std::format("{} {} {} ", login, get_date(time((time_t *)0), 0),
+                    fullname_in_conference(&st_glob));
+            const auto len = over.size();
+            for (j = oldlen; j > 76; j -= 76) {
+                for (size_t k = 0; k < 75; k++)
+                    std::print(fp, "{:c}", over[k % len]);
+                std::println(fp, "");
+            }
+            for (size_t k = 0; k < j - 1; k++)
+                std::println(fp, "{:c}", over[k % len]);
+            std::println(fp, "");
+            std::println(fp, ",E");
+        } else {
+            /* Replace if the new text fits in the old space */
+            int k;
+            /* Write new timestamp */
+            for (k = 14; k > 7; k--) {
+                int c;
+                fseek(fp, re[i].textoff - k, 0);
+                c = getc(fp);
+                if (c == ',')
+                    break;
+            }
+            if (k == 7) {
+                const auto errmsg = std::format("{} #{}.{}",
+                    compress(conflist[confidx].name).c_str(), st_glob.i_current,
+                    i);
+                error("lost date in ", errmsg);
+            } else {
+                fseek(fp, re[i].textoff - k, 0);
+                std::println(fp, ",D{:08X}", time(NULL));
+            }
 
-			/* Write new text and pad with spaces after the ,E */
-			fseek(fp, re[i].textoff, 0);
-			for (j = 0; j < n - 1; j++)
-				std::println(fp, "{}", text[j]);
-			if (oldlen - newlen < MAX_LINE_LENGTH) {
-				std::println(fp, "{}", text[j]);
-				std::println(fp, ",E{}", spaces(oldlen - newlen));
-			} else {
-				int spaces_added;
-				int spaces_to_add = oldlen - newlen;
-				std::println(fp, "{}", text[j]);
-				std::print(fp, ",E");
-				for (spaces_added = 0;
-				     spaces_to_add - spaces_added >=
-				     MAX_LINE_LENGTH;
-				     spaces_added += (MAX_LINE_LENGTH - 1)) {
-					std::print(fp, "{}",
-					    spaces(MAX_LINE_LENGTH - 1));
-				}
+            /* Write new text and pad with spaces after the ,E */
+            fseek(fp, re[i].textoff, 0);
+            for (j = 0; j < n - 1; j++) std::println(fp, "{}", text[j]);
+            if (oldlen - newlen < MAX_LINE_LENGTH) {
+                std::println(fp, "{}", text[j]);
+                std::println(fp, ",E{}", spaces(oldlen - newlen));
+            } else {
+                int spaces_added;
+                int spaces_to_add = oldlen - newlen;
+                std::println(fp, "{}", text[j]);
+                std::print(fp, ",E");
+                for (spaces_added = 0;
+                    spaces_to_add - spaces_added >= MAX_LINE_LENGTH;
+                    spaces_added += (MAX_LINE_LENGTH - 1)) {
+                    std::print(fp, "{}", spaces(MAX_LINE_LENGTH - 1));
+                }
 
-				/* Add any remaining spaces */
-				std::println(fp, "{}",
-				    spaces(spaces_to_add - spaces_added));
-			}
+                /* Add any remaining spaces */
+                std::println(fp, "{}", spaces(spaces_to_add - spaces_added));
+            }
 
-			if (is_at_end)
-				ftruncate(fileno(fp), ftell(fp));
-		}
-		mclose(fp);
+            if (is_at_end)
+                ftruncate(fileno(fp), ftell(fp));
+        }
+        mclose(fp);
 
-		/* Added 4/18, since sum file wasn't being updated, causing
-		 * set sensitive to fail. */
-		sum[st_glob.i_current - 1].last = time((time_t *)0);
-		save_sum(sum, (short)(st_glob.i_current - 1), confidx, &st_glob);
-		dirty_sum(st_glob.i_current - 1);
-	}
-	if (newlen > oldlen) {
-		/* At this point, the old text is scribbled, and the new text
-		 * is in text, so just do a normal add response. */
-		add_response(&sum[st_glob.i_current - 1], text,
-		    confidx, sum, part, &st_glob, 0, "", uid, login, re[i].fullname,
-		    re[i].parent);
-	}
+        /* Added 4/18, since sum file wasn't being updated, causing
+         * set sensitive to fail. */
+        sum[st_glob.i_current - 1].last = time((time_t *)0);
+        save_sum(sum, (short)(st_glob.i_current - 1), confidx, &st_glob);
+        dirty_sum(st_glob.i_current - 1);
+    }
+    if (newlen > oldlen) {
+        /* At this point, the old text is scribbled, and the new text
+         * is in text, so just do a normal add response. */
+        add_response(&sum[st_glob.i_current - 1], text, confidx, sum, part,
+            &st_glob, 0, "", uid, login, re[i].fullname, re[i].parent);
+    }
 
-	/* free_sum(sum); unneeded, always SF_FAST */
-	re[i].text.clear();
+    /* free_sum(sum); unneeded, always SF_FAST */
+    re[i].text.clear();
 
-	custom_log("edit", M_RFP);
+    custom_log("edit", M_RFP);
 
-	/* Remove the cf.buffer file now that we are done */
-	const auto cfbuffer = str::concat({work, "/cf.buffer"});
-	rm(cfbuffer, SL_USER);
+    /* Remove the cf.buffer file now that we are done */
+    const auto cfbuffer = str::concat({work, "/cf.buffer"});
+    rm(cfbuffer, SL_USER);
 
-	return 1;
+    return 1;
 }

--- a/files.cc
+++ b/files.cc
@@ -21,11 +21,11 @@
 
 /* Information about each open file */
 typedef struct fd_tt {
-	std::string filename;
-	short flg;
-	int fd;
-	int pid; /* child process id, if secure */
-	struct fd_tt *next;
+    std::string filename;
+    short flg;
+    int fd;
+    int pid; /* child process id, if secure */
+    struct fd_tt *next;
 } fd_t;
 static fd_t *first_fd = 0;
 
@@ -35,12 +35,12 @@ static fd_t *first_fd = 0;
 void
 mdump(void)
 {
-	/* ARGUMENTS: (none)  */
-	fd_t *thisfd;
-	for (thisfd = first_fd; thisfd; thisfd = thisfd->next) {
-		std::println("mdump: fd={} filename='{}' flg={:x}", thisfd->fd,
-		    thisfd->filename, thisfd->flg);
-	}
+    /* ARGUMENTS: (none)  */
+    fd_t *thisfd;
+    for (thisfd = first_fd; thisfd; thisfd = thisfd->next) {
+        std::println("mdump: fd={} filename='{}' flg={:x}", thisfd->fd,
+            thisfd->filename, thisfd->flg);
+    }
 }
 /******************************************************************************/
 /* ADD AN OPEN FD TO THE DATABASE (FROM SPOPEN/MOPEN)                         */
@@ -48,15 +48,15 @@ mdump(void)
 void
 madd(int fd, const std::string_view &file, int flg, int pid)
 {
-	fd_t *thisfd;
-	/* Save info for debugging */
-	thisfd = new fd_t{};
-	thisfd->fd = fd;
-	thisfd->filename = file;
-	thisfd->flg = flg;
-	thisfd->pid = pid;
-	thisfd->next = first_fd;
-	first_fd = thisfd;
+    fd_t *thisfd;
+    /* Save info for debugging */
+    thisfd = new fd_t{};
+    thisfd->fd = fd;
+    thisfd->filename = file;
+    thisfd->flg = flg;
+    thisfd->pid = pid;
+    thisfd->next = first_fd;
+    first_fd = thisfd;
 }
 /******************************************************************************/
 /* OPEN A FILE AND LOCK IT FOR EXCLUSIVE ACCESS                               */
@@ -67,110 +67,110 @@ madd(int fd, const std::string_view &file, int flg, int pid)
 FILE *
 mopen(const std::string &file, long flg)
 {
-	struct stat st;
-	short err = 0;
-	int fd, perm;
-	const char *modestr;
-	FILE *fp;
+    struct stat st;
+    short err = 0;
+    int fd, perm;
+    const char *modestr;
+    FILE *fp;
 
-	if (debug & DB_FILES)
-		std::println("mopen: flags={:x}", flg);
+    if (debug & DB_FILES)
+        std::println("mopen: flags={:x}", flg);
 
-	/* Process flags: ensure it exists or doesn't exist if required */
-	// XXX: TOCTOU bug here.
-	if (flg & (O_EXCL | O_NOCREATE))
-		err = stat(file.c_str(), &st);
-	if (err && (flg & O_NOCREATE)) {
-		if (!(flg & O_SILENT))
-			error("opening ", file);
-		return NULL; /* append: doesn't exist  */
-	} else if (!err && (flg & O_CREAT) && (flg & O_EXCL)) {
-		if (!(flg & O_SILENT))
-			error("creating ", file);
-		return NULL; /* create: already exists */
-	}
-	perm = umask(0);
+    /* Process flags: ensure it exists or doesn't exist if required */
+    // XXX: TOCTOU bug here.
+    if (flg & (O_EXCL | O_NOCREATE))
+        err = stat(file.c_str(), &st);
+    if (err && (flg & O_NOCREATE)) {
+        if (!(flg & O_SILENT))
+            error("opening ", file);
+        return NULL; /* append: doesn't exist  */
+    } else if (!err && (flg & O_CREAT) && (flg & O_EXCL)) {
+        if (!(flg & O_SILENT))
+            error("creating ", file);
+        return NULL; /* create: already exists */
+    }
+    perm = umask(0);
 
-	/* Open file */
-	fd = open(file.c_str(), flg & O_PASSTHRU, (flg & O_PRIVATE) ? 0600 : 0644);
-	if (fd < 0) {
-		if (!(flg & O_SILENT))
-			error("opening ", file);
-		umask(perm);
-		return NULL;
-	}
-	/* Lock it */
-	if (flg & O_LOCK) {
-		if (flock(fd, (flg & O_NOBLOCK) ? LOCK_EX | LOCK_NB : LOCK_EX) < 0) {
-			/*
-			 * ignore this error, since it may be /dev/null or
-			 * something weird like that. 8/4/95
-			 * error("Lock failed on ", file);
-			 *
-			 * allow it to continue without lock, can't flock an NFS
-			 * file in BSD1.1 it seems
-			 * umask(perm); return NULL;
-			 *
-			 * 8/28/95 need it to fail for license, fail only on
-			 * NOBLOCK
-			 */
-			if (flg & O_NOBLOCK) {
-				umask(perm);
-				close(fd);
-				/*error("Lock failed on ", file);*/
-				return NULL;
-			}
-		}
-	}
+    /* Open file */
+    fd = open(file.c_str(), flg & O_PASSTHRU, (flg & O_PRIVATE) ? 0600 : 0644);
+    if (fd < 0) {
+        if (!(flg & O_SILENT))
+            error("opening ", file);
+        umask(perm);
+        return NULL;
+    }
+    /* Lock it */
+    if (flg & O_LOCK) {
+        if (flock(fd, (flg & O_NOBLOCK) ? LOCK_EX | LOCK_NB : LOCK_EX) < 0) {
+            /*
+             * ignore this error, since it may be /dev/null or
+             * something weird like that. 8/4/95
+             * error("Lock failed on ", file);
+             *
+             * allow it to continue without lock, can't flock an NFS
+             * file in BSD1.1 it seems
+             * umask(perm); return NULL;
+             *
+             * 8/28/95 need it to fail for license, fail only on
+             * NOBLOCK
+             */
+            if (flg & O_NOBLOCK) {
+                umask(perm);
+                close(fd);
+                /*error("Lock failed on ", file);*/
+                return NULL;
+            }
+        }
+    }
 
-	/* Open/lock succeeded */
-	umask(perm);
-	if (flg & O_APPEND)
-		lseek(fd, 0L, 2);
+    /* Open/lock succeeded */
+    umask(perm);
+    if (flg & O_APPEND)
+        lseek(fd, 0L, 2);
 
-	/* Determine mode string */
-	modestr = "";
-	if ((flg & O_WPLUS) == O_WPLUS)
-		modestr = "w+";
-	else if ((flg & O_W) == O_W)
-		modestr = "w";
-	else if ((flg & O_APLUS) == O_APLUS)
-		modestr = "a+";
-	else if ((flg & O_A) == O_A)
-		modestr = "a";
-	else if ((flg & O_RPLUS) == O_RPLUS)
-		modestr = "r+"; /* should be next to last */
-	else if ((flg & O_R) == O_R)
-		modestr = "r"; /* MUST be last */
-	else
-		std::println("KKK Invalid mopen mode");
+    /* Determine mode string */
+    modestr = "";
+    if ((flg & O_WPLUS) == O_WPLUS)
+        modestr = "w+";
+    else if ((flg & O_W) == O_W)
+        modestr = "w";
+    else if ((flg & O_APLUS) == O_APLUS)
+        modestr = "a+";
+    else if ((flg & O_A) == O_A)
+        modestr = "a";
+    else if ((flg & O_RPLUS) == O_RPLUS)
+        modestr = "r+"; /* should be next to last */
+    else if ((flg & O_R) == O_R)
+        modestr = "r"; /* MUST be last */
+    else
+        std::println("KKK Invalid mopen mode");
 
-	/* Save info for debugging */
-	madd(fd, file, flg, 0);
+    /* Save info for debugging */
+    madd(fd, file, flg, 0);
 
-	/* Reopen fd as file pointer of equivalent mode */
-	if ((fp = fdopen(fd, modestr)) == NULL) {
-		if ((flg & O_SILENT) == 0) {
-			const auto msg = std::format("{} for {} after mode {:x}\n",
-			    file, modestr, flg);
-			error("reopening ", msg);
-		}
-	}
-	return fp;
+    /* Reopen fd as file pointer of equivalent mode */
+    if ((fp = fdopen(fd, modestr)) == NULL) {
+        if ((flg & O_SILENT) == 0) {
+            const auto msg =
+                std::format("{} for {} after mode {:x}\n", file, modestr, flg);
+            error("reopening ", msg);
+        }
+    }
+    return fp;
 }
 
 int
 get_pid(FILE *fp)
 {
-	if (fp == nullptr) {
-		error("invalid file pointer passed to get_pid");
-		return 0;
-	}
-	for (fd_t *thisfd = first_fd; thisfd != nullptr; thisfd = thisfd->next)
-		if (thisfd->fd == fileno(fp))
-			return thisfd->pid;
-	error("file pointer not found by get_pid");
-	return 0; /* not found */
+    if (fp == nullptr) {
+        error("invalid file pointer passed to get_pid");
+        return 0;
+    }
+    for (fd_t *thisfd = first_fd; thisfd != nullptr; thisfd = thisfd->next)
+        if (thisfd->fd == fileno(fp))
+            return thisfd->pid;
+    error("file pointer not found by get_pid");
+    return 0; /* not found */
 }
 /******************************************************************************/
 /* CLOSE AND UNLOCK A FILE                                                    */
@@ -180,31 +180,30 @@ get_pid(FILE *fp)
 int
 mclose(FILE *fp)
 {
-	fd_t *thisfd, *prev = 0;
-	int ret;
+    fd_t *thisfd, *prev = 0;
+    int ret;
 
-	fflush(fp);
-	for (thisfd = first_fd; thisfd && thisfd->fd != fileno(fp);
-	     prev = thisfd, thisfd = thisfd->next)
-		;
-	if (!thisfd) {
-		std::println("Tried to close unopened file");
-		return 1; /* not found */
-	}
-	if (!fp) {
-		std::println("Tried to close null file");
-		return 1;
-	}
-	ret = fclose(fp); /* flock automatically closes */
+    fflush(fp);
+    for (thisfd = first_fd; thisfd && thisfd->fd != fileno(fp);
+        prev = thisfd, thisfd = thisfd->next);
+    if (!thisfd) {
+        std::println("Tried to close unopened file");
+        return 1; /* not found */
+    }
+    if (!fp) {
+        std::println("Tried to close null file");
+        return 1;
+    }
+    ret = fclose(fp); /* flock automatically closes */
 
-	/* Remove from debugging database */
-	if (!prev)
-		first_fd = thisfd->next;
-	else
-		prev->next = thisfd->next;
-	delete thisfd;
+    /* Remove from debugging database */
+    if (!prev)
+        first_fd = thisfd->next;
+    else
+        prev->next = thisfd->next;
+    delete thisfd;
 
-	return ret;
+    return ret;
 }
 /******************************************************************************/
 /* VERIFY THAT ALL FILES HAVE BEEN CLOSED                                     */
@@ -212,11 +211,11 @@ mclose(FILE *fp)
 void
 mcheck(void)
 {
-	if (!first_fd) {
-		if (debug & DB_FILES)
-			puts("mcheck: Everything closed.\n");
-	} else {
-		std::println("mcheck: Error, failed to close the following:");
-		mdump();
-	}
+    if (!first_fd) {
+        if (debug & DB_FILES)
+            puts("mcheck: Everything closed.\n");
+    } else {
+        std::println("mcheck: Error, failed to close the following:");
+        mdump();
+    }
 }

--- a/help.cc
+++ b/help.cc
@@ -22,79 +22,80 @@
 /* Argument list       */
 /* Filename of list    */
 /* Help display header */
-namespace {
-void
-show_help(int *count, int argc, char **argv, const std::string &file, const std::optional<std::string_view> &hdr)
+namespace
 {
-	std::string_view dir, fil;
-	bool is_valid;
+void
+show_help(int *count, int argc, char **argv, const std::string &file,
+    const std::optional<std::string_view> &hdr)
+{
+    std::string_view dir, fil;
+    bool is_valid;
 
-	/* Set location */
-	if (file[0] == '%') {
-		dir = bbsdir;
-		fil = std::string_view(file).substr(1);
-	} else {
-		dir = helpdir;
-		fil = file;
-	}
+    /* Set location */
+    if (file[0] == '%') {
+        dir = bbsdir;
+        fil = std::string_view(file).substr(1);
+    } else {
+        dir = helpdir;
+        fil = file;
+    }
 
-	/* Is this a text file or a list? */
-	const auto headers = grab_file(dir, fil, GF_HEADER);
-	if (headers.empty())
-		return;
-	is_valid = headers[0] == "!<hl01>";
+    /* Is this a text file or a list? */
+    const auto headers = grab_file(dir, fil, GF_HEADER);
+    if (headers.empty())
+        return;
+    is_valid = headers[0] == "!<hl01>";
 
-	if (!is_valid) {
-		if (*count < argc)
-			std::println("Sorry, only this message available.");
-		else if (hdr.has_value())
-			std::println("****    {}    ****", *hdr);
-		if (!more(dir, fil))
-			std::println("Can't find help file {}/{}.", dir, fil);
-		return;
-	}
+    if (!is_valid) {
+        if (*count < argc)
+            std::println("Sorry, only this message available.");
+        else if (hdr.has_value())
+            std::println("****    {}    ****", *hdr);
+        if (!more(dir, fil))
+            std::println("Can't find help file {}/{}.", dir, fil);
+        return;
+    }
 
-	/* Read in help list */
-	const auto helpvec = grab_list(dir, fil, 0);
-	if (helpvec.empty())
-		return;
-	const assoc_t *help = nullptr;
-	const auto *topic = "(none)";
-	if (*count < argc) {
-		topic = argv[*count];
-		help = assoc_list_find(helpvec, topic);
-	}
+    /* Read in help list */
+    const auto helpvec = grab_list(dir, fil, 0);
+    if (helpvec.empty())
+        return;
+    const assoc_t *help = nullptr;
+    const auto *topic = "(none)";
+    if (*count < argc) {
+        topic = argv[*count];
+        help = assoc_list_find(helpvec, topic);
+    }
 
-	/* Display requested file */
-	if (*count >= argc) {
-		/* No arguments, use default file */
-		++*count;
-		show_help(count, argc, argv, helpvec[0].location, hdr);
-		return;
-	}
+    /* Display requested file */
+    if (*count >= argc) {
+        /* No arguments, use default file */
+        ++*count;
+        show_help(count, argc, argv, helpvec[0].location, hdr);
+        return;
+    }
 
-	++*count;
-	if (help == NULL) {
-		std::println("Sorry, no help available for \"{}\"", topic);
-		return;
-	}
+    ++*count;
+    if (help == NULL) {
+        std::println("Sorry, no help available for \"{}\"", topic);
+        return;
+    }
 
-	/* %filename indicates file is in bbsdir not helpdir */
-	if (help->location[0] == '%') {
-		/* normal help files are in helpdir and get a
-		 * header displayed */
-		show_help(count, argc, argv, help->location, hdr);
-	} else {
-		auto header = compress(help->name);
-		for (auto &c: header)
-			c = toupper(c);
-		if (hdr)
-			header = std::string(*hdr) + " " + header;
+    /* %filename indicates file is in bbsdir not helpdir */
+    if (help->location[0] == '%') {
+        /* normal help files are in helpdir and get a
+         * header displayed */
+        show_help(count, argc, argv, help->location, hdr);
+    } else {
+        auto header = compress(help->name);
+        for (auto &c : header) c = toupper(c);
+        if (hdr)
+            header = std::string(*hdr) + " " + header;
 
-		show_help(count, argc, argv, help->location, header);
-	}
+        show_help(count, argc, argv, help->location, header);
+    }
 }
-} // empty namespace
+} // namespace
 
 //*****************************************************************************
 // GET HELP ON SOME TOPIC
@@ -105,14 +106,14 @@ show_help(int *count, int argc, char **argv, const std::string &file, const std:
 int
 help(int argc, char **argv)
 {
-	auto helpfile = grab_file(helpdir, HELPINDEX, false);
-	if (argc < 1 || helpfile.size() <= mode)
-		return 1;
+    auto helpfile = grab_file(helpdir, HELPINDEX, false);
+    if (argc < 1 || helpfile.size() <= mode)
+        return 1;
 
-	int count = 1;
-	do {
-		show_help(&count, argc, argv, helpfile[mode], {});
-	} while (count < argc);
+    int count = 1;
+    do {
+        show_help(&count, argc, argv, helpfile[mode], {});
+    } while (count < argc);
 
-	return 1;
+    return 1;
 }

--- a/html_check.cc
+++ b/html_check.cc
@@ -24,14 +24,14 @@ int stack[STACKSIZE];
 int top = 0;
 
 /* Illegal case-insensitive strings */
-const char *illegal[] = {"HTML", "BODY", "HEAD", "TITLE", "ADDRESS", "ISINDEX", NULL};
+const char *illegal[] = {
+    "HTML", "BODY", "HEAD", "TITLE", "ADDRESS", "ISINDEX", NULL};
 
-const char *matching[] = {
-    "H1", "H2", "H3", "H4", "H5", "H6", "A", "UL", "OL", "DL",
-    "PRE", "BLOCKQUOTE", "DFN", "EM", "CITE", "CODE", "KBD", "SAMP", "STRONG",
-    "VAR", "B", "I", "TT", "BLINK", "FORM", "SELECT", "TEXTAREA", "SUP", "SUB",
-    "DIV", "FONT", "CENTER", "NOFRAMES", "FRAMESET", "TABLE", "TD", "TR", NULL
-};
+const char *matching[] = {"H1", "H2", "H3", "H4", "H5", "H6", "A", "UL", "OL",
+    "DL", "PRE", "BLOCKQUOTE", "DFN", "EM", "CITE", "CODE", "KBD", "SAMP",
+    "STRONG", "VAR", "B", "I", "TT", "BLINK", "FORM", "SELECT", "TEXTAREA",
+    "SUP", "SUB", "DIV", "FONT", "CENTER", "NOFRAMES", "FRAMESET", "TABLE",
+    "TD", "TR", NULL};
 
 char *Umatching[100];
 char *Uillegal[100];
@@ -39,20 +39,20 @@ char *Uillegal[100];
 void
 push(int i)
 {
-	if (top == STACKSIZE) {
-		std::println("Stack overflow");
-		exit(1);
-	}
-	stack[top++] = i;
+    if (top == STACKSIZE) {
+        std::println("Stack overflow");
+        exit(1);
+    }
+    stack[top++] = i;
 }
 
 int
 pop(void)
 {
-	if (top == 0)
-		return -1;
-	top--;
-	return stack[top];
+    if (top == 0)
+        return -1;
+    top--;
+    return stack[top];
 }
 /*
  * Load custom tags into malloc'ed space pointed to by elements of
@@ -62,198 +62,212 @@ pop(void)
 int
 load_illegal_tags(char *file)
 {
-	FILE *fp;
-	char buff[80];
-	int i;
-	fp = fopen(file, "r");
-	if (!fp)
-		return 0; /* use non-custom tags */
+    FILE *fp;
+    char buff[80];
+    int i;
+    fp = fopen(file, "r");
+    if (!fp)
+        return 0; /* use non-custom tags */
 
-	/* Load illegal tags first */
-	i = 0;
-	while (fscanf(fp, "%s", buff) == 1) {
-		if (str::eq(buff, "|"))
-			break;
-		Uillegal[i] = estrdup(buff);
-		i++;
-	}
-	Uillegal[i] = NULL;
+    /* Load illegal tags first */
+    i = 0;
+    while (fscanf(fp, "%s", buff) == 1) {
+        if (str::eq(buff, "|"))
+            break;
+        Uillegal[i] = estrdup(buff);
+        i++;
+    }
+    Uillegal[i] = NULL;
 
-	fclose(fp);
-	return 1;
+    fclose(fp);
+    return 1;
 }
 
 int
 load_matched_tags(char *file)
 {
-	FILE *fp;
-	char buff[80];
-	int i;
-	fp = fopen(file, "r");
-	if (!fp)
-		return 0; /* use non-custom tags */
+    FILE *fp;
+    char buff[80];
+    int i;
+    fp = fopen(file, "r");
+    if (!fp)
+        return 0; /* use non-custom tags */
 
-	/* Now load matching tags */
-	i = 0;
-	while (fscanf(fp, "%s", buff) == 1) {
-		Umatching[i] = estrdup(buff);
-		i++;
-	}
-	Umatching[i] = NULL;
+    /* Now load matching tags */
+    i = 0;
+    while (fscanf(fp, "%s", buff) == 1) {
+        Umatching[i] = estrdup(buff);
+        i++;
+    }
+    Umatching[i] = NULL;
 
-	fclose(fp);
-	return 1;
+    fclose(fp);
+    return 1;
 }
 
 void
 usage(void)
 {
-	std::println(stderr, "Yapp {} (c)1996 Armidale Software", VERSION);
-	std::println(stderr, " usage: html_check [-h] [-m file] [-i file]");
-	std::println(stderr, " -h       Allow HTML header as legal");
-	std::println(stderr, " -i file  Use tags in file as those which are illegal");
-	std::println(stderr, " -m file  Use tags in file as those which must be matched");
-	exit(1);
+    std::println(stderr, "Yapp {} (c)1996 Armidale Software", VERSION);
+    std::println(stderr, " usage: html_check [-h] [-m file] [-i file]");
+    std::println(stderr, " -h       Allow HTML header as legal");
+    std::println(
+        stderr, " -i file  Use tags in file as those which are illegal");
+    std::println(
+        stderr, " -m file  Use tags in file as those which must be matched");
+    exit(1);
 }
 /* Also match quotes ("...") inside < > */
 
 int
 main(int argc, char **argv)
 {
-	FILE *fp;
-	char buff[1024], *p;
-	const char *tag;
-	int html = 0, undo, quot = 0;
-	int i;
-	int allow_header = 0, illegal_tags = 0, matched_tags = 0;
-	const char *options = "hvi:m:"; /* Command-line options */
-	extern char *optarg;
-	extern int optind, opterr;
-	while ((i = getopt(argc, argv, options)) != -1) {
-		switch (i) {
-		case 'h':
-			allow_header = 1;
-			break;
-		case 'm':
-			matched_tags = load_matched_tags(optarg);
-			break;
-		case 'i':
-			illegal_tags = load_illegal_tags(optarg);
-			break;
-		case 'v':
-		default:
-			usage();
-		}
-	}
-	argc -= optind;
-	argv += optind;
+    FILE *fp;
+    char buff[1024], *p;
+    const char *tag;
+    int html = 0, undo, quot = 0;
+    int i;
+    int allow_header = 0, illegal_tags = 0, matched_tags = 0;
+    const char *options = "hvi:m:"; /* Command-line options */
+    extern char *optarg;
+    extern int optind, opterr;
+    while ((i = getopt(argc, argv, options)) != -1) {
+        switch (i) {
+        case 'h':
+            allow_header = 1;
+            break;
+        case 'm':
+            matched_tags = load_matched_tags(optarg);
+            break;
+        case 'i':
+            illegal_tags = load_illegal_tags(optarg);
+            break;
+        case 'v':
+        default:
+            usage();
+        }
+    }
+    argc -= optind;
+    argv += optind;
 
-	if (argc > 0) {
-		if ((fp = fopen(argv[0], "r")) == NULL) {
-			std::println(stderr, "Can't open {}", argv[0]);
-			exit(1);
-		}
-	} else
-		fp = stdin;
+    if (argc > 0) {
+        if ((fp = fopen(argv[0], "r")) == NULL) {
+            std::println(stderr, "Can't open {}", argv[0]);
+            exit(1);
+        }
+    } else
+        fp = stdin;
 
-	while (fgets(buff, sizeof(buff), fp) != NULL) {
-		for (p = buff; *p;) {
-			/* Match < > */
-			if (*p == '<') {
-				if (html) {
-					std::println("Found \"<\" inside HTML tag in " "\{}\".", buff);
-					std::println("Use \"&lt;\" instead of \"<\" if you want a less-than sign to appear.");
-					exit(1);
-				}
-				html++;
-				quot = 0;
+    while (fgets(buff, sizeof(buff), fp) != NULL) {
+        for (p = buff; *p;) {
+            /* Match < > */
+            if (*p == '<') {
+                if (html) {
+                    std::println("Found \"<\" inside HTML tag in "
+                                 "\{}\".",
+                        buff);
+                    std::println("Use \"&lt;\" instead of \"<\" if you want a "
+                                 "less-than sign to appear.");
+                    exit(1);
+                }
+                html++;
+                quot = 0;
 
-				p++;
-				if (*p == '/') {
-					undo = 1;
-					p++;
-				} else
-					undo = 0;
+                p++;
+                if (*p == '/') {
+                    undo = 1;
+                    p++;
+                } else
+                    undo = 0;
 
-				/* Compare to list of illegal tags */
-				if (!allow_header) {
-					i = 0;
-					tag = (illegal_tags) ? Uillegal[i] : illegal[i];
-					while (tag) {
-						if (!strncasecmp(p, tag, strlen(tag)) &&
-						    !isalnum(p[strlen(tag)])) {
-							std::println("Illegal HTML tag found: {}", tag);
-							exit(1);
-						}
-						i++;
-						tag = (illegal_tags) ? Uillegal[i] : illegal[i];
-					}
-				}
+                /* Compare to list of illegal tags */
+                if (!allow_header) {
+                    i = 0;
+                    tag = (illegal_tags) ? Uillegal[i] : illegal[i];
+                    while (tag) {
+                        if (!strncasecmp(p, tag, strlen(tag)) &&
+                            !isalnum(p[strlen(tag)])) {
+                            std::println("Illegal HTML tag found: {}", tag);
+                            exit(1);
+                        }
+                        i++;
+                        tag = (illegal_tags) ? Uillegal[i] : illegal[i];
+                    }
+                }
 
-				/* Compare to list of matching tags */
-				i = 0;
-				tag = (matched_tags) ? Umatching[i] : matching[i];
-				while (tag) {
-					if (!strncasecmp(p, tag, strlen(tag)) &&
-					    !isalnum(p[strlen(tag)])) {
+                /* Compare to list of matching tags */
+                i = 0;
+                tag = (matched_tags) ? Umatching[i] : matching[i];
+                while (tag) {
+                    if (!strncasecmp(p, tag, strlen(tag)) &&
+                        !isalnum(p[strlen(tag)])) {
 
-						/* Disallow overlapping tags
-						 * like B I /B /I But allow H1
-						 * A /A H1 */
-						if (undo) {
-							int j = pop();
-							if (j < 0) {
-								std::println("closing {} tag found without opening tag", tag);
-								exit(1);
-							}
-							if (i != j) {
-								std::println("tags {} and {} overlap in \"{}\"",
-								    tag, ((matched_tags) ? Umatching[j] : matching[j]), buff);
-								exit(1);
-							}
-						} else {
-							push(i);
-						}
-						break;
-					}
-					i++;
-					tag = (matched_tags) ? Umatching[i] : matching[i];
-				}
-			} else if (*p == '>') {
-				if (!html) {
-					std::println("\">\" appears outside an HTML tag in \"{}\".", buff);
-					std::println("Use \"&gt;\" instead of \">\" if you want a greater-than sign to appear.");
-					exit(1);
-				}
-				html--;
-				if (quot) {
-					std::println("Missing end quote in HTML tag in \"{}\".", buff);
-					exit(1);
-				}
-				p++;
-			} else if (*p == '"' && html) {
-				quot = 1 - quot;
-				p++;
-			} else
-				p++;
-		}
-	}
+                        /* Disallow overlapping tags
+                         * like B I /B /I But allow H1
+                         * A /A H1 */
+                        if (undo) {
+                            int j = pop();
+                            if (j < 0) {
+                                std::println(
+                                    "closing {} tag found without opening tag",
+                                    tag);
+                                exit(1);
+                            }
+                            if (i != j) {
+                                std::println("tags {} and {} overlap in \"{}\"",
+                                    tag,
+                                    ((matched_tags) ? Umatching[j]
+                                                    : matching[j]),
+                                    buff);
+                                exit(1);
+                            }
+                        } else {
+                            push(i);
+                        }
+                        break;
+                    }
+                    i++;
+                    tag = (matched_tags) ? Umatching[i] : matching[i];
+                }
+            } else if (*p == '>') {
+                if (!html) {
+                    std::println(
+                        "\">\" appears outside an HTML tag in \"{}\".", buff);
+                    std::println("Use \"&gt;\" instead of \">\" if you want a "
+                                 "greater-than sign to appear.");
+                    exit(1);
+                }
+                html--;
+                if (quot) {
+                    std::println(
+                        "Missing end quote in HTML tag in \"{}\".", buff);
+                    exit(1);
+                }
+                p++;
+            } else if (*p == '"' && html) {
+                quot = 1 - quot;
+                p++;
+            } else
+                p++;
+        }
+    }
 
-	/* Make sure not still in tag */
-	if (html) {
-		std::println("Missing \">\" at end of HTML tag.");
-		std::println("Use \"&lt;\" instead of \"<\" if you want a less-than sign to appear.");
-		exit(1);
-	}
+    /* Make sure not still in tag */
+    if (html) {
+        std::println("Missing \">\" at end of HTML tag.");
+        std::println("Use \"&lt;\" instead of \"<\" if you want a less-than "
+                     "sign to appear.");
+        exit(1);
+    }
 
-	/* Make sure stack is empty */
-	if (top) {
-		i = pop();
-		std::println("Missing ending {} tag",
-		    (matched_tags) ? Umatching[i] : matching[i]);
-		exit(1);
-	}
+    /* Make sure stack is empty */
+    if (top) {
+        i = pop();
+        std::println("Missing ending {} tag",
+            (matched_tags) ? Umatching[i] : matching[i]);
+        exit(1);
+    }
 
-	/* Ok, no problems found */
-	exit(0);
+    /* Ok, no problems found */
+    exit(0);
 }

--- a/html_filter.cc
+++ b/html_filter.cc
@@ -16,70 +16,70 @@
 void
 usage(void)
 {
-	std::println(stderr, "Yapp {} (c)1996 Armidale Software", VERSION);
-	std::println(stderr, "n usage: html_filter [-cn]");
-	std::println(stderr, " -c   Map \\n to newline");
-	std::println(stderr, " -n   Don't output newlines");
-	exit(1);
+    std::println(stderr, "Yapp {} (c)1996 Armidale Software", VERSION);
+    std::println(stderr, "n usage: html_filter [-cn]");
+    std::println(stderr, " -c   Map \\n to newline");
+    std::println(stderr, " -n   Don't output newlines");
+    exit(1);
 }
 
 int
 main(int argc, char **argv)
 {
-	int c;
-	int newline = 1,           /* pass newlines through */
-	    back = 0, convert = 0; /* convert \n to newline */
+    int c;
+    int newline = 1,           /* pass newlines through */
+        back = 0, convert = 0; /* convert \n to newline */
 
-	const char *options = "hvnc"; /* Command-line options */
-	extern int optind;
-	while ((c = getopt(argc, argv, options)) != -1) {
-		switch (c) {
-		case 'n':
-			newline = 0;
-			break;
-		case 'c':
-			convert = 1;
-			break;
-		case 'v':
-		case 'h':
-		default:
-			usage();
-		}
-	}
-	argc -= optind;
-	argv += optind;
+    const char *options = "hvnc"; /* Command-line options */
+    extern int optind;
+    while ((c = getopt(argc, argv, options)) != -1) {
+        switch (c) {
+        case 'n':
+            newline = 0;
+            break;
+        case 'c':
+            convert = 1;
+            break;
+        case 'v':
+        case 'h':
+        default:
+            usage();
+        }
+    }
+    argc -= optind;
+    argv += optind;
 
-	while ((c = getchar()) != EOF) {
-		if (convert) {
-			if (back) {
-				if (c == 'n')
-					c = '\n';
-				back = 0;
-			} else if (c == '\\') {
-				back = 1;
-				continue;
-			}
-		}
-		switch (c) {
-		case '>':
-			std::print("&gt;");
-			break;
-		case '<':
-			std::print("&lt;");
-			break;
-		case '&':
-			std::print("&amp;");
-			break;
-		case '"':
-			std::print("&quot;");
-			break;
-		case '\n':
-			if (newline)
-				putchar(c);
-			break;
-		default:
-			putchar(c);
-		}
-	}
-	exit(0);
+    while ((c = getchar()) != EOF) {
+        if (convert) {
+            if (back) {
+                if (c == 'n')
+                    c = '\n';
+                back = 0;
+            } else if (c == '\\') {
+                back = 1;
+                continue;
+            }
+        }
+        switch (c) {
+        case '>':
+            std::print("&gt;");
+            break;
+        case '<':
+            std::print("&lt;");
+            break;
+        case '&':
+            std::print("&amp;");
+            break;
+        case '"':
+            std::print("&quot;");
+            break;
+        case '\n':
+            if (newline)
+                putchar(c);
+            break;
+        default:
+            putchar(c);
+        }
+    }
+    exit(0);
 }

--- a/html_pager.cc
+++ b/html_pager.cc
@@ -14,53 +14,51 @@
 int
 main(int argc, char **argv)
 {
-	char buff[1024], tag[1024];
-	char *p;
-	int inside,    /* true if we're inside a link <a> ... </a> */
-	    intag = 0; /* true if we're inside an html tag < ... > */
-	int i;
+    char buff[1024], tag[1024];
+    char *p;
+    int inside,    /* true if we're inside a link <a> ... </a> */
+        intag = 0; /* true if we're inside an html tag < ... > */
+    int i;
 
-	if (argc > 1 && str::eq(argv[1], "-v")) {
-		std::println("html_pager v1.0 (c)1996 Armidale Software");
-		exit(0);
-	}
-	while (fgets(buff, 1024, stdin)) {
+    if (argc > 1 && str::eq(argv[1], "-v")) {
+        std::println("html_pager v1.0 (c)1996 Armidale Software");
+        exit(0);
+    }
+    while (fgets(buff, 1024, stdin)) {
 
-		inside = 0;
-		for (p = buff; *p;) {
-			if (*p == '<') {
-				if (toupper(p[1]) == 'A')
-					intag = 1;
-				else if (p[1] == '/' && toupper(p[2]) == 'A')
-					intag = 0;
-				inside = 1;
-			} else if (inside && (*p == '>' || *p == '\n')) {
-				inside = 0;
-			}
-			if (!inside && !intag &&
-			    (!strncasecmp(p, "ftp:/", 5) ||
-			        !strncasecmp(p, "http://", 7) ||
-			        !strncasecmp(p, "gopher://", 9) ||
-			        !strncasecmp(p, "mailto://", 9) ||
-			        !strncasecmp(p, "news:", 5) ||
-			        !strncasecmp(p, "nntp:", 5) ||
-			        !strncasecmp(p, "telnet://", 9) ||
-			        !strncasecmp(p, "wais:/", 6) ||
-			        !strncasecmp(p, "file:/", 6) ||
-			        !strncasecmp(p, "prospero://", 11))) {
-				for (i = 0; p[i] != '<' &&
-				            (isalnum(p[i]) || ispunct(p[i]));
-				     i++)
-					tag[i] = p[i];
-				if (ispunct(tag[i - 1]) && tag[i - 1] != '/')
-					i--;
-				tag[i] = '\0';
-				std::print("<A HREF=\"{}\">{}</A>", tag, tag);
-				p += i;
-				continue;
-			} else
-				putchar(*p++);
-		}
-	}
-	exit(0);
+        inside = 0;
+        for (p = buff; *p;) {
+            if (*p == '<') {
+                if (toupper(p[1]) == 'A')
+                    intag = 1;
+                else if (p[1] == '/' && toupper(p[2]) == 'A')
+                    intag = 0;
+                inside = 1;
+            } else if (inside && (*p == '>' || *p == '\n')) {
+                inside = 0;
+            }
+            if (!inside && !intag &&
+                (!strncasecmp(p, "ftp:/", 5) || !strncasecmp(p, "http://", 7) ||
+                    !strncasecmp(p, "gopher://", 9) ||
+                    !strncasecmp(p, "mailto://", 9) ||
+                    !strncasecmp(p, "news:", 5) ||
+                    !strncasecmp(p, "nntp:", 5) ||
+                    !strncasecmp(p, "telnet://", 9) ||
+                    !strncasecmp(p, "wais:/", 6) ||
+                    !strncasecmp(p, "file:/", 6) ||
+                    !strncasecmp(p, "prospero://", 11))) {
+                for (i = 0; p[i] != '<' && (isalnum(p[i]) || ispunct(p[i]));
+                    i++)
+                    tag[i] = p[i];
+                if (ispunct(tag[i - 1]) && tag[i - 1] != '/')
+                    i--;
+                tag[i] = '\0';
+                std::print("<A HREF=\"{}\">{}</A>", tag, tag);
+                p += i;
+                continue;
+            } else
+                putchar(*p++);
+        }
+    }
+    exit(0);
 }

--- a/item.cc
+++ b/item.cc
@@ -55,80 +55,80 @@ short ext_first, ext_last; /* for 'again' */
 int
 is_enterer(int item)
 {
-	response_t tempre[MAX_RESPONSES];
+    response_t tempre[MAX_RESPONSES];
 
-	const auto path = std::format("{}/_{}", conflist[confidx].location, item);
-	FILE *fp = mopen(path, O_R);
-	if (fp == nullptr)
-		return 0;
-	get_item(fp, item, tempre, sum);
-	get_resp(fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
-	mclose(fp);
-	return (re[0].uid == uid) && str::eq(re[0].login, login);
+    const auto path = std::format("{}/_{}", conflist[confidx].location, item);
+    FILE *fp = mopen(path, O_R);
+    if (fp == nullptr)
+        return 0;
+    get_item(fp, item, tempre, sum);
+    get_resp(fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
+    mclose(fp);
+    return (re[0].uid == uid) && str::eq(re[0].login, login);
 }
 /******************************************************************************/
 /* CREATE A NEW ITEM                                                          */
 /******************************************************************************/
 int
-do_enter(sumentry_t *sumthis, /* New item summary */
-    const std::string_view &sub,             /* New item subject */
-    const std::vector<std::string> &text,    /* New item text    */
+do_enter(sumentry_t *sumthis,             /* New item summary */
+    const std::string_view &sub,          /* New item subject */
+    const std::vector<std::string> &text, /* New item text    */
     int idx, sumentry_t *sum, partentry_t *part, status_t *stt, long art,
-    const std::string_view &mid,
-    int uid, const std::string_view &login, const std::string_view &fullname)
+    const std::string_view &mid, int uid, const std::string_view &login,
+    const std::string_view &fullname)
 {
-	/* item = ++(stt->i_last);  * next item number */
-	auto item = ++(stt->c_confitems); /* next item number */
-	if (!art && !(flags & O_QUIET))
-		std::print("Saving as {} {}...", topic(), item);
-	if (debug & DB_ITEM)
-		std::println("{} flags={} sub=!{}!", topic(), sumthis->flags, sub);
-	const auto path = std::format("{}/_{}", conflist[idx].location, item);
-	long mod = O_W | O_EXCL;
-	if (stt->c_security & CT_BASIC)
-		mod |= O_PRIVATE;
-	FILE *fp = mopen(path, mod);
-	if (fp == NULL)
-		return 0;
-	std::println(fp, "!<ps02>\n,H{}{}\n,R{:04X}\n,U{},{}\n,A{}\n,D{:08X}\n,T",
-	    sub, spaces(str::toi(get_conf_param("padding", PADDING)) - sub.size()),
-	    RF_NORMAL, uid, login, fullname, (unsigned long)sumthis->first);
+    /* item = ++(stt->i_last);  * next item number */
+    auto item = ++(stt->c_confitems); /* next item number */
+    if (!art && !(flags & O_QUIET))
+        std::print("Saving as {} {}...", topic(), item);
+    if (debug & DB_ITEM)
+        std::println("{} flags={} sub=!{}!", topic(), sumthis->flags, sub);
+    const auto path = std::format("{}/_{}", conflist[idx].location, item);
+    long mod = O_W | O_EXCL;
+    if (stt->c_security & CT_BASIC)
+        mod |= O_PRIVATE;
+    FILE *fp = mopen(path, mod);
+    if (fp == NULL)
+        return 0;
+    std::println(fp, "!<ps02>\n,H{}{}\n,R{:04X}\n,U{},{}\n,A{}\n,D{:08X}\n,T",
+        sub, spaces(str::toi(get_conf_param("padding", PADDING)) - sub.size()),
+        RF_NORMAL, uid, login, fullname, (unsigned long)sumthis->first);
 
-	if (art) {
-		std::println(fp, ",N{:06d}", art);
-		std::println(fp, ",M{}", mid);
-	} else {
-		for (auto line = 0uz; line < text.size(); line++) {
-			if (text[line][0] == ',')
-				std::print(fp, ",,");
-			std::println(fp, "{}", text[line]);
-		}
-	}
-	std::println(fp, ",E{}",
-	    spaces(str::toi(get_conf_param("padding", PADDING))));
-	fflush(fp);
-	if (!std::ferror(fp)) {
-		time(&(part[item - 1].last));
-		part[item - 1].nr = sumthis->nr;
-		dirty_part(item - 1);
-	} else
-		error("writing ", topic());
+    if (art) {
+        std::println(fp, ",N{:06d}", art);
+        std::println(fp, ",M{}", mid);
+    } else {
+        for (auto line = 0uz; line < text.size(); line++) {
+            if (text[line][0] == ',')
+                std::print(fp, ",,");
+            std::println(fp, "{}", text[line]);
+        }
+    }
+    std::println(
+        fp, ",E{}", spaces(str::toi(get_conf_param("padding", PADDING))));
+    fflush(fp);
+    if (!std::ferror(fp)) {
+        time(&(part[item - 1].last));
+        part[item - 1].nr = sumthis->nr;
+        dirty_part(item - 1);
+    } else
+        error("writing ", topic());
 
-	/* If sum doesn't exist, we must make sure the data has been written
-	 * before the sum file is created. */
-	memcpy(&sum[item - 1], sumthis, sizeof(sumentry_t));
-	save_sum(sum, (short)(item - 1), idx, stt);
-	dirty_sum(item - 1);
-	mclose(fp);
-	store_subj(idx, item - 1, sub);
-	store_auth(idx, item - 1, login);
+    /* If sum doesn't exist, we must make sure the data has been written
+     * before the sum file is created. */
+    memcpy(&sum[item - 1], sumthis, sizeof(sumentry_t));
+    save_sum(sum, (short)(item - 1), idx, stt);
+    dirty_sum(item - 1);
+    mclose(fp);
+    store_subj(idx, item - 1, sub);
+    store_auth(idx, item - 1, login);
 #ifdef SUBJFILE
-	update_subj(idx, item - 1); /* update subjects file */
+    update_subj(idx, item - 1); /* update subjects file */
 #endif
-	if (!art && !(flags & O_QUIET))
-		wputs("saved.\n");
-	stt->i_numitems++;
-	return 1;
+    if (!art && !(flags & O_QUIET))
+        wputs("saved.\n");
+    stt->i_numitems++;
+    return 1;
 }
 
 /******************************************************************************/
@@ -140,133 +140,136 @@ enter(          /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	std::string sub;
-	sumentry_t sumthis;
+    std::string sub;
+    sumentry_t sumthis;
 
-	if (argc > 1) {
-		std::println("Bad {} range near \"{}\"", topic(), argv[1]);
-		return 1;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    if (argc > 1) {
+        std::println("Bad {} range near \"{}\"", topic(), argv[1]);
+        return 1;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (!check_acl(ENTER_RIGHT, confidx)) {
-		std::println("You are not allowed to enter new {}s.", topic());
-		return 1;
-	}
+    if (!check_acl(ENTER_RIGHT, confidx)) {
+        std::println("You are not allowed to enter new {}s.", topic());
+        return 1;
+    }
 
-	if (!st_glob.i_numitems && !(st_glob.c_status & CS_FW)) {
-		const auto msg =
-		    std::format("Only the {} can enter the first {}.  Sorry!\n",
-		        fairwitness(), topic());
-		wputs(msg);
-		return 1;
-	}
-	if (st_glob.i_last == MAX_ITEMS) { /* numbered 1-last */
-		wputs(std::format("Too many %ss.\n", topic()));
-		return 1;
-	}
+    if (!st_glob.i_numitems && !(st_glob.c_status & CS_FW)) {
+        const auto msg =
+            std::format("Only the {} can enter the first {}.  Sorry!\n",
+                fairwitness(), topic());
+        wputs(msg);
+        return 1;
+    }
+    if (st_glob.i_last == MAX_ITEMS) { /* numbered 1-last */
+        wputs(std::format("Too many %ss.\n", topic()));
+        return 1;
+    }
 #ifdef NEWS
-	if (st_glob.c_security & CT_NEWS) {
-		make_rnhead(re, 0);
-		const auto rnh = str::concat({home, "/.rnhead"});
-		const auto cmd = str::concat({"Pnews -h ", rnh});
-		unix_cmd(cmd);
-		rm(rnh, SL_USER);
-		return 1;
-	}
+    if (st_glob.c_security & CT_NEWS) {
+        make_rnhead(re, 0);
+        const auto rnh = str::concat({home, "/.rnhead"});
+        const auto cmd = str::concat({"Pnews -h ", rnh});
+        unix_cmd(cmd);
+        rm(rnh, SL_USER);
+        return 1;
+    }
 #endif
 
-	const auto cfbufr = str::concat({work, "/cf.buffer"});
-	if (text_loop(1, "text")) {
-		auto file = grab_file(work, "cf.buffer", false);
-		if (file.empty()) {
-			wputs("can't open cfbuffer\n");
-		} else {
-			/* Get the subject */
-			do {
-				if (!(flags & O_QUIET))
-					std::print("Enter a one line {} or ':' to edit\n? ", subject(0));
-				ngets(sub, st_glob.inp); /* st_glob.inp */
+    const auto cfbufr = str::concat({work, "/cf.buffer"});
+    if (text_loop(1, "text")) {
+        auto file = grab_file(work, "cf.buffer", false);
+        if (file.empty()) {
+            wputs("can't open cfbuffer\n");
+        } else {
+            /* Get the subject */
+            do {
+                if (!(flags & O_QUIET))
+                    std::print(
+                        "Enter a one line {} or ':' to edit\n? ", subject(0));
+                ngets(sub, st_glob.inp); /* st_glob.inp */
 
-				if (str::eq(sub, ":")) {
-					file.clear();
-					if (!edit(cfbufr, "", 0) || ((file = grab_file(work, "cf.buffer", false)), file.empty())) {
-						wputs("can't open cfbuffer\n");
-						return 1;
-					}
-					sub.clear();
-					continue;
-				}
-				const auto prompt = std::format("Ok to abandon {} entry? ", topic());
-				if (sub.empty() && get_yes(prompt, true)) {
-					rm(cfbufr, SL_USER);
-					wputs(std::format("No text -- {} entry aborted!\n", topic()));
-					return 1;
-				}
-			} while (sub.empty());
+                if (str::eq(sub, ":")) {
+                    file.clear();
+                    if (!edit(cfbufr, "", 0) ||
+                        ((file = grab_file(work, "cf.buffer", false)),
+                            file.empty())) {
+                        wputs("can't open cfbuffer\n");
+                        return 1;
+                    }
+                    sub.clear();
+                    continue;
+                }
+                const auto prompt =
+                    std::format("Ok to abandon {} entry? ", topic());
+                if (sub.empty() && get_yes(prompt, true)) {
+                    rm(cfbufr, SL_USER);
+                    wputs(
+                        std::format("No text -- {} entry aborted!\n", topic()));
+                    return 1;
+                }
+            } while (sub.empty());
 
-			/* Expand seps in subject IF first character is % */
-			if (sub[0] == '%') {
-				const char *str, *f;
-				str = sub.c_str() + 1;
-				f = get_sep(&str);
-				sub = f;
-			}
-			{
+            /* Expand seps in subject IF first character is % */
+            if (sub[0] == '%') {
+                const char *str, *f;
+                str = sub.c_str() + 1;
+                f = get_sep(&str);
+                sub = f;
+            }
+            {
 
-				/* Replace any control characters with spaces */
-				char *p;
-				for (p = sub.data(); *p; p++)
-					if (iscntrl(*p))
-						*p = ' ';
-			}
+                /* Replace any control characters with spaces */
+                char *p;
+                for (p = sub.data(); *p; p++)
+                    if (iscntrl(*p))
+                        *p = ' ';
+            }
 
-			/* Verify item entry */
-			const auto prompt = std::format("Ok to enter this {}? ", topic());
-			if (!get_yes(prompt, false)) {
-				rm(cfbufr, SL_USER);
-				wputs(std::format("No text -- {} entry aborted!\n", topic()));
-				return 1;
-			}
-			sumthis.nr = 1;
-			sumthis.flags = IF_ACTIVE;
-			sumthis.last = time(&(sumthis.first));
+            /* Verify item entry */
+            const auto prompt = std::format("Ok to enter this {}? ", topic());
+            if (!get_yes(prompt, false)) {
+                rm(cfbufr, SL_USER);
+                wputs(std::format("No text -- {} entry aborted!\n", topic()));
+                return 1;
+            }
+            sumthis.nr = 1;
+            sumthis.flags = IF_ACTIVE;
+            sumthis.last = time(&(sumthis.first));
 
-			/* make sure nothing changed since we started */
-			refresh_sum(0, confidx, sum, part, &st_glob);
-			/* dont need to free anything */
+            /* make sure nothing changed since we started */
+            refresh_sum(0, confidx, sum, part, &st_glob);
+            /* dont need to free anything */
 
-			if (st_glob.c_security & CT_EMAIL) {
-				char cfbufr2[MAX_LINE_LENGTH];
-				const auto cfbuf2 = cfbufr + ".tmp";
-				move_file(cfbufr, cfbufr2, SL_USER);
+            if (st_glob.c_security & CT_EMAIL) {
+                char cfbufr2[MAX_LINE_LENGTH];
+                const auto cfbuf2 = cfbufr + ".tmp";
+                move_file(cfbufr, cfbufr2, SL_USER);
 
-				store_subj(confidx, st_glob.i_numitems, sub);
-				st_glob.i_current = st_glob.i_numitems + 1;
-				make_emhead(re, 0);
+                store_subj(confidx, st_glob.i_numitems, sub);
+                st_glob.i_current = st_glob.i_numitems + 1;
+                make_emhead(re, 0);
 
-				const auto cat = std::format("cat {} >> {}", cfbuf2, cfbufr);
-				unix_cmd(cat);
-				rm(cfbufr2, SL_USER);
+                const auto cat = std::format("cat {} >> {}", cfbuf2, cfbufr);
+                unix_cmd(cat);
+                rm(cfbufr2, SL_USER);
 
-				make_emtail();
-				const auto sendmail = std::format("{} -t < {}",
-				    get_conf_param("sendmail", SENDMAIL),
-				    cfbufr);
-				unix_cmd(sendmail);
-			} else {
-				do_enter(&sumthis, sub, file, confidx, sum, part,
-				    &st_glob, 0, "", uid, login,
-				    fullname_in_conference(&st_glob));
-			}
+                make_emtail();
+                const auto sendmail = std::format(
+                    "{} -t < {}", get_conf_param("sendmail", SENDMAIL), cfbufr);
+                unix_cmd(sendmail);
+            } else {
+                do_enter(&sumthis, sub, file, confidx, sum, part, &st_glob, 0,
+                    "", uid, login, fullname_in_conference(&st_glob));
+            }
 
-			refresh_stats(sum, part, &st_glob);
-			st_glob.i_current = st_glob.i_last;
-			custom_log("enter", M_RFP);
-		}
-	}
-	rm(cfbufr, SL_USER);
-	return 1;
+            refresh_stats(sum, part, &st_glob);
+            st_glob.i_current = st_glob.i_last;
+            custom_log("enter", M_RFP);
+        }
+    }
+    rm(cfbufr, SL_USER);
+    return 1;
 }
 /******************************************************************************/
 /* DISPLAY CURRENT ITEM HEADER                                                */
@@ -275,74 +278,73 @@ enter(          /* ARGUMENTS:             */
 void
 show_header(void)
 {
-	FILE *fp;
-	std::string buff;
-	int scrib = 0;
-	open_pipe();
+    FILE *fp;
+    std::string buff;
+    int scrib = 0;
+    open_pipe();
 
-	const auto path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	if ((fp = mopen(path, O_R)) != NULL) {
-		st_glob.r_current = 0; /* current resp = header */
-		get_item(fp, st_glob.i_current, re, sum);
-		get_resp(
-		    fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
-		/* The problem here is that itemsep uses r_current as an index
-		   to the information in re, so we can't show # new responses
-		      st_glob.r_current = sum[st_glob.i_current-1].nr
-		       - abs(part[st_glob.i_current-1].nr);
-		 */
+    const auto path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    if ((fp = mopen(path, O_R)) != NULL) {
+        st_glob.r_current = 0; /* current resp = header */
+        get_item(fp, st_glob.i_current, re, sum);
+        get_resp(fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
+        /* The problem here is that itemsep uses r_current as an index
+           to the information in re, so we can't show # new responses
+              st_glob.r_current = sum[st_glob.i_current-1].nr
+               - abs(part[st_glob.i_current-1].nr);
+         */
 
-		/* Get info about the actual item text if possible */
-		if (!(re[st_glob.r_current].flags &
-		        (RF_EXPIRED | RF_SCRIBBLED)))
-			get_resp(fp, &(re[st_glob.r_current]), (short)GR_ALL,
-			    st_glob.r_current);
+        /* Get info about the actual item text if possible */
+        if (!(re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED)))
+            get_resp(
+                fp, &(re[st_glob.r_current]), (short)GR_ALL, st_glob.r_current);
 
-		if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
-		    re[st_glob.r_current].numchars > 7) {
-			fseek(fp, re[st_glob.r_current].textoff, 0);
-			ngets(buff, fp);
-			re[st_glob.r_current].text.clear();
-			re[st_glob.r_current].text.push_back(buff);
-			scrib = 1;
-		}
-		if (flags & O_LABEL)
-			sepinit(IS_CENSORED | IS_UID | IS_DATE);
-		itemsep(expand((st_glob.opt_flags & OF_int) ? "ishort" : "isep",
-		            DM_VAR),
-		    0);
+        if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
+            re[st_glob.r_current].numchars > 7) {
+            fseek(fp, re[st_glob.r_current].textoff, 0);
+            ngets(buff, fp);
+            re[st_glob.r_current].text.clear();
+            re[st_glob.r_current].text.push_back(buff);
+            scrib = 1;
+        }
+        if (flags & O_LABEL)
+            sepinit(IS_CENSORED | IS_UID | IS_DATE);
+        itemsep(
+            expand((st_glob.opt_flags & OF_int) ? "ishort" : "isep", DM_VAR),
+            0);
 
-		/* If we've allocated the text, free it */
-		if (!scrib)
-			re[st_glob.r_current].text.clear();
+        /* If we've allocated the text, free it */
+        if (!scrib)
+            re[st_glob.r_current].text.clear();
 
-		st_glob.r_current = 0; /* current resp = header */
-		mclose(fp);
-	}
+        st_glob.r_current = 0; /* current resp = header */
+        mclose(fp);
+    }
 }
 
 void
 show_nsep(FILE *fp)
 {
-	short tmp, i = st_glob.r_first;
-	tmp = st_glob.r_current;
+    short tmp, i = st_glob.r_first;
+    tmp = st_glob.r_current;
 
-	if (st_glob.since) {
-		while (i < sum[st_glob.i_current - 1].nr &&
-		       st_glob.since > re[i].date) {
-			i++;
-			get_resp(fp, &(re[i]), (short)GR_HEADER, i);
-			if (i >= sum[st_glob.i_current - 1].nr)
-				break;
-		}
-	} else if (!st_glob.r_first)
-		i = abs(part[st_glob.i_current - 1].nr);
-	if (!i)
-		i++;
+    if (st_glob.since) {
+        while (
+            i < sum[st_glob.i_current - 1].nr && st_glob.since > re[i].date) {
+            i++;
+            get_resp(fp, &(re[i]), (short)GR_HEADER, i);
+            if (i >= sum[st_glob.i_current - 1].nr)
+                break;
+        }
+    } else if (!st_glob.r_first)
+        i = abs(part[st_glob.i_current - 1].nr);
+    if (!i)
+        i++;
 
-	st_glob.r_current = sum[st_glob.i_current - 1].nr - i; /* calc # new */
-	itemsep(expand("nsep", DM_VAR), 0);
-	st_glob.r_current = tmp;
+    st_glob.r_current = sum[st_glob.i_current - 1].nr - i; /* calc # new */
+    itemsep(expand("nsep", DM_VAR), 0);
+    st_glob.r_current = tmp;
 }
 /******************************************************************************/
 /* SHOW CURRENT RESPONSE                                                      */
@@ -350,57 +352,56 @@ show_nsep(FILE *fp)
 void
 show_resp(FILE *fp)
 {
-	std::string buff;
-	int pr = 0;
+    std::string buff;
+    int pr = 0;
 
-	/* Get resp to initialize stats like %s (itemsep) */
-	get_resp(fp, &(re[st_glob.r_current]), (short)GR_HEADER, st_glob.r_current);
-	if (!(re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED))) {
-		get_resp(fp, &(re[st_glob.r_current]), (short)GR_ALL,
-		    st_glob.r_current);
-		if (re[st_glob.r_current].flags & RF_CENSORED)
-			pr = ((st_glob.opt_flags & OF_NOFORGET) ||
-			      !(flags & O_FORGET));
-		else
-			pr = 1;
-	}
-	if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
-	    re[st_glob.r_current].numchars > 7) {
-		fseek(fp, re[st_glob.r_current].textoff, 0);
-		ngets(buff, fp);
-		re[st_glob.r_current].text.clear();
-		re[st_glob.r_current].text.push_back(buff);
-	}
+    /* Get resp to initialize stats like %s (itemsep) */
+    get_resp(fp, &(re[st_glob.r_current]), (short)GR_HEADER, st_glob.r_current);
+    if (!(re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED))) {
+        get_resp(
+            fp, &(re[st_glob.r_current]), (short)GR_ALL, st_glob.r_current);
+        if (re[st_glob.r_current].flags & RF_CENSORED)
+            pr = ((st_glob.opt_flags & OF_NOFORGET) || !(flags & O_FORGET));
+        else
+            pr = 1;
+    }
+    if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
+        re[st_glob.r_current].numchars > 7) {
+        fseek(fp, re[st_glob.r_current].textoff, 0);
+        ngets(buff, fp);
+        re[st_glob.r_current].text.clear();
+        re[st_glob.r_current].text.push_back(buff);
+    }
 
-	/* Print response header */
-	if (st_glob.r_current) {
-		if (flags & O_LABEL)
-			sepinit(IS_PARENT | IS_CENSORED | IS_UID | IS_DATE);
-		itemsep(expand("rsep", DM_VAR), 0);
-	}
+    /* Print response header */
+    if (st_glob.r_current) {
+        if (flags & O_LABEL)
+            sepinit(IS_PARENT | IS_CENSORED | IS_UID | IS_DATE);
+        itemsep(expand("rsep", DM_VAR), 0);
+    }
 
-	/* Print response text */
-	/* read short could do response headers only to browse resps */
-	/* if (pr && !(st_glob.opt_flags & OF_int)) */
-	if (pr) {
-		if (!st_glob.r_current)
-			wfputc('\n', st_glob.outp);
-		for (st_glob.l_current = 0;
-		     st_glob.l_current < re[st_glob.r_current].text.size() &&
-		     !(status & S_INT);
-		     st_glob.l_current++) {
-			itemsep(expand("txtsep", DM_VAR), 0);
-		}
-	}
+    /* Print response text */
+    /* read short could do response headers only to browse resps */
+    /* if (pr && !(st_glob.opt_flags & OF_int)) */
+    if (pr) {
+        if (!st_glob.r_current)
+            wfputc('\n', st_glob.outp);
+        for (st_glob.l_current = 0;
+            st_glob.l_current < re[st_glob.r_current].text.size() &&
+            !(status & S_INT);
+            st_glob.l_current++) {
+            itemsep(expand("txtsep", DM_VAR), 0);
+        }
+    }
 
-	/* Unless response was scribbled (in which case text holds the
-	 * scribbler), free up the response text. */
-	if ((re[st_glob.r_current].flags & RF_SCRIBBLED) == 0)
-		re[st_glob.r_current].text.clear();
+    /* Unless response was scribbled (in which case text holds the
+     * scribbler), free up the response text. */
+    if ((re[st_glob.r_current].flags & RF_SCRIBBLED) == 0)
+        re[st_glob.r_current].text.clear();
 
-	/* Count it as seen */
-	if (st_glob.r_lastseen <= st_glob.r_current)
-		st_glob.r_lastseen = st_glob.r_current + 1;
+    /* Count it as seen */
+    if (st_glob.r_lastseen <= st_glob.r_current)
+        st_glob.r_lastseen = st_glob.r_current + 1;
 }
 /******************************************************************************/
 /* SHOW RANGE OF RESPONSES                                                    */
@@ -408,33 +409,34 @@ show_resp(FILE *fp)
 void
 show_range(void)
 {
-	if (st_glob.r_first > st_glob.r_last)
-		return; /* invalid range */
-	refresh_sum(st_glob.i_current, confidx, sum, part, &st_glob);
-	/* in case new reponses came */
-	st_glob.r_max = sum[st_glob.i_current - 1].nr - 1;
-	st_glob.r_current =
-	    sum[st_glob.i_current - 1].nr - abs(part[st_glob.i_current - 1].nr);
+    if (st_glob.r_first > st_glob.r_last)
+        return; /* invalid range */
+    refresh_sum(st_glob.i_current, confidx, sum, part, &st_glob);
+    /* in case new reponses came */
+    st_glob.r_max = sum[st_glob.i_current - 1].nr - 1;
+    st_glob.r_current =
+        sum[st_glob.i_current - 1].nr - abs(part[st_glob.i_current - 1].nr);
 
-	open_pipe();
-	const auto path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	FILE *fp = mopen(path, O_R);
-	if (fp != nullptr) {
-		/* For each response */
-		for (st_glob.r_current = st_glob.r_first;
-		     st_glob.r_current <= st_glob.r_last &&
-		     st_glob.r_current <= st_glob.r_max && !(status & S_INT);
-		     st_glob.r_current++) {
-			if (st_glob.r_first == 0 && st_glob.r_current == 1)
-				show_nsep(fp); /* nsep between resp 0 and 1 */
-			show_resp(fp);
-		}
-		status &= ~S_INT; /* Int terminates range */
+    open_pipe();
+    const auto path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    FILE *fp = mopen(path, O_R);
+    if (fp != nullptr) {
+        /* For each response */
+        for (st_glob.r_current = st_glob.r_first;
+            st_glob.r_current <= st_glob.r_last &&
+            st_glob.r_current <= st_glob.r_max && !(status & S_INT);
+            st_glob.r_current++) {
+            if (st_glob.r_first == 0 && st_glob.r_current == 1)
+                show_nsep(fp); /* nsep between resp 0 and 1 */
+            show_resp(fp);
+        }
+        status &= ~S_INT; /* Int terminates range */
 
-		mclose(fp);
-		st_glob.r_current--;
-		itemsep(expand("zsep", DM_VAR), 0);
-	}
+        mclose(fp);
+        st_glob.r_current--;
+        itemsep(expand("zsep", DM_VAR), 0);
+    }
 }
 /******************************************************************************/
 /* READ THE CURRENT ITEM                                                      */
@@ -442,164 +444,159 @@ show_range(void)
 void
 read_item(void)
 {
-	FILE *fp;
-	short i_lastseen; /* Macro for current item index */
-	std::string buff;
-	short oldnr, topt_flags;
-	long oldlast;
-	time_t tsince;
-	partentry_t oldpart;
-	sepinit(IS_ITEM);
-	if (flags & O_LABEL)
-		sepinit(IS_ALL);
-	i_lastseen = st_glob.i_current - 1;
-	memcpy(&oldpart, &part[i_lastseen], sizeof(oldpart));
-	oldnr = st_glob.r_lastseen = abs(part[i_lastseen].nr);
-	st_glob.r_current = 0;
-	oldlast = part[i_lastseen].last;
+    FILE *fp;
+    short i_lastseen; /* Macro for current item index */
+    std::string buff;
+    short oldnr, topt_flags;
+    long oldlast;
+    time_t tsince;
+    partentry_t oldpart;
+    sepinit(IS_ITEM);
+    if (flags & O_LABEL)
+        sepinit(IS_ALL);
+    i_lastseen = st_glob.i_current - 1;
+    memcpy(&oldpart, &part[i_lastseen], sizeof(oldpart));
+    oldnr = st_glob.r_lastseen = abs(part[i_lastseen].nr);
+    st_glob.r_current = 0;
+    oldlast = part[i_lastseen].last;
 
-	if (confidx < 0) return;
-	/* Open file */
-	const auto path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	if (!(fp = mopen(path, O_R)))
-		return;
-	if (!ngets(buff, fp) || !str::eq(buff, "!<ps02>")) {
-		wputs("Invalid _N file format\n");
-		mclose(fp);
-		return;
-	}
-	if (!ngets(buff, fp) || !buff.starts_with(",H")) {
-		wputs("Invalid _N file format\n");
-		mclose(fp);
-		return;
-	}
+    if (confidx < 0)
+        return;
+    /* Open file */
+    const auto path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    if (!(fp = mopen(path, O_R)))
+        return;
+    if (!ngets(buff, fp) || !str::eq(buff, "!<ps02>")) {
+        wputs("Invalid _N file format\n");
+        mclose(fp);
+        return;
+    }
+    if (!ngets(buff, fp) || !buff.starts_with(",H")) {
+        wputs("Invalid _N file format\n");
+        mclose(fp);
+        return;
+    }
 
-	/* Get all the response offsets       */
-	/* censor/scribble require this setup */
-	get_item(fp, st_glob.i_current, re, sum);
-	/* moved up here from above response set loop */
+    /* Get all the response offsets       */
+    /* censor/scribble require this setup */
+    get_item(fp, st_glob.i_current, re, sum);
+    /* moved up here from above response set loop */
 
-	get_resp(fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
-	if (st_glob.opt_flags & (OF_NEWRESP | OF_NORESPONSE))
-		st_glob.r_first = abs(part[i_lastseen].nr);
-	else if (st_glob.since) {
-		st_glob.r_first = 0;
-		while (st_glob.since > re[st_glob.r_first].date) {
-			st_glob.r_first++;
-			get_resp(fp, &(re[st_glob.r_first]), (short)GR_HEADER,
-			    st_glob.r_first);
-			if (st_glob.r_first >= sum[i_lastseen].nr)
-				break;
-		}
-	}
+    get_resp(fp, re, (short)GR_HEADER, (short)0); /* Get header of #0 */
+    if (st_glob.opt_flags & (OF_NEWRESP | OF_NORESPONSE))
+        st_glob.r_first = abs(part[i_lastseen].nr);
+    else if (st_glob.since) {
+        st_glob.r_first = 0;
+        while (st_glob.since > re[st_glob.r_first].date) {
+            st_glob.r_first++;
+            get_resp(
+                fp, &(re[st_glob.r_first]), (short)GR_HEADER, st_glob.r_first);
+            if (st_glob.r_first >= sum[i_lastseen].nr)
+                break;
+        }
+    }
 
-	/* Display item header */
-	open_pipe();
-	show_header();
+    /* Display item header */
+    open_pipe();
+    show_header();
 
-	st_glob.r_last = MAX_RESPONSES;
-	st_glob.r_max = sum[i_lastseen].nr - 1;
+    st_glob.r_last = MAX_RESPONSES;
+    st_glob.r_max = sum[i_lastseen].nr - 1;
 
-	/* For each response set */
-	if (!(st_glob.opt_flags & OF_NORESPONSE) &&
-	    st_glob.r_first <= st_glob.r_max) {
-		if (st_glob.r_first > 0)
-			show_nsep(fp); /* nsep between header and responses */
-		show_range();
-	} else
-		st_glob.r_current = st_glob.r_first; /* for -# command */
-	if (!(st_glob.opt_flags & OF_PASS))
-		status &= ~S_INT;
+    /* For each response set */
+    if (!(st_glob.opt_flags & OF_NORESPONSE) &&
+        st_glob.r_first <= st_glob.r_max) {
+        if (st_glob.r_first > 0)
+            show_nsep(fp); /* nsep between header and responses */
+        show_range();
+    } else
+        st_glob.r_current = st_glob.r_first; /* for -# command */
+    if (!(st_glob.opt_flags & OF_PASS))
+        status &= ~S_INT;
 
-	/* Save range info */
-	topt_flags = st_glob.opt_flags;
-	tsince = st_glob.since;
-	buff = st_glob.string;
-	ext_fp = fp;
-	ext_first = st_glob.r_first;
-	ext_last = st_glob.r_last;
+    /* Save range info */
+    topt_flags = st_glob.opt_flags;
+    tsince = st_glob.since;
+    buff = st_glob.string;
+    ext_fp = fp;
+    ext_first = st_glob.r_first;
+    ext_last = st_glob.r_last;
 
-	/* RFP loop until pass or EOF (S_STOP) */
-	while (!(status & S_STOP) && (st_glob.r_last >= 0)) {
+    /* RFP loop until pass or EOF (S_STOP) */
+    while (!(status & S_STOP) && (st_glob.r_last >= 0)) {
 
-		/* Temporarily mark seen, for forget command */
-		/* but DON'T mark this as dirty since it's temporary */
-		part[i_lastseen].nr = st_glob.r_lastseen;
-		if ((sum[i_lastseen].flags & IF_FORGOTTEN) &&
-		    part[i_lastseen].nr > 0)
-			part[i_lastseen].nr =
-			    -part[i_lastseen].nr; /* stay forgotten */
+        /* Temporarily mark seen, for forget command */
+        /* but DON'T mark this as dirty since it's temporary */
+        part[i_lastseen].nr = st_glob.r_lastseen;
+        if ((sum[i_lastseen].flags & IF_FORGOTTEN) && part[i_lastseen].nr > 0)
+            part[i_lastseen].nr = -part[i_lastseen].nr; /* stay forgotten */
 
-		/* Main RFP cmd loop */
-		mode = M_RFP;
-		{
-			short tmp_stat;
-			tmp_stat = st_glob.c_status;
-			if ((sum[i_lastseen].flags & IF_FROZEN) ||
-			    (flags & O_READONLY))
-				st_glob.c_status |= CS_NORESPONSE;
-			/* while (mode==M_RFP && !(status & S_INT)) */
-			/* test stop in case ^D hit */
-			while (mode == M_RFP && !(status & S_STOP)) {
-				if (st_glob.opt_flags & OF_PASS)
-					command("pass", 0);
-				else if (!get_command("pass", 0)) { /* eof */
-					/* status |= S_INT; WHY was
-					 * this here? */
-					if (!(status & S_STOP)) {
-						status |= S_STOP; /* instead */
-						if (!(flags & O_QUIET))
-							wputs("Stopping.\n");
-					}
-					mode = M_OK;
-					st_glob.r_last = -1;
+        /* Main RFP cmd loop */
+        mode = M_RFP;
+        {
+            short tmp_stat;
+            tmp_stat = st_glob.c_status;
+            if ((sum[i_lastseen].flags & IF_FROZEN) || (flags & O_READONLY))
+                st_glob.c_status |= CS_NORESPONSE;
+            /* while (mode==M_RFP && !(status & S_INT)) */
+            /* test stop in case ^D hit */
+            while (mode == M_RFP && !(status & S_STOP)) {
+                if (st_glob.opt_flags & OF_PASS)
+                    command("pass", 0);
+                else if (!get_command("pass", 0)) { /* eof */
+                    /* status |= S_INT; WHY was
+                     * this here? */
+                    if (!(status & S_STOP)) {
+                        status |= S_STOP; /* instead */
+                        if (!(flags & O_QUIET))
+                            wputs("Stopping.\n");
+                    }
+                    mode = M_OK;
+                    st_glob.r_last = -1;
 
-					if (st_glob.opt_flags & OF_REVERSE)
-						st_glob.i_current =
-						    st_glob.i_first;
-					else
-						st_glob.i_current =
-						    st_glob.i_last;
-				}
-			}
-			st_glob.c_status = tmp_stat;
-		}
-	}
-	/* KKK what if new items come in? */
+                    if (st_glob.opt_flags & OF_REVERSE)
+                        st_glob.i_current = st_glob.i_first;
+                    else
+                        st_glob.i_current = st_glob.i_last;
+                }
+            }
+            st_glob.c_status = tmp_stat;
+        }
+    }
+    /* KKK what if new items come in? */
 
-	/* Save range info */
-	st_glob.opt_flags = topt_flags;
-	st_glob.since = tsince;
-	st_glob.string = buff;
+    /* Save range info */
+    st_glob.opt_flags = topt_flags;
+    st_glob.since = tsince;
+    st_glob.string = buff;
 
-	/* Save to lastseen */
-	/* 4/18 added NORESP check so that timestamp is only updated if they
-	 * actually saw the responses.  Thus, "browse new" doesn't make things
-	 * un-new for set sensitive. */
-	if (!(st_glob.opt_flags & OF_NORESPONSE) &&
-	    (st_glob.r_last > -2)) { /* unless preserved or forgotten */
-		part[i_lastseen].nr = st_glob.r_lastseen;
-		if ((sum[i_lastseen].flags & IF_FORGOTTEN) &&
-		    part[i_lastseen].nr > 0)
-			part[i_lastseen].nr =
-			    -part[i_lastseen].nr; /* stay forgotten */
-		if (abs(part[i_lastseen].nr) == sum[i_lastseen].nr)
-			time(&(part[i_lastseen].last));
-		if (flags & O_AUTOSAVE) {
-			const auto config = get_config(confidx);
-			if (config.size() > CF_PARTFILE)
-				write_part(config[CF_PARTFILE]);
-		}
-	} else if (st_glob.r_last == -2) { /* unless preserved or
-		                            * forgotten */
-		part[i_lastseen].nr = oldnr;
-		part[i_lastseen].last = oldlast;
-	}
-	if (memcmp(&oldpart, &part[i_lastseen], sizeof(oldpart)))
-		dirty_part(i_lastseen);
+    /* Save to lastseen */
+    /* 4/18 added NORESP check so that timestamp is only updated if they
+     * actually saw the responses.  Thus, "browse new" doesn't make things
+     * un-new for set sensitive. */
+    if (!(st_glob.opt_flags & OF_NORESPONSE) &&
+        (st_glob.r_last > -2)) { /* unless preserved or forgotten */
+        part[i_lastseen].nr = st_glob.r_lastseen;
+        if ((sum[i_lastseen].flags & IF_FORGOTTEN) && part[i_lastseen].nr > 0)
+            part[i_lastseen].nr = -part[i_lastseen].nr; /* stay forgotten */
+        if (abs(part[i_lastseen].nr) == sum[i_lastseen].nr)
+            time(&(part[i_lastseen].last));
+        if (flags & O_AUTOSAVE) {
+            const auto config = get_config(confidx);
+            if (config.size() > CF_PARTFILE)
+                write_part(config[CF_PARTFILE]);
+        }
+    } else if (st_glob.r_last == -2) { /* unless preserved or
+                                        * forgotten */
+        part[i_lastseen].nr = oldnr;
+        part[i_lastseen].last = oldlast;
+    }
+    if (memcmp(&oldpart, &part[i_lastseen], sizeof(oldpart)))
+        dirty_part(i_lastseen);
 
-	/* Must be kept open past RFP mode so 'since' command can access it */
-	mclose(fp);
+    /* Must be kept open past RFP mode so 'since' command can access it */
+    mclose(fp);
 }
 /*
  * Same as usual item read progression EXCEPT it ignores the numerical
@@ -609,14 +606,13 @@ read_item(void)
 int
 nextitem(int inc)
 {
-	int i;
-	for (i = st_glob.i_current + inc;
-	     i >= st_glob.i_first && i <= st_glob.i_last; i += inc) {
-		if (cover(i, confidx, st_glob.opt_flags, A_COVER, sum, part,
-		        &st_glob))
-			return i;
-	}
-	return -1;
+    int i;
+    for (i = st_glob.i_current + inc;
+        i >= st_glob.i_first && i <= st_glob.i_last; i += inc) {
+        if (cover(i, confidx, st_glob.opt_flags, A_COVER, sum, part, &st_glob))
+            return i;
+    }
+    return -1;
 }
 /******************************************************************************/
 /* READ A SET OF ITEMS IN THE CONFERENCE                                      */
@@ -627,68 +623,66 @@ do_read(        /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	short i_s, i_i, shown = 0, rfirst = 0, br;
-	char act[MAX_ITEMS];
+    short i_s, i_i, shown = 0, rfirst = 0, br;
+    char act[MAX_ITEMS];
 
-	br = (match(argv[0], "b_rowse") || match(argv[0], "s_can"));
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	st_glob.r_first = 0;
-	st_glob.opt_flags = (br) ? OF_int | OF_NORESPONSE | OF_PASS : 0;
+    br = (match(argv[0], "b_rowse") || match(argv[0], "s_can"));
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    st_glob.r_first = 0;
+    st_glob.opt_flags = (br) ? OF_int | OF_NORESPONSE | OF_PASS : 0;
 
-	/* Check arguments */
-	if (argc > 1)
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    /* Check arguments */
+    if (argc > 1)
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
 
-	if (!(st_glob.opt_flags & OF_RANGE)) {
-		rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
-		if (!(st_glob.opt_flags &
-		        (OF_UNSEEN | OF_FORGOTTEN | OF_RETIRED | OF_NEWRESP |
-		            OF_BRANDNEW)) &&
-		    !st_glob.since && !br) {
-			rangetoken(
-			    "new", &st_glob.opt_flags, act, sum, &st_glob);
-		}
-	}
-	if (st_glob.opt_flags & OF_REVERSE) {
-		i_s = st_glob.i_last;
-		i_i = -1;
-	} else {
-		i_s = st_glob.i_first;
-		i_i = 1;
-	}
-	rfirst = st_glob.r_first;
+    if (!(st_glob.opt_flags & OF_RANGE)) {
+        rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
+        if (!(st_glob.opt_flags & (OF_UNSEEN | OF_FORGOTTEN | OF_RETIRED |
+                                      OF_NEWRESP | OF_BRANDNEW)) &&
+            !st_glob.since && !br) {
+            rangetoken("new", &st_glob.opt_flags, act, sum, &st_glob);
+        }
+    }
+    if (st_glob.opt_flags & OF_REVERSE) {
+        i_s = st_glob.i_last;
+        i_i = -1;
+    } else {
+        i_s = st_glob.i_first;
+        i_i = 1;
+    }
+    rfirst = st_glob.r_first;
 
-	if (match(argv[0], "pr_int"))
-		confsep(expand("printmsg", DM_VAR), confidx, &st_glob, part, 0);
+    if (match(argv[0], "pr_int"))
+        confsep(expand("printmsg", DM_VAR), confidx, &st_glob, part, 0);
 
-	/* Process items */
-	sepinit(IS_START);
+    /* Process items */
+    sepinit(IS_START);
 
-	for (st_glob.i_current = i_s;
-	     st_glob.i_current >= st_glob.i_first &&
-	     st_glob.i_current <= st_glob.i_last && !(status & S_INT);
-	     st_glob.i_current += i_i) {
-		if (cover(st_glob.i_current, confidx, st_glob.opt_flags,
-		        act[st_glob.i_current - 1], sum, part, &st_glob)) {
-			st_glob.i_next = nextitem(1);
-			st_glob.i_prev = nextitem(-1);
-			st_glob.r_first = rfirst;
-			read_item();
-			shown++;
-			if (match(argv[0], "pr_int"))
-				wputs("^L\n");
-		}
-	}
-	if (!shown && (st_glob.opt_flags & (OF_BRANDNEW | OF_NEWRESP))) {
-		wputs(std::format("No new {}s matched.\n", topic()));
-	}
+    for (st_glob.i_current = i_s;
+        st_glob.i_current >= st_glob.i_first &&
+        st_glob.i_current <= st_glob.i_last && !(status & S_INT);
+        st_glob.i_current += i_i) {
+        if (cover(st_glob.i_current, confidx, st_glob.opt_flags,
+                act[st_glob.i_current - 1], sum, part, &st_glob)) {
+            st_glob.i_next = nextitem(1);
+            st_glob.i_prev = nextitem(-1);
+            st_glob.r_first = rfirst;
+            read_item();
+            shown++;
+            if (match(argv[0], "pr_int"))
+                wputs("^L\n");
+        }
+    }
+    if (!shown && (st_glob.opt_flags & (OF_BRANDNEW | OF_NEWRESP))) {
+        wputs(std::format("No new {}s matched.\n", topic()));
+    }
 
-	/* Check for new mail only */
-	refresh_stats(sum, part, &st_glob);
-	check_mail(0);
+    /* Check for new mail only */
+    refresh_stats(sum, part, &st_glob);
+    check_mail(0);
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* FORGET A SET OF ITEMS IN THE CONFERENCE                                    */
@@ -699,38 +693,39 @@ forget(         /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    char act[MAX_ITEMS];
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc < 2) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
-		if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
-		        &st_glob)) {
-			if (!part[j - 1].nr) {
-				/* Pretend we've read the initial text */
-				part[j - 1].nr = 1;
-				dirty_part(j - 1);
-			}
-			if (!(sum[j - 1].flags & IF_FORGOTTEN)) {
-				if (!(flags & O_QUIET))
-					std::println("Forgetting {} {}", topic(), j);
-				st_glob.r_lastseen = part[j - 1].nr = -part[j - 1].nr;
-				sum[j - 1].flags |= IF_FORGOTTEN;
-				time(&(part[j - 1].last)); /* current time */
-				dirty_part(j - 1);
-				dirty_sum(j - 1);
-			}
-		}
-	}
-	st_glob.r_last = -1; /* go on to next item if at RFP prompt */
-	return 1;
+    /* Process items */
+    for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
+        j++) {
+        if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
+                &st_glob)) {
+            if (!part[j - 1].nr) {
+                /* Pretend we've read the initial text */
+                part[j - 1].nr = 1;
+                dirty_part(j - 1);
+            }
+            if (!(sum[j - 1].flags & IF_FORGOTTEN)) {
+                if (!(flags & O_QUIET))
+                    std::println("Forgetting {} {}", topic(), j);
+                st_glob.r_lastseen = part[j - 1].nr = -part[j - 1].nr;
+                sum[j - 1].flags |= IF_FORGOTTEN;
+                time(&(part[j - 1].last)); /* current time */
+                dirty_part(j - 1);
+                dirty_sum(j - 1);
+            }
+        }
+    }
+    st_glob.r_last = -1; /* go on to next item if at RFP prompt */
+    return 1;
 }
 /******************************************************************************/
 /* LOCATE A WORD OR GROUP OF WORDS IN A CONFERENCE                            */
@@ -741,109 +736,114 @@ do_find(        /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS], pr;
-	std::string str, astr;
-	short icur;
-	size_t j;
-	FILE *fp;
-	int count = 0;
-	icur = st_glob.i_current;
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    char act[MAX_ITEMS], pr;
+    std::string str, astr;
+    short icur;
+    size_t j;
+    FILE *fp;
+    int count = 0;
+    icur = st_glob.i_current;
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc > 1) /* Process argc */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	if (!(st_glob.opt_flags & OF_RANGE))
-		rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
+    if (argc > 1) /* Process argc */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    if (!(st_glob.opt_flags & OF_RANGE))
+        rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
 
-	if (st_glob.string.empty() && st_glob.author.empty()) {
-		if (!(flags & O_QUIET))
-			wputs("Find: look for what?\n");
-		return 1;
-	}
-	str = st_glob.string;  /* so items match */
-	astr = st_glob.author; /* so items match */
-	lower_case(str);
-	lower_case(astr);
-	st_glob.string.clear();
-	st_glob.author.clear();
+    if (st_glob.string.empty() && st_glob.author.empty()) {
+        if (!(flags & O_QUIET))
+            wputs("Find: look for what?\n");
+        return 1;
+    }
+    str = st_glob.string;  /* so items match */
+    astr = st_glob.author; /* so items match */
+    lower_case(str);
+    lower_case(astr);
+    st_glob.string.clear();
+    st_glob.author.clear();
 
-	/* Process items */
-	open_pipe();
-	sepinit(IS_START);
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
-		st_glob.i_current = j;
-		if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part, &st_glob)) {
-			const auto path = std::format("{}/_{}", conflist[confidx].location, j);
-			if (!(fp = mopen(path, O_R)))
-				continue;
-			get_item(fp, j, re, sum);
-			sepinit(IS_ITEM);
-			if (flags & O_LABEL)
-				sepinit(IS_ALL);
+    /* Process items */
+    open_pipe();
+    sepinit(IS_START);
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        st_glob.i_current = j;
+        if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
+                &st_glob)) {
+            const auto path =
+                std::format("{}/_{}", conflist[confidx].location, j);
+            if (!(fp = mopen(path, O_R)))
+                continue;
+            get_item(fp, j, re, sum);
+            sepinit(IS_ITEM);
+            if (flags & O_LABEL)
+                sepinit(IS_ALL);
 
-			/* For each response */
-			for (st_glob.r_current = 0;
-			     st_glob.r_current < sum[j - 1].nr &&
-			     !(status & S_INT);
-			     st_glob.r_current++) {
+            /* For each response */
+            for (st_glob.r_current = 0;
+                st_glob.r_current < sum[j - 1].nr && !(status & S_INT);
+                st_glob.r_current++) {
 
-				get_resp(fp, &(re[st_glob.r_current]),
-				    (short)GR_HEADER, st_glob.r_current);
+                get_resp(fp, &(re[st_glob.r_current]), (short)GR_HEADER,
+                    st_glob.r_current);
 
-				/* Scan response text */
-				if (re[st_glob.r_current].flags &
-				    (RF_EXPIRED | RF_SCRIBBLED))
-					pr = 0;
-				else if (re[st_glob.r_current].flags &
-				         RF_CENSORED)
-					pr = ((st_glob.opt_flags &
-					          OF_NOFORGET) ||
-					      !(flags & O_FORGET));
-				else
-					pr = 1;
+                /* Scan response text */
+                if (re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED))
+                    pr = 0;
+                else if (re[st_glob.r_current].flags & RF_CENSORED)
+                    pr = ((st_glob.opt_flags & OF_NOFORGET) ||
+                          !(flags & O_FORGET));
+                else
+                    pr = 1;
 
-				if (pr) {
-					get_resp(fp, &(re[st_glob.r_current]),
-					    (short)GR_ALL, st_glob.r_current);
-					sepinit(IS_RESP);
+                if (pr) {
+                    get_resp(fp, &(re[st_glob.r_current]), (short)GR_ALL,
+                        st_glob.r_current);
+                    sepinit(IS_RESP);
 
-					if (astr.empty() ||
-					    str::eq(re[st_glob.r_current].login, astr)) {
-						if (!str.empty()) {
-							for (st_glob.l_current = 0;
-							    !(status & S_INT) && st_glob.l_current < re[st_glob.r_current].text.size();
-							    st_glob.l_current++) {
-								if (strstr(lower_case(re[st_glob.r_current].text[st_glob.l_current]).c_str(), str.c_str())) {
-									itemsep(expand("fsep", DM_VAR), 0);
-									count++;
-								}
-							}
-						} else {
-							st_glob.l_current = 0;
-							itemsep(expand("fsep", DM_VAR), 0);
-							count++;
-						}
-					}
-					re[st_glob.r_current].text.clear();
-				}
-			}
-			mclose(fp);
-		}
-	}
+                    if (astr.empty() ||
+                        str::eq(re[st_glob.r_current].login, astr)) {
+                        if (!str.empty()) {
+                            for (st_glob.l_current = 0;
+                                !(status & S_INT) &&
+                                st_glob.l_current <
+                                    re[st_glob.r_current].text.size();
+                                st_glob.l_current++) {
+                                if (strstr(
+                                        lower_case(re[st_glob.r_current]
+                                                       .text[st_glob.l_current])
+                                            .c_str(),
+                                        str.c_str())) {
+                                    itemsep(expand("fsep", DM_VAR), 0);
+                                    count++;
+                                }
+                            }
+                        } else {
+                            st_glob.l_current = 0;
+                            itemsep(expand("fsep", DM_VAR), 0);
+                            count++;
+                        }
+                    }
+                    re[st_glob.r_current].text.clear();
+                }
+            }
+            mclose(fp);
+        }
+    }
 
-	/* Reload initial re[] contents */
-	st_glob.i_current = icur;
-	if (icur >= st_glob.i_first && icur <= st_glob.i_last) {
-		const auto path = std::format("{}/_{}", conflist[confidx].location, icur);
-		if ((fp = mopen(path, O_R)) != NULL) {
-			get_item(fp, j, re, sum);
-			mclose(fp);
-		}
-	}
-	if (!count)
-		wputs("No matches found.\n");
-	return 1;
+    /* Reload initial re[] contents */
+    st_glob.i_current = icur;
+    if (icur >= st_glob.i_first && icur <= st_glob.i_last) {
+        const auto path =
+            std::format("{}/_{}", conflist[confidx].location, icur);
+        if ((fp = mopen(path, O_R)) != NULL) {
+            get_item(fp, j, re, sum);
+            mclose(fp);
+        }
+    }
+    if (!count)
+        wputs("No matches found.\n");
+    return 1;
 }
 /******************************************************************************/
 /* FREEZE/THAW/RETIRE/UNRETIRE A SET OF ITEMS IN THE CONFERENCE               */
@@ -854,78 +854,76 @@ freeze(         /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	short j;
-	struct stat stt;
-	rangeinit(&st_glob, act);
+    char act[MAX_ITEMS];
+    short j;
+    struct stat stt;
+    rangeinit(&st_glob, act);
 
-	if (argc < 2) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
-	     j++) {
-		if (!act[j - 1] || !sum[j - 1].flags)
-			continue;
-		const auto path = std::format("{}/_{}", conflist[confidx].location, j);
-		st_glob.i_current = j;
+    /* Process items */
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        if (!act[j - 1] || !sum[j - 1].flags)
+            continue;
+        const auto path = std::format("{}/_{}", conflist[confidx].location, j);
+        st_glob.i_current = j;
 
-		/* Check for permission */
-		if (!(st_glob.c_status & CS_FW) && !is_enterer(j)) {
-			std::println("You can't do that!");
-			continue;
-		}
-		if (!match(get_conf_param("freezelinked", FREEZE_LINKED),
-		        "true")) {
-			if ((sum[j - 1].flags & IF_LINKED) &&
-			    (re[0].uid != uid || !str::eq(re[0].login, login))) {
-				std::println("{} {} is linked!", topic(1), j);
-				continue;
-			}
-		}
+        /* Check for permission */
+        if (!(st_glob.c_status & CS_FW) && !is_enterer(j)) {
+            std::println("You can't do that!");
+            continue;
+        }
+        if (!match(get_conf_param("freezelinked", FREEZE_LINKED), "true")) {
+            if ((sum[j - 1].flags & IF_LINKED) &&
+                (re[0].uid != uid || !str::eq(re[0].login, login))) {
+                std::println("{} {} is linked!", topic(1), j);
+                continue;
+            }
+        }
 
-		/* Do the change */
-		if (stat(path.c_str(), &stt)) {
-			std::println("Error accessing {}", path);
-			continue;
-		}
-		switch (tolower(argv[0][0])) {
-		case 'f': /* Freeze   r--r--r-- */
-			sum[j - 1].flags |= IF_FROZEN;
-			if (chmod(path.c_str(), stt.st_mode & ~S_IWUSR))
-				error("freezing ", path);
-			else
-				custom_log("freeze", M_RFP);
-			break;
-		case 't': /* Thaw     rw-r--r-- */
-			sum[j - 1].flags &= ~IF_FROZEN;
-			if (chmod(path.c_str(), stt.st_mode | S_IWUSR))
-				error("thawing ", path);
-			else
-				custom_log("thaw", M_RFP);
-			break;
-		case 'r': /* Retire   r-xr--r-- F,R */
-			sum[j - 1].flags |= IF_RETIRED;
-			if (chmod(path.c_str(), stt.st_mode | S_IXUSR))
-				error("retiring ", path);
-			else
-				custom_log("retire", M_RFP);
-			break;
-		case 'u': /* Unretire rw-r--r-- */
-			sum[j - 1].flags &= ~IF_RETIRED;
-			if (chmod(path.c_str(), stt.st_mode & ~S_IXUSR))
-				error("unretiring ", path);
-			else
-				custom_log("unretire", M_RFP);
-			break;
-		}
-		save_sum(sum, (short)(j - 1), confidx, &st_glob);
-		dirty_sum(j - 1);
-	}
-	return 1;
+        /* Do the change */
+        if (stat(path.c_str(), &stt)) {
+            std::println("Error accessing {}", path);
+            continue;
+        }
+        switch (tolower(argv[0][0])) {
+        case 'f': /* Freeze   r--r--r-- */
+            sum[j - 1].flags |= IF_FROZEN;
+            if (chmod(path.c_str(), stt.st_mode & ~S_IWUSR))
+                error("freezing ", path);
+            else
+                custom_log("freeze", M_RFP);
+            break;
+        case 't': /* Thaw     rw-r--r-- */
+            sum[j - 1].flags &= ~IF_FROZEN;
+            if (chmod(path.c_str(), stt.st_mode | S_IWUSR))
+                error("thawing ", path);
+            else
+                custom_log("thaw", M_RFP);
+            break;
+        case 'r': /* Retire   r-xr--r-- F,R */
+            sum[j - 1].flags |= IF_RETIRED;
+            if (chmod(path.c_str(), stt.st_mode | S_IXUSR))
+                error("retiring ", path);
+            else
+                custom_log("retire", M_RFP);
+            break;
+        case 'u': /* Unretire rw-r--r-- */
+            sum[j - 1].flags &= ~IF_RETIRED;
+            if (chmod(path.c_str(), stt.st_mode & ~S_IXUSR))
+                error("unretiring ", path);
+            else
+                custom_log("unretire", M_RFP);
+            break;
+        }
+        save_sum(sum, (short)(j - 1), confidx, &st_glob);
+        dirty_sum(j - 1);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* LINK AN ITEM INTO THE CONFERENCE                                           */
@@ -936,90 +934,90 @@ linkfrom(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	short idx, i, j;
-	/* unsigned int sec; */
-	sumentry_t fr_sum[MAX_ITEMS];
-	char act[MAX_ITEMS];
-	status_t fr_st{};
-	partentry_t part2[MAX_ITEMS];
-	st_glob.opt_flags = 0;
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (!(st_glob.c_status & CS_FW)) {
-		std::println("Sorry, you can't do that!");
-		return 1;
-	}
-	if (argc < 2) {
-		std::println("No {} specified!", conference());
-		return 1;
-	}
-	idx = get_idx(argv[1], conflist);
-	if (idx < 0) {
-		std::println("Cannot access {} {}.", conference(), argv[1]);
-		return 1;
-	}
+    short idx, i, j;
+    /* unsigned int sec; */
+    sumentry_t fr_sum[MAX_ITEMS];
+    char act[MAX_ITEMS];
+    status_t fr_st{};
+    partentry_t part2[MAX_ITEMS];
+    st_glob.opt_flags = 0;
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (!(st_glob.c_status & CS_FW)) {
+        std::println("Sorry, you can't do that!");
+        return 1;
+    }
+    if (argc < 2) {
+        std::println("No {} specified!", conference());
+        return 1;
+    }
+    idx = get_idx(argv[1], conflist);
+    if (idx < 0) {
+        std::println("Cannot access {} {}.", conference(), argv[1]);
+        return 1;
+    }
 
-	/* Pass security checks (from join() in conf.c) */
-	if (!check_acl(JOIN_RIGHT, idx) || !check_acl(RESPOND_RIGHT, idx)) {
-		std::println("You are not allowed to link {}s from the {} {}.",
-		    compress(conflist[idx].name), topic(), conference());
-		return 1;
-	}
+    /* Pass security checks (from join() in conf.c) */
+    if (!check_acl(JOIN_RIGHT, idx) || !check_acl(RESPOND_RIGHT, idx)) {
+        std::println("You are not allowed to link {}s from the {} {}.",
+            compress(conflist[idx].name), topic(), conference());
+        return 1;
+    }
 
-	/* Get item range */
-	if (argc < 3) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-		return 1;
-	}
-	/* Read in config file */
-	const auto config = get_config(idx);
-	if (config.size() <= CF_PARTFILE)
-		return 1;
+    /* Get item range */
+    if (argc < 3) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+        return 1;
+    }
+    /* Read in config file */
+    const auto config = get_config(idx);
+    if (config.size() <= CF_PARTFILE)
+        return 1;
 
 #ifdef NEWS
-	fr_st.c_article = 0;
+    fr_st.c_article = 0;
 #endif
 
-	/* Read in partfile */
-	read_part(config[CF_PARTFILE], part2, &fr_st, idx);
-	fr_st.c_security = security_type(config, idx);
-	rangeinit(&fr_st, act);
+    /* Read in partfile */
+    read_part(config[CF_PARTFILE], part2, &fr_st, idx);
+    fr_st.c_security = security_type(config, idx);
+    rangeinit(&fr_st, act);
 
-	/* get subjs for range */
-	get_status(&fr_st, fr_sum, part2, idx);
+    /* get subjs for range */
+    get_status(&fr_st, fr_sum, part2, idx);
 
-	range(argc, argv, &st_glob.opt_flags, act, fr_sum, &fr_st, 1);
+    range(argc, argv, &st_glob.opt_flags, act, fr_sum, &fr_st, 1);
 
-	/* Process items */
-	for (j = fr_st.i_first; j <= fr_st.i_last && !(status & S_INT); j++) {
-		if (!cover(j, idx, st_glob.opt_flags, act[j - 1], fr_sum, part2,
-		        &fr_st))
-			continue;
+    /* Process items */
+    for (j = fr_st.i_first; j <= fr_st.i_last && !(status & S_INT); j++) {
+        if (!cover(
+                j, idx, st_glob.opt_flags, act[j - 1], fr_sum, part2, &fr_st))
+            continue;
 
-		const auto from_path = std::format("{}/_{}", conflist[idx].location, j);
-		i = ++(st_glob.c_confitems); /* next item number */
-		std::print("Linking as {} {}...", topic(), i);
-		const auto to_path = std::format("{}/_{}", conflist[confidx].location, i);
-		if (link(from_path.c_str(), to_path.c_str()) != 0 &&
-		    symlink(from_path.c_str(), to_path.c_str()) != 0)
-			error("linking from ", from_path);
-		else {
-			fr_sum[j - 1].flags |= IF_LINKED;
-			memcpy(&(sum[i - 1]), &(fr_sum[j - 1]),
-			    sizeof(sumentry_t));
-			save_sum(fr_sum, (short)(j - 1), idx, &fr_st);
-			save_sum(sum, (short)(i - 1), confidx, &st_glob);
-			dirty_sum(i - 1);
+        const auto from_path = std::format("{}/_{}", conflist[idx].location, j);
+        i = ++(st_glob.c_confitems); /* next item number */
+        std::print("Linking as {} {}...", topic(), i);
+        const auto to_path =
+            std::format("{}/_{}", conflist[confidx].location, i);
+        if (link(from_path.c_str(), to_path.c_str()) != 0 &&
+            symlink(from_path.c_str(), to_path.c_str()) != 0)
+            error("linking from ", from_path);
+        else {
+            fr_sum[j - 1].flags |= IF_LINKED;
+            memcpy(&(sum[i - 1]), &(fr_sum[j - 1]), sizeof(sumentry_t));
+            save_sum(fr_sum, (short)(j - 1), idx, &fr_st);
+            save_sum(sum, (short)(i - 1), confidx, &st_glob);
+            dirty_sum(i - 1);
 
-			/* Log action to both conferences */
-			ylog(idx, std::format("linked {} {} to {} {}",
-			    topic(), j, compress(conflist[confidx].name), i));
-			ylog(confidx, std::format("linked {} {} from {} {}",
-			    topic(), i, compress(conflist[idx].name), j));
+            /* Log action to both conferences */
+            ylog(idx, std::format("linked {} {} to {} {}", topic(), j,
+                          compress(conflist[confidx].name), i));
+            ylog(confidx, std::format("linked {} {} from {} {}", topic(), i,
+                              compress(conflist[idx].name), j));
 
-			std::println("done.");
-		}
-	}
-	return 1;
+            std::println("done.");
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* KILL A SET OF ITEMS IN THE CONFERENCE                                      */
@@ -1030,51 +1028,50 @@ do_kill(        /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	short j;
-	FILE *fp;
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    char act[MAX_ITEMS];
+    short j;
+    FILE *fp;
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc < 2) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
-	     j++) {
-		if (!act[j - 1] || !sum[j - 1].flags)
-			continue;
-		const auto path = std::format("{}/_{}", conflist[confidx].location, j);
+    /* Process items */
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        if (!act[j - 1] || !sum[j - 1].flags)
+            continue;
+        const auto path = std::format("{}/_{}", conflist[confidx].location, j);
 
-		/* Check for permission */
-		if (!(st_glob.c_status & CS_FW)) {
-			if (!(fp = mopen(path, O_R)))
-				continue;
-			get_item(fp, j, re, sum);
-			mclose(fp);
-			if (re[0].uid != uid || !str::eq(re[0].login, login) ||
-			    sum[j - 1].nr > 1) {
-				wputs("You can't do that!\n");
-				continue;
-			}
-		}
+        /* Check for permission */
+        if (!(st_glob.c_status & CS_FW)) {
+            if (!(fp = mopen(path, O_R)))
+                continue;
+            get_item(fp, j, re, sum);
+            mclose(fp);
+            if (re[0].uid != uid || !str::eq(re[0].login, login) ||
+                sum[j - 1].nr > 1) {
+                wputs("You can't do that!\n");
+                continue;
+            }
+        }
 
-		/* Do the remove */
-		const auto prompt = std::format("Ok to kill {} {}? ", topic(), j);
-		if (get_yes(prompt, false)) {
-			std::println("(Killing {} {})", topic(), j);
-			rm(path, SL_OWNER);
-			sum[j - 1].flags = 0;
-			save_sum(sum, (short)(j - 1), confidx, &st_glob);
-			dirty_sum(j - 1);
-			custom_log("kill", M_RFP);
-		}
-	}
-	st_glob.r_last = -1; /* go on to next item if at RFP prompt */
-	return 1;
+        /* Do the remove */
+        const auto prompt = std::format("Ok to kill {} {}? ", topic(), j);
+        if (get_yes(prompt, false)) {
+            std::println("(Killing {} {})", topic(), j);
+            rm(path, SL_OWNER);
+            sum[j - 1].flags = 0;
+            save_sum(sum, (short)(j - 1), confidx, &st_glob);
+            dirty_sum(j - 1);
+            custom_log("kill", M_RFP);
+        }
+    }
+    st_glob.r_last = -1; /* go on to next item if at RFP prompt */
+    return 1;
 }
 /******************************************************************************/
 /* REMEMBER (UNFORGET) A SET OF ITEMS IN THE CONFERENCE                       */
@@ -1085,28 +1082,27 @@ remember(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	short j;
-	/* Initialize range */
-	rangeinit(&st_glob, act);
+    char act[MAX_ITEMS];
+    short j;
+    /* Initialize range */
+    rangeinit(&st_glob, act);
 
-	/* Process arguments */
-	if (argc < 2)
-		rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
-	else
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    /* Process arguments */
+    if (argc < 2)
+        rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
+    else
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
 
-	/* Process items in specified range */
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
-	     j++) {
-		if (!act[j - 1] || !sum[j - 1].flags)
-			continue;
-		part[j - 1].nr = abs(part[j - 1].nr);
-		sum[j - 1].flags &= ~IF_FORGOTTEN;
-		dirty_part(j - 1);
-		dirty_sum(j - 1);
-	}
-	return 1;
+    /* Process items in specified range */
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        if (!act[j - 1] || !sum[j - 1].flags)
+            continue;
+        part[j - 1].nr = abs(part[j - 1].nr);
+        sum[j - 1].flags &= ~IF_FORGOTTEN;
+        dirty_part(j - 1);
+        dirty_sum(j - 1);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* MARK A SET OF ITEMS AS BEING SEEN                                          */
@@ -1117,28 +1113,27 @@ fixseen(        /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	short j;
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    char act[MAX_ITEMS];
+    short j;
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc < 2) {
-		rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
-	     j++) {
-		if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
-		        &st_glob)) {
-			part[j - 1].nr = sum[j - 1].nr;
-			time(&(part[j - 1].last)); /* or sum.last? */
-			dirty_part(j - 1);
-		}
-	}
-	return 1;
+    /* Process items */
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        if (cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
+                &st_glob)) {
+            part[j - 1].nr = sum[j - 1].nr;
+            time(&(part[j - 1].last)); /* or sum.last? */
+            dirty_part(j - 1);
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* MARK A SET OF RESPONSES AS BEING SEEN                                      */
@@ -1148,54 +1143,54 @@ fixto(int argc, /* IN: Number of arguments */
     char **argv /* IN: Argument list       */
 )
 {
-	char act[MAX_ITEMS];
-	size_t j = 0;
-	int r;
-	time_t stamp;
+    char act[MAX_ITEMS];
+    size_t j = 0;
+    int r;
+    time_t stamp;
 
-	std::vector<std::string> args;
-	for (auto i = 0; i < argc; i++)
-		args.push_back(argv[i]);
-	stamp = since(args, &j);
-	argc -= j;
-	argv += j;
+    std::vector<std::string> args;
+    for (auto i = 0; i < argc; i++) args.push_back(argv[i]);
+    stamp = since(args, &j);
+    argc -= j;
+    argv += j;
 
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc < 2) {
-		rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
-	} else { /* Process args */
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	}
+    if (argc < 2) {
+        rangetoken("all", &st_glob.opt_flags, act, sum, &st_glob);
+    } else { /* Process args */
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
-		if (!cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
-		        &st_glob) ||
-		    !sum[j - 1].nr || part[j - 1].nr < 0)
-			continue;
+    /* Process items */
+    for (auto j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
+        j++) {
+        if (!cover(j, confidx, st_glob.opt_flags, act[j - 1], sum, part,
+                &st_glob) ||
+            !sum[j - 1].nr || part[j - 1].nr < 0)
+            continue;
 
-		/* Load response times */
-		const auto path = std::format("{}/_{}", conflist[confidx].location, j);
-		FILE *fp = mopen(path, O_R);
-		if (fp != NULL) {
-			get_item(fp, j, re, sum);
+        /* Load response times */
+        const auto path = std::format("{}/_{}", conflist[confidx].location, j);
+        FILE *fp = mopen(path, O_R);
+        if (fp != NULL) {
+            get_item(fp, j, re, sum);
 
-			/* Find first response # which is dated > timestamp */
-			for (r = 0; r < sum[j - 1].nr; r++) {
-				get_resp(fp, &re[r], (short)GR_HEADER, r);
-				if (re[r].date > stamp)
-					break;
-			}
+            /* Find first response # which is dated > timestamp */
+            for (r = 0; r < sum[j - 1].nr; r++) {
+                get_resp(fp, &re[r], (short)GR_HEADER, r);
+                if (re[r].date > stamp)
+                    break;
+            }
 
-			/* Store new info */
-			part[j - 1].nr = r;
-			part[j - 1].last = stamp;
-			dirty_part(j - 1);
+            /* Store new info */
+            part[j - 1].nr = r;
+            part[j - 1].last = stamp;
+            dirty_part(j - 1);
 
-			mclose(fp);
-		}
-	}
-	return 1;
+            mclose(fp);
+        }
+    }
+    return 1;
 }

--- a/joq.cc
+++ b/joq.cc
@@ -45,102 +45,100 @@ joq_cmd_dispatch(/* ARGUMENTS:                  */
     char **argv  /* Argument list            */
 )
 {
-	if (match(argv[0], "r_egister") || match(argv[0], "j_oin") ||
-	    match(argv[0], "p_articipate")) {
-		if (confidx >= 0)
-			leave(0, (char **)0);
-		write_part("");
-		st_new.c_status |= CS_JUSTJOINED;
-		mode = M_OK;
+    if (match(argv[0], "r_egister") || match(argv[0], "j_oin") ||
+        match(argv[0], "p_articipate")) {
+        if (confidx >= 0)
+            leave(0, (char **)0);
+        write_part("");
+        st_new.c_status |= CS_JUSTJOINED;
+        mode = M_OK;
 
-		/* Unless ulist file is referenced in an acl, add login to
-		 * ulist */
-		const auto config = get_config(joinidx);
-		if (!config.empty()) {
-			if (is_auto_ulist(joinidx)) {
-				if (!is_inlistfile(joinidx, "ulist")) {
-					const auto path = str::join("/",
-					    {conflist[joinidx].location, "ulist"});
-					write_file(path, std::format("{}\n", login));
-					custom_log("newjoin", M_OK);
-				}
-			}
-		}
-	} else if (match(argv[0], "o_bserver")) {
-		sumentry_t sum2[MAX_ITEMS];
-		short i;
-		if (confidx >= 0)
-			leave(0, (char **)0);
-		st_new.c_status |= (CS_OBSERVER | CS_JUSTJOINED);
-		mode = M_OK;
+        /* Unless ulist file is referenced in an acl, add login to
+         * ulist */
+        const auto config = get_config(joinidx);
+        if (!config.empty()) {
+            if (is_auto_ulist(joinidx)) {
+                if (!is_inlistfile(joinidx, "ulist")) {
+                    const auto path =
+                        str::join("/", {conflist[joinidx].location, "ulist"});
+                    write_file(path, std::format("{}\n", login));
+                    custom_log("newjoin", M_OK);
+                }
+            }
+        }
+    } else if (match(argv[0], "o_bserver")) {
+        sumentry_t sum2[MAX_ITEMS];
+        short i;
+        if (confidx >= 0)
+            leave(0, (char **)0);
+        st_new.c_status |= (CS_OBSERVER | CS_JUSTJOINED);
+        mode = M_OK;
 
-		/* Initialize part[] */
-		for (i = 0; i < MAX_ITEMS; i++) {
-			part[i].nr = part[i].last = 0;
-			dirty_part(i);
-		}
-		get_status(&st_new, sum2, part, joinidx);
-		st_new.sumtime = 0;
-		for (i = st_new.i_first + 1; i < st_new.i_last; i++)
-			time(&(part[i - 1].last));
-	} else if (match(argv[0], "h_elp"))
-		help(argc, argv);
-	else if (match(argv[0], "q_uit")) {
-		status |= S_QUIT;
-		mode = M_OK;
-	} else
-		return misc_cmd_dispatch(argc, argv);
-	return 1;
+        /* Initialize part[] */
+        for (i = 0; i < MAX_ITEMS; i++) {
+            part[i].nr = part[i].last = 0;
+            dirty_part(i);
+        }
+        get_status(&st_new, sum2, part, joinidx);
+        st_new.sumtime = 0;
+        for (i = st_new.i_first + 1; i < st_new.i_last; i++)
+            time(&(part[i - 1].last));
+    } else if (match(argv[0], "h_elp"))
+        help(argc, argv);
+    else if (match(argv[0], "q_uit")) {
+        status |= S_QUIT;
+        mode = M_OK;
+    } else
+        return misc_cmd_dispatch(argc, argv);
+    return 1;
 }
 
 static void
 write_part2(const std::string &partfile, status_t *stt, sumentry_t *sum3)
 {
-	if (debug & DB_PART) {
-		std::println("after split: Partfile={}", partfile);
-		fflush(stdout);
-	}
-	if (debug & DB_PART)
-		std::println("file {} uid {} euid {}", partfile, getuid(), geteuid());
+    if (debug & DB_PART) {
+        std::println("after split: Partfile={}", partfile);
+        fflush(stdout);
+    }
+    if (debug & DB_PART)
+        std::println("file {} uid {} euid {}", partfile, getuid(), geteuid());
 
-	/* KKK*** in the future, allocate string array of #items+2, save lines
-	 * in there, call dump_file, and free the array */
-	const auto path = std::format("{}.new", partfile);
-	auto ferrno = 0;
-	FILE *fp = mopen(path, O_W);
-	if (fp == NULL) /* "w" */
-		exit(1);
-	if (debug & DB_PART)
-		std::println("open succeeded");
-	std::println(fp, "!<pr03>");
-	std::println(fp, "{}", stt->fullname);
+    /* KKK*** in the future, allocate string array of #items+2, save lines
+     * in there, call dump_file, and free the array */
+    const auto path = std::format("{}.new", partfile);
+    auto ferrno = 0;
+    FILE *fp = mopen(path, O_W);
+    if (fp == NULL) /* "w" */
+        exit(1);
+    if (debug & DB_PART)
+        std::println("open succeeded");
+    std::println(fp, "!<pr03>");
+    std::println(fp, "{}", stt->fullname);
 
-	if (debug & DB_PART)
-		std::println("first {} last {}", stt->i_first, stt->i_last);
-	for (auto i = stt->i_first; i <= stt->i_last; i++) {
-		if (debug & DB_PART)
-			std::print("sum3[{}]={} ", i - 1, sum3[i - 1].nr);
-		if (sum3[i - 1].nr || part[i - 1].last) {
-			std::println(fp, "{} {} {:X}",
-			    i, part[i - 1].nr, part[i - 1].last);
-			fflush(fp);
-			if (debug & DB_PART)
-				std::print(": {} {} {:X}",
-				    i, part[i - 1].nr, part[i - 1].last);
-		}
-		if (debug & DB_PART)
-			std::print("\n");
-	}
-	ferrno = ferror(fp);
-	mclose(fp);
+    if (debug & DB_PART)
+        std::println("first {} last {}", stt->i_first, stt->i_last);
+    for (auto i = stt->i_first; i <= stt->i_last; i++) {
+        if (debug & DB_PART)
+            std::print("sum3[{}]={} ", i - 1, sum3[i - 1].nr);
+        if (sum3[i - 1].nr || part[i - 1].last) {
+            std::println(fp, "{} {} {:X}", i, part[i - 1].nr, part[i - 1].last);
+            fflush(fp);
+            if (debug & DB_PART)
+                std::print(": {} {} {:X}", i, part[i - 1].nr, part[i - 1].last);
+        }
+        if (debug & DB_PART)
+            std::print("\n");
+    }
+    ferrno = ferror(fp);
+    mclose(fp);
 
-	/* Now atomically replace the old participation file */
-	if (!ferrno)
-		rename(path.c_str(), partfile.c_str());
-	else {
-		error("writing ", partfile);
-		unlink(path.c_str());
-	}
+    /* Now atomically replace the old participation file */
+    if (!ferrno)
+        rename(path.c_str(), partfile.c_str());
+    else {
+        error("writing ", partfile);
+        unlink(path.c_str());
+    }
 }
 /******************************************************************************/
 /* WRITE OUT A USER PARTICIPATION FILE FOR THE CURRENT CONFERENCE             */
@@ -149,75 +147,74 @@ write_part2(const std::string &partfile, status_t *stt, sumentry_t *sum3)
 void
 write_part(const std::string &partfile)
 {
-	std::string file;
-	short i, cpid, wpid;
-	status_t *stt;
-	sumentry_t sum2[MAX_ITEMS], *sum3;
+    std::string file;
+    short i, cpid, wpid;
+    status_t *stt;
+    sumentry_t sum2[MAX_ITEMS], *sum3;
 
-	if (st_glob.c_status & CS_OBSERVER)
-		return;
+    if (st_glob.c_status & CS_OBSERVER)
+        return;
 
-	if (!partfile.empty()) {
-		file = partfile;
-		sum3 = sum;
-		stt = &st_glob;
-	} else {
-		const auto config = get_config(joinidx);
-		if (config.empty() || config.size() <= CF_PARTFILE)
-			return;
-		file = config[CF_PARTFILE];
-		sum3 = sum2;
-		stt = &st_new;
+    if (!partfile.empty()) {
+        file = partfile;
+        sum3 = sum;
+        stt = &st_glob;
+    } else {
+        const auto config = get_config(joinidx);
+        if (config.empty() || config.size() <= CF_PARTFILE)
+            return;
+        file = config[CF_PARTFILE];
+        sum3 = sum2;
+        stt = &st_new;
 
-		/* Initialize part[] */
-		for (i = 0; i < MAX_ITEMS; i++) {
-			part[i].nr = part[i].last = 0;
-			dirty_part(i);
-		}
-		get_status(stt, sum2, part, joinidx);
-		if (flags & O_UNSEEN) {
-			for (i = st_new.i_first + 1; i < st_new.i_last; i++)
-				time(&(part[i - 1].last));
-		}
-		stt->sumtime = 0;
-	}
+        /* Initialize part[] */
+        for (i = 0; i < MAX_ITEMS; i++) {
+            part[i].nr = part[i].last = 0;
+            dirty_part(i);
+        }
+        get_status(stt, sum2, part, joinidx);
+        if (flags & O_UNSEEN) {
+            for (i = st_new.i_first + 1; i < st_new.i_last; i++)
+                time(&(part[i - 1].last));
+        }
+        stt->sumtime = 0;
+    }
 
-	/* Create WORK/.name.cf */
-	const auto path = str::join("/", {partdir, file});
-	if (debug & DB_PART) {
-		std::println("before split: Partfile={}", path);
-		fflush(stdout);
-	}
-	if (partfile_perm() == SL_OWNER) {
-		write_part2(path, stt, sum3);
-		return;
-	}
+    /* Create WORK/.name.cf */
+    const auto path = str::join("/", {partdir, file});
+    if (debug & DB_PART) {
+        std::println("before split: Partfile={}", path);
+        fflush(stdout);
+    }
+    if (partfile_perm() == SL_OWNER) {
+        write_part2(path, stt, sum3);
+        return;
+    }
 
-	/* FORK */
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    /* FORK */
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return; /* error: couldn't fork */
-		while ((wpid = wait((int *)0)) != cpid && wpid != -1)
-			;
-	} else { /* child */
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0); /* make sure we don't touch stdin */
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return; /* error: couldn't fork */
+        while ((wpid = wait((int *)0)) != cpid && wpid != -1);
+    } else { /* child */
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0); /* make sure we don't touch stdin */
 
-		setuid(getuid());
-		setgid(getgid());
+        setuid(getuid());
+        setgid(getgid());
 
-		write_part2(path, stt, sum3);
-		exit(0);
-	} /* ENDFORK */
+        write_part2(path, stt, sum3);
+        exit(0);
+    } /* ENDFORK */
 
-	if (debug & DB_PART)
-		std::println("write_part: fullname={}", st_glob.fullname);
+    if (debug & DB_PART)
+        std::println("write_part: fullname={}", st_glob.fullname);
 }
 /******************************************************************************/
 /* READ IN A USER PARTICIPATION FILE FOR SOME CONFERENCE                      */
@@ -226,44 +223,42 @@ char
 read_part(                       /* ARGUMENTS:       */
     const std::string &partfile, /* Filename         */
     partentry_t part[MAX_ITEMS], /* Array to fill in */
-    status_t *stt,
-    int idx)
+    status_t *stt, int idx)
 {
-	for (auto i = 0; i < MAX_ITEMS; i++) {
-		part[i].nr = part[i].last = 0;
-		dirty_part(i);
-	}
-	stt->fullname = st_glob.fullname;
-	const auto partf = grab_file(partdir, partfile, GF_SILENT);
-	if (partf.empty()) {
-		/* Newly joined, Initialize part[] */
-		for (auto i = 0; i < MAX_ITEMS; i++)
-			part[i].nr = part[i].last = 0;
-		sumentry_t sum2[MAX_ITEMS];
-		get_status(stt, sum2, part, idx);
-		stt->sumtime = 0;
-		for (auto i = stt->i_first + 1; i < stt->i_last; i++)
-			time(&(part[i - 1].last));
-		return 0;
-	}
-	if (!str::eq(partf[0], "!<pr03>"))
-		std::println("Invalid participation file format.");
-	else if (partf.size() > 1)
-		stt->fullname = partf[1];
-	for (const auto &pf: partf) {
-		short a, b;
-		long d;
-		sscanf(pf.c_str(), "%hd %hd %lx", &a, &b, &d);
-		if (a >= 1 && a <= MAX_ITEMS) {
-			part[a - 1].nr = b;
-			part[a - 1].last = d;
-		}
-	}
-	const auto path = str::join("/", {partdir, partfile});
-	struct stat st{};
-	if (!stat(path.c_str(), &st) && st.st_size > 0)
-		stt->parttime = st.st_mtime;
-	if (debug & DB_PART)
-		std::println("read_part: fullname={}", st_glob.fullname);
-	return 1;
+    for (auto i = 0; i < MAX_ITEMS; i++) {
+        part[i].nr = part[i].last = 0;
+        dirty_part(i);
+    }
+    stt->fullname = st_glob.fullname;
+    const auto partf = grab_file(partdir, partfile, GF_SILENT);
+    if (partf.empty()) {
+        /* Newly joined, Initialize part[] */
+        for (auto i = 0; i < MAX_ITEMS; i++) part[i].nr = part[i].last = 0;
+        sumentry_t sum2[MAX_ITEMS];
+        get_status(stt, sum2, part, idx);
+        stt->sumtime = 0;
+        for (auto i = stt->i_first + 1; i < stt->i_last; i++)
+            time(&(part[i - 1].last));
+        return 0;
+    }
+    if (!str::eq(partf[0], "!<pr03>"))
+        std::println("Invalid participation file format.");
+    else if (partf.size() > 1)
+        stt->fullname = partf[1];
+    for (const auto &pf : partf) {
+        short a, b;
+        long d;
+        sscanf(pf.c_str(), "%hd %hd %lx", &a, &b, &d);
+        if (a >= 1 && a <= MAX_ITEMS) {
+            part[a - 1].nr = b;
+            part[a - 1].last = d;
+        }
+    }
+    const auto path = str::join("/", {partdir, partfile});
+    struct stat st{};
+    if (!stat(path.c_str(), &st) && st.st_size > 0)
+        stt->parttime = st.st_mtime;
+    if (debug & DB_PART)
+        std::println("read_part: fullname={}", st_glob.fullname);
+    return 1;
 }

--- a/lib.cc
+++ b/lib.cc
@@ -36,51 +36,48 @@
 std::string_view
 strim(std::string_view s, const std::string_view ws)
 {
-	return str::trim(s, ws);
+    return str::trim(s, ws);
 }
 
 std::string_view
 strimw(std::string_view s)
 {
-	return str::trim(s, " \t\r\n\f\v");
+    return str::trim(s, " \t\r\n\f\v");
 }
 
 char *
 trim(char *str)
 {
-	if (str == NULL)
-		return NULL;
-	while (*str == ' ')
-		str++;
-	char *end = str + strlen(str);
-	while (end != str && *--end == ' ')
-		*end = '\0';
-	return str;
+    if (str == NULL)
+        return NULL;
+    while (*str == ' ') str++;
+    char *end = str + strlen(str);
+    while (end != str && *--end == ' ') *end = '\0';
+    return str;
 }
 
 // Returns true IFF s matches m.
 bool
 match(const std::string_view &s, const std::string_view &m)
 {
-	return str::match(s, m);
+    return str::match(s, m);
 }
 
 /******************************************************************************/
 /* CHECK FOR A PARTIAL STRING MATCH (required_optional)                       */
 /******************************************************************************/
 bool
-match(
-    const char *ent, // String entered by user
-    const char *und  // String with underlines to match
+match(const char *ent, // String entered by user
+    const char *und    // String with underlines to match
 )
 {
-	if (ent == NULL)
-		ent = "";
-	if (und == NULL)
-		und = "";
-	const std::string_view entv{ent, strlen(ent)};
-	const std::string_view undv{und, strlen(und)};
-	return match(entv, undv);
+    if (ent == NULL)
+        ent = "";
+    if (und == NULL)
+        und = "";
+    const std::string_view entv{ent, strlen(ent)};
+    const std::string_view undv{und, strlen(und)};
+    return match(entv, undv);
 }
 
 /******************************************************************************/
@@ -98,15 +95,15 @@ Description: Appends a block of text to a file with a single operation.
 bool
 write_file(const std::string &filename, const std::string_view &str)
 {
-	FILE *fp;
-	long mod = O_A;
-	if (st_glob.c_security & CT_BASIC)
-		mod |= O_PRIVATE;
-	if ((fp = mopen(filename, mod)) == NULL)
-		return 0;
-	auto n = fwrite(str.data(), str.size(), 1, fp);
-	mclose(fp);
-	return n == str.size();
+    FILE *fp;
+    long mod = O_A;
+    if (st_glob.c_security & CT_BASIC)
+        mod |= O_PRIVATE;
+    if ((fp = mopen(filename, mod)) == NULL)
+        return 0;
+    auto n = fwrite(str.data(), str.size(), 1, fp);
+    mclose(fp);
+    return n == str.size();
 }
 
 //*****************************************************************************
@@ -124,21 +121,20 @@ write_file(const std::string &filename, const std::string_view &str)
 bool
 cat(const std::string_view &dir, const std::string_view &filename)
 {
-	std::string path(dir);
-	if (!filename.empty()) {
-		path.append("/");
-		path.append(filename);
-	}
-	if (debug & DB_LIB)
-		std::println("cat: {}", path);
-	FILE *fp = mopen(path, O_R | O_SILENT);
-	if (fp == NULL)
-		return 0;
-	int c;
-	while ((c = fgetc(fp)) != EOF && !(status & S_INT))
-		wputchar(c);
-	mclose(fp);
-	return true;
+    std::string path(dir);
+    if (!filename.empty()) {
+        path.append("/");
+        path.append(filename);
+    }
+    if (debug & DB_LIB)
+        std::println("cat: {}", path);
+    FILE *fp = mopen(path, O_R | O_SILENT);
+    if (fp == NULL)
+        return 0;
+    int c;
+    while ((c = fgetc(fp)) != EOF && !(status & S_INT)) wputchar(c);
+    mclose(fp);
+    return true;
 }
 
 extern std::string pipebuf;
@@ -151,48 +147,48 @@ extern std::string pipebuf;
 bool
 more(const std::string_view &dir, const std::string_view &filename)
 {
-	/* Need to check if pager exists */
-	if (pipebuf.empty())
-		pipebuf = expand("pager", DM_VAR);
-	if (!(flags & O_BUFFER) || pipebuf.empty())
-		return cat(dir, filename);
-	std::string path(dir);
-	if (!filename.empty()) {
-		path.append("/");
-		path.append(filename);
-	}
-	if (debug & DB_LIB)
-		std::cout << "CAT: " << path << std::endl;
-	FILE *fp = mopen(path, O_R | O_SILENT);
-	if (fp == NULL)
-		return false;
-	open_pipe();
-	int c;
-	while ((c = fgetc(fp)) != EOF)
-		if (fputc(c, st_glob.outp) == EOF)
-			break;
-	spclose(st_glob.outp);
-	mclose(fp);
-	status &= ~S_INT;
-	return true;
+    /* Need to check if pager exists */
+    if (pipebuf.empty())
+        pipebuf = expand("pager", DM_VAR);
+    if (!(flags & O_BUFFER) || pipebuf.empty())
+        return cat(dir, filename);
+    std::string path(dir);
+    if (!filename.empty()) {
+        path.append("/");
+        path.append(filename);
+    }
+    if (debug & DB_LIB)
+        std::cout << "CAT: " << path << std::endl;
+    FILE *fp = mopen(path, O_R | O_SILENT);
+    if (fp == NULL)
+        return false;
+    open_pipe();
+    int c;
+    while ((c = fgetc(fp)) != EOF)
+        if (fputc(c, st_glob.outp) == EOF)
+            break;
+    spclose(st_glob.outp);
+    mclose(fp);
+    status &= ~S_INT;
+    return true;
 }
 
 static char *
 readaline(FILE *fp, char **strp)
 {
-	char *str;
+    char *str;
 
-	if (0 && fp == stdin) {
-		str = readline(NULL);
-		*strp = str;
-		if (str == NULL)
-			*strp = (char *)emalloz(MAX_LINE_LENGTH + 1);
-		return str;
-	} else {
-		str = (char *)emalloz(MAX_LINE_LENGTH + 1);
-		*strp = str;
-		return fgets(str, MAX_LINE_LENGTH, fp);
-	}
+    if (0 && fp == stdin) {
+        str = readline(NULL);
+        *strp = str;
+        if (str == NULL)
+            *strp = (char *)emalloz(MAX_LINE_LENGTH + 1);
+        return str;
+    } else {
+        str = (char *)emalloz(MAX_LINE_LENGTH + 1);
+        *strp = str;
+        return fgets(str, MAX_LINE_LENGTH, fp);
+    }
 }
 
 /******************************************************************************/
@@ -205,259 +201,253 @@ readaline(FILE *fp, char **strp)
 char *
 xgets(FILE *fp, int lvl)
 {
-	char *ok;
-	char *str;
-	int strsize;
-	int i, j, strip = 0;
-	char *tmp, *cp;
-	int done = 0, len;
+    char *ok;
+    char *str;
+    int strsize;
+    int i, j, strip = 0;
+    char *tmp, *cp;
+    int done = 0, len;
 
-	if (!fp)
-		return NULL;
+    if (!fp)
+        return NULL;
 
-	/* Initialize buffer */
-	len = strsize = MAX_LINE_LENGTH;
+    /* Initialize buffer */
+    len = strsize = MAX_LINE_LENGTH;
 
-	/* Loop over \-continued lines */
-	do {
+    /* Loop over \-continued lines */
+    do {
 
-		/* If reading from command input, reset stuff */
-		if (fp == st_glob.inp) { /* st_glob.inp */
-			if (status & S_PAGER)
-				spclose(st_glob.outp);
+        /* If reading from command input, reset stuff */
+        if (fp == st_glob.inp) { /* st_glob.inp */
+            if (status & S_PAGER)
+                spclose(st_glob.outp);
 
-			/* Make SIGINT abort fgets() */
-			ints_on();
-		}
+            /* Make SIGINT abort fgets() */
+            ints_on();
+        }
 
-		/* Get a line, (may be aborted by SIGINT) */
-		ok = readaline(fp, &str);
-		cp = str;
+        /* Get a line, (may be aborted by SIGINT) */
+        ok = readaline(fp, &str);
+        cp = str;
 
-		/* If command input, reset stuff */
-		if (fp == st_glob.inp) { /* st_glob.inp */
+        /* If command input, reset stuff */
+        if (fp == st_glob.inp) { /* st_glob.inp */
 
-			/* Stop SIGINT from aborting fgets() */
-			ints_off();
+            /* Stop SIGINT from aborting fgets() */
+            ints_off();
 
-			if (!ok) {
-				/* If reading from tty, just reset the EOF */
-				/* XXX this should only happen for KEYBOARD input, not xfile XXX */
-				if (isatty(fileno(st_glob.inp))) {
-					/* mystdin */
-					clearerr(fp);
-					if (!(flags & O_QUIET))
-						std::println("");
-				} else {
+            if (!ok) {
+                /* If reading from tty, just reset the EOF */
+                /* XXX this should only happen for KEYBOARD input, not xfile XXX
+                 */
+                if (isatty(fileno(st_glob.inp))) {
+                    /* mystdin */
+                    clearerr(fp);
+                    if (!(flags & O_QUIET))
+                        std::println("");
+                } else {
 
-					/* Reading commands from a file */
-					free(str);
-					if (stdin_stack_top > 0 + (orig_stdin[0].type == STD_SKIP)) {
-						pop_stdin();
-						if (stdin_stack_top >= lvl)
-							return xgets(st_glob.inp, lvl);
-					}
-					return NULL;
-				}
-			}
-		}
+                    /* Reading commands from a file */
+                    free(str);
+                    if (stdin_stack_top >
+                        0 + (orig_stdin[0].type == STD_SKIP)) {
+                        pop_stdin();
+                        if (stdin_stack_top >= lvl)
+                            return xgets(st_glob.inp, lvl);
+                    }
+                    return NULL;
+                }
+            }
+        }
 
-		/* If SIGINT seen when getting a command, return empty command
-		 */
-		/* st_glob.inp */
-		if (!ok && (status & S_INT) && (fp == st_glob.inp)) {
-			/* for systems where interrupts abort fgets */
-			if (str == NULL)
-				str = estrdup("");
-			str[0] = '\0';
-			return str;
-		}
+        /* If SIGINT seen when getting a command, return empty command
+         */
+        /* st_glob.inp */
+        if (!ok && (status & S_INT) && (fp == st_glob.inp)) {
+            /* for systems where interrupts abort fgets */
+            if (str == NULL)
+                str = estrdup("");
+            str[0] = '\0';
+            return str;
+        }
 
-		/* Strip other characters if needed */
-		/* st_glob.inp */
-		if (ok && fp == st_glob.inp && (flags & O_STRIP)) {
-			tmp = (char *)emalloz(strlen(cp) + 1);
-			for (i = j = 0; i < strlen(cp); i++) {
-				if (isprint(cp[i]) || isspace(cp[i]))
-					tmp[j++] = cp[i];
-				else
-					std::print("{} ^{}",
-					    (strip++) ? ""
-					              : "Stripping bad input:",
-					    cp[i] + 64);
-			}
-			if (strip)
-				std::println("");
-			tmp[j] = '\0';
-			strcpy(cp, tmp);
-			free(tmp);
-		}
+        /* Strip other characters if needed */
+        /* st_glob.inp */
+        if (ok && fp == st_glob.inp && (flags & O_STRIP)) {
+            tmp = (char *)emalloz(strlen(cp) + 1);
+            for (i = j = 0; i < strlen(cp); i++) {
+                if (isprint(cp[i]) || isspace(cp[i]))
+                    tmp[j++] = cp[i];
+                else
+                    std::print("{} ^{}",
+                        (strip++) ? "" : "Stripping bad input:", cp[i] + 64);
+            }
+            if (strip)
+                std::println("");
+            tmp[j] = '\0';
+            strcpy(cp, tmp);
+            free(tmp);
+        }
 
-		/* If it ends with \\\n, delete both */
-		if (ok && strlen(cp) > 1 && cp[strlen(cp) - 1] == '\n' &&
-		    cp[strlen(cp) - 2] == '\\') {
-			cp[strlen(cp) - 2] = '\0';
-		}
+        /* If it ends with \\\n, delete both */
+        if (ok && strlen(cp) > 1 && cp[strlen(cp) - 1] == '\n' &&
+            cp[strlen(cp) - 2] == '\\') {
+            cp[strlen(cp) - 2] = '\0';
+        }
 
-		/* If newline read, trash it and mark as done */
-		if (ok && cp[0] && cp[strlen(cp) - 1] == '\n') {
-			cp[strlen(cp) - 1] = 0;
-			done = 1;
-		} else if (!ok) { /* EOF */
-			done = 1;
-		} else { /* continues on next line */
-			cp += strlen(cp);
-			len = strsize - (cp - str); /* space left */
-			if (len < 80) {
-				strsize += 256;
-				str = (char *)erealloc(str, strsize);
-				len += 256;
-				cp = str + strsize - len;
-			}
-			done = 0;
-		}
-	} while (!done);
+        /* If newline read, trash it and mark as done */
+        if (ok && cp[0] && cp[strlen(cp) - 1] == '\n') {
+            cp[strlen(cp) - 1] = 0;
+            done = 1;
+        } else if (!ok) { /* EOF */
+            done = 1;
+        } else { /* continues on next line */
+            cp += strlen(cp);
+            len = strsize - (cp - str); /* space left */
+            if (len < 80) {
+                strsize += 256;
+                str = (char *)erealloc(str, strsize);
+                len += 256;
+                cp = str + strsize - len;
+            }
+            done = 0;
+        }
+    } while (!done);
 
-	if (ok)
-		return str;
+    if (ok)
+        return str;
 
-	free(str);
-	return NULL;
+    free(str);
+    return NULL;
 }
 /******************************************************************************/
 /* GET INPUT WITHOUT OVERFLOWING BUFFER                                       */
 /* Also get multiple lines if a line ended with \                             */
 /******************************************************************************/
 char *
-oldngets(         /* ARGUMENTS:            */
+oldngets(      /* ARGUMENTS:            */
     char *str, /* Input buffer       */
     FILE *fp   /* Input stream       */
 )
 {
-	char *ok;
-	int i, j, strip = 0;
-	char tmp[MAX_LINE_LENGTH], *cp = str;
-	int done = 0, len = MAX_LINE_LENGTH;
-	/* Loop over \-continued lines */
-	do {
+    char *ok;
+    int i, j, strip = 0;
+    char tmp[MAX_LINE_LENGTH], *cp = str;
+    int done = 0, len = MAX_LINE_LENGTH;
+    /* Loop over \-continued lines */
+    do {
 
-		/* If reading from command input, reset stuff */
-		if (fp == st_glob.inp) { /* st_glob.inp */
-			if (status & S_PAGER)
-				spclose(st_glob.outp);
+        /* If reading from command input, reset stuff */
+        if (fp == st_glob.inp) { /* st_glob.inp */
+            if (status & S_PAGER)
+                spclose(st_glob.outp);
 
-			/* Make INT abort fgets() */
-			ints_on();
-		}
+            /* Make INT abort fgets() */
+            ints_on();
+        }
 
-		/* Get a line, (may be aborted by SIGINT) */
-		if (!fp) {
-			str[0] = '\0';
-			return NULL;
-		} else
-			ok = fgets(cp, len, fp);
+        /* Get a line, (may be aborted by SIGINT) */
+        if (!fp) {
+            str[0] = '\0';
+            return NULL;
+        } else
+            ok = fgets(cp, len, fp);
 
-		/* If command input, reset stuff */
-		if (fp == st_glob.inp) { /* st_glob.inp */
+        /* If command input, reset stuff */
+        if (fp == st_glob.inp) { /* st_glob.inp */
 
-			/* Stop INT from aborting fgets() */
-			ints_off();
+            /* Stop INT from aborting fgets() */
+            ints_off();
 
-			if (!ok) {
-				/* If reading from tty, just reset the EOF */
-				/* XXX this should only happen for KEYBOARD
-				 * input, not xfile XXX */
-				if (fp == st_glob.inp &&
-				    !(status & S_BATCH)) { /* mystdin */
-					clearerr(fp);
-					if (!(flags & O_QUIET))
-						std::println("");
-				} else {
-					/* we might want the old stuff below,
-					 * and here's why: when your .cfrc
-					 * contains "r" and there's new stuff,
-					 * you got in 2.3 a message saying
-					 * "Tried to close unopened file"
-					 * because of the mclose below. However,
-					 * the ngets allowed control to flow
-					 * from a script to stdin easily, so you
-					 * wouldn't get a Stopping message.
-					 * Turns out this is extremely
-					 * problematic and not really necessary.
-					 * Basically, you want to return all the
-					 * way up to source() to close the file,
-					 * and Stopping is generated way down
-					 * inside, in a get_command() in item.c
-					 */
+            if (!ok) {
+                /* If reading from tty, just reset the EOF */
+                /* XXX this should only happen for KEYBOARD
+                 * input, not xfile XXX */
+                if (fp == st_glob.inp && !(status & S_BATCH)) { /* mystdin */
+                    clearerr(fp);
+                    if (!(flags & O_QUIET))
+                        std::println("");
+                } else {
+                    /* we might want the old stuff below,
+                     * and here's why: when your .cfrc
+                     * contains "r" and there's new stuff,
+                     * you got in 2.3 a message saying
+                     * "Tried to close unopened file"
+                     * because of the mclose below. However,
+                     * the ngets allowed control to flow
+                     * from a script to stdin easily, so you
+                     * wouldn't get a Stopping message.
+                     * Turns out this is extremely
+                     * problematic and not really necessary.
+                     * Basically, you want to return all the
+                     * way up to source() to close the file,
+                     * and Stopping is generated way down
+                     * inside, in a get_command() in item.c
+                     */
 
-					/* Reading commands from a file */
-					if (stdin_stack_top >
-					    0 + (orig_stdin[0].type ==
-					            STD_SKIP)) {
-						pop_stdin();
-						return oldngets(str, st_glob.inp);
-					} else {
-						return NULL;
-					}
-				}
-			}
-		}
+                    /* Reading commands from a file */
+                    if (stdin_stack_top >
+                        0 + (orig_stdin[0].type == STD_SKIP)) {
+                        pop_stdin();
+                        return oldngets(str, st_glob.inp);
+                    } else {
+                        return NULL;
+                    }
+                }
+            }
+        }
 
-		/* If SIGINT seen when getting a command, return empty command
-		 */
-		if (ok)
-			cp[strlen(cp) - 1] = 0; /* trash newline */
-		else if ((status & S_INT) &&
-		         (fp == st_glob.inp)) { /* st_glob.inp
-			                         */
-			/* for systems where interrupts abort fgets */
-			str[0] = '\0';
-			return str;
-		}
+        /* If SIGINT seen when getting a command, return empty command
+         */
+        if (ok)
+            cp[strlen(cp) - 1] = 0;                         /* trash newline */
+        else if ((status & S_INT) && (fp == st_glob.inp)) { /* st_glob.inp
+                                                             */
+            /* for systems where interrupts abort fgets */
+            str[0] = '\0';
+            return str;
+        }
 
-		/* Strip characters if needed */
-		if ((fp == st_glob.inp) &&
-		    (flags & O_STRIP)) { /* st_glob.inp */
-			for (i = j = 0; i < strlen(cp); i++) {
-				if (isprint(cp[i]) || isspace(cp[i]))
-					tmp[j++] = cp[i];
-				else {
-					std::print("{} ^{}",
-					    (strip++) ? ""
-					              : "Stripping bad input:",
-					    cp[i] + 64);
-				}
-			}
-			if (strip)
-				std::println("");
-			tmp[j] = '\0';
-			strcpy(cp, tmp);
-		}
+        /* Strip characters if needed */
+        if ((fp == st_glob.inp) && (flags & O_STRIP)) { /* st_glob.inp */
+            for (i = j = 0; i < strlen(cp); i++) {
+                if (isprint(cp[i]) || isspace(cp[i]))
+                    tmp[j++] = cp[i];
+                else {
+                    std::print("{} ^{}",
+                        (strip++) ? "" : "Stripping bad input:", cp[i] + 64);
+                }
+            }
+            if (strip)
+                std::println("");
+            tmp[j] = '\0';
+            strcpy(cp, tmp);
+        }
 
-		/* Check if continues on next line */
-		done = 1;
-		if (cp[0] && cp[strlen(cp) - 1] == '\\') {
-			cp += strlen(cp) - 1;
-			len = MAX_LINE_LENGTH - (cp - str); /* space left */
-			if (len > 1)
-				done = 0;
-		}
-	} while (!done);
+        /* Check if continues on next line */
+        done = 1;
+        if (cp[0] && cp[strlen(cp) - 1] == '\\') {
+            cp += strlen(cp) - 1;
+            len = MAX_LINE_LENGTH - (cp - str); /* space left */
+            if (len > 1)
+                done = 0;
+        }
+    } while (!done);
 
-	return (ok) ? str : NULL;
+    return (ok) ? str : NULL;
 }
 
 bool
 ngets(std::string &str, FILE *fp)
 {
-	char buf[MAX_LINE_LENGTH];
-	auto p = oldngets(buf, fp);
-	if (p == nullptr) {
-		str.clear();
-		return false;
-	}
-	str = p;
-	return true;
+    char buf[MAX_LINE_LENGTH];
+    auto p = oldngets(buf, fp);
+    if (p == nullptr) {
+        str.clear();
+        return false;
+    }
+    str = p;
+    return true;
 }
 
 //*****************************************************************************
@@ -473,42 +463,43 @@ ngets(std::string &str, FILE *fp)
 // Filename to read into memory
 // Flags (see lib.h)
 std::vector<std::string>
-grab_file(const std::string_view &dir, const std::string_view &filename, int flags)
+grab_file(
+    const std::string_view &dir, const std::string_view &filename, int flags)
 {
-	std::vector<std::string> lines;
+    std::vector<std::string> lines;
 
-	std::string path(dir);
-	if (!filename.empty()) {
-		path.append("/");
-		path.append(filename);
-	}
+    std::string path(dir);
+    if (!filename.empty()) {
+        path.append("/");
+        path.append(filename);
+    }
 
-	FILE *fp = mopen(path, (flags & GF_SILENT) ? O_R | O_SILENT : O_R);
-	if (fp == nullptr)
-		return lines;
+    FILE *fp = mopen(path, (flags & GF_SILENT) ? O_R | O_SILENT : O_R);
+    if (fp == nullptr)
+        return lines;
 
-	if (flags & GF_WORD) {
-		/* count each word as a line */
-		char word[MAX_LINE_LENGTH];
-		while (fscanf(fp, "%s", word) == 1) {
-			/* what type of file is this? */
-			if (word[0] == '#' && (flags & GF_IGNCMT)) {
-				fgets(word, MAX_LINE_LENGTH, fp);
-				continue;
-			}
-			lines.push_back(word);
-		}
-	} else {
-		char *line = NULL;           /* normal files */
-		while ((line = xgets(fp, 0)) != NULL) {
-			if (line[0] != '#' || (flags & GF_IGNCMT) == 0)
-				lines.push_back(line);
-			free(line);
-		}
-	}
-	mclose(fp);
+    if (flags & GF_WORD) {
+        /* count each word as a line */
+        char word[MAX_LINE_LENGTH];
+        while (fscanf(fp, "%s", word) == 1) {
+            /* what type of file is this? */
+            if (word[0] == '#' && (flags & GF_IGNCMT)) {
+                fgets(word, MAX_LINE_LENGTH, fp);
+                continue;
+            }
+            lines.push_back(word);
+        }
+    } else {
+        char *line = NULL; /* normal files */
+        while ((line = xgets(fp, 0)) != NULL) {
+            if (line[0] != '#' || (flags & GF_IGNCMT) == 0)
+                lines.push_back(line);
+            free(line);
+        }
+    }
+    mclose(fp);
 
-	return lines;
+    return lines;
 }
 
 //*****************************************************************************
@@ -522,22 +513,23 @@ grab_file(const std::string_view &dir, const std::string_view &filename, int fla
 std::vector<std::string>
 grab_more(FILE *fp, const char *end, size_t *endlen)
 {
-	std::vector<std::string> lines;
-	if (endlen != NULL)
-		*endlen = 0;
-	for (char *large = nullptr; (large = xgets(fp, 0)) != nullptr;) {
-		std::string line(large);
-		free(large);
-		if (end != nullptr && line[0] == end[0] && line[1] == end[0])
-			line.erase(0, 2);
-		if ((end != nullptr && line.starts_with(end)) || line.starts_with(",R")) {
-			if (endlen)
-				*endlen = line.size();
-			break;
-		}
-		lines.push_back(line);
-	}
-	return lines;
+    std::vector<std::string> lines;
+    if (endlen != NULL)
+        *endlen = 0;
+    for (char *large = nullptr; (large = xgets(fp, 0)) != nullptr;) {
+        std::string line(large);
+        free(large);
+        if (end != nullptr && line[0] == end[0] && line[1] == end[0])
+            line.erase(0, 2);
+        if ((end != nullptr && line.starts_with(end)) ||
+            line.starts_with(",R")) {
+            if (endlen)
+                *endlen = line.size();
+            break;
+        }
+        lines.push_back(line);
+    }
+    return lines;
 }
 
 //*****************************************************************************
@@ -549,23 +541,23 @@ grab_more(FILE *fp, const char *end, size_t *endlen)
 bool
 get_yes(const std::string_view &prompt, bool dflt)
 {
-	char buff[MAX_LINE_LENGTH], *p = buff;
+    char buff[MAX_LINE_LENGTH], *p = buff;
 
-	for (;;) {
-		if ((flags & O_QUIET) == 0)
-			wputs(prompt);
-		if (!oldngets(buff, st_glob.inp)) /* st_glob.inp */
-			return dflt;
+    for (;;) {
+        if ((flags & O_QUIET) == 0)
+            wputs(prompt);
+        if (!oldngets(buff, st_glob.inp)) /* st_glob.inp */
+            return dflt;
 
-		/* Skip leading whitespace */
-		while (isspace(*p)) p++;
+        /* Skip leading whitespace */
+        while (isspace(*p)) p++;
 
-		if (match(p, "n_on") || match(p, "nop_e"))
-			return 0;
-		if (match(p, "y_es") || match(p, "ok"))
-			return 1;
-		std::println("\"{}\" is invalid.  Try yes or no.", p);
-	}
+        if (match(p, "n_on") || match(p, "nop_e"))
+            return 0;
+        if (match(p, "y_es") || match(p, "ok"))
+            return 1;
+        std::println("\"{}\" is invalid.  Try yes or no.", p);
+    }
 }
 
 /******************************************************************************/
@@ -577,98 +569,101 @@ get_yes(const std::string_view &prompt, bool dflt)
 /* Directory containing file   */
 /* Filename to read from       */
 std::vector<assoc_t>
-grab_list(const std::string_view &dir, const std::string_view &filename, int flags)
+grab_list(
+    const std::string_view &dir, const std::string_view &filename, int flags)
 {
-	std::vector<assoc_t> v;
-	std::string line;
+    std::vector<assoc_t> v;
+    std::string line;
 
-	/* Compose filename */
-	const char *sep = "";
-	if (!dir.empty() && !filename.empty())
-		sep = "/";
-	const auto path = str::concat({dir, sep, filename});
+    /* Compose filename */
+    const char *sep = "";
+    if (!dir.empty() && !filename.empty())
+        sep = "/";
+    const auto path = str::concat({dir, sep, filename});
 
-	/* Open the file to read */
-	FILE *fp = mopen(path, O_R | O_SILENT);;
-	if (fp == NULL) {
-		if ((flags & GF_SILENT) == 0)
-			error("grabbing list ", path);
-		return v;
-	}
+    /* Open the file to read */
+    FILE *fp = mopen(path, O_R | O_SILENT);
+    ;
+    if (fp == NULL) {
+        if ((flags & GF_SILENT) == 0)
+            error("grabbing list ", path);
+        return v;
+    }
 
-	if ((flags & GF_NOHEADER) == 0) {
-		/*
-		 * Get the first line (skipping any comments).
-		 * This is the default.
-		 */
-		while (ngets(line, fp)) {
-			if (!line.empty() && line[0] != '#' && line[0] != '!')
-				break;
-		}
+    if ((flags & GF_NOHEADER) == 0) {
+        /*
+         * Get the first line (skipping any comments).
+         * This is the default.
+         */
+        while (ngets(line, fp)) {
+            if (!line.empty() && line[0] != '#' && line[0] != '!')
+                break;
+        }
 
-		/* If empty, return null array */
-		if (line.empty()) {
-			std::println(stderr, "Error: {} is empty.", path);
-			mclose(fp);
-			return v;
-		}
+        /* If empty, return null array */
+        if (line.empty()) {
+            std::println(stderr, "Error: {} is empty.", path);
+            mclose(fp);
+            return v;
+        }
 
-		/* Start the list, and save default in location 0 */
-		v.push_back(assoc_t("", line));
+        /* Start the list, and save default in location 0 */
+        v.push_back(assoc_t("", line));
 
-		if (debug & DB_LIB)
-			std::println("Default: '{}'", line);
-		if (line.find(':') != std::string::npos)
-			std::println(stderr, "Warning: {} may be missing default.", path);
-	}
+        if (debug & DB_LIB)
+            std::println("Default: '{}'", line);
+        if (line.find(':') != std::string::npos)
+            std::println(stderr, "Warning: {} may be missing default.", path);
+    }
 
-	/* Read until EOF */
-	while (ngets(line, fp)) {
-		if (debug & DB_LIB)
-			std::println("Line: '{}'", line);
+    /* Read until EOF */
+    while (ngets(line, fp)) {
+        if (debug & DB_LIB)
+            std::println("Line: '{}'", line);
 
-		/* Skip comment and blank lines */
-		if (line.empty() || line[0] == '#')
-			continue;
+        /* Skip comment and blank lines */
+        if (line.empty() || line[0] == '#')
+            continue;
 
-		/* Have a line, split into name and location */
-		char *l = line.data();
-		char *p = strchr(l, ':');
-		if (p != NULL) {
-			*p++ = '\0';
-			if (debug & DB_LIB)
-				std::println("Name: '{}' Dir: '{}'", line, p);
-			v.push_back(assoc_t(l, p));
-		} else if (line[0] == '=' && line[1] != '\0') {
-			/* Chain to another file */
-			mclose(fp);
-			const char *next = line.c_str() + 1;
+        /* Have a line, split into name and location */
+        char *l = line.data();
+        char *p = strchr(l, ':');
+        if (p != NULL) {
+            *p++ = '\0';
+            if (debug & DB_LIB)
+                std::println("Name: '{}' Dir: '{}'", line, p);
+            v.push_back(assoc_t(l, p));
+        } else if (line[0] == '=' && line[1] != '\0') {
+            /* Chain to another file */
+            mclose(fp);
+            const char *next = line.c_str() + 1;
 
-			std::string path;
-			if (*next == '%')
-				path = str::join("/", {bbsdir, next + 1 + (next[1] == '/')});
-			else if (!dir.empty())
-				path = str::join("/", {dir, std::string_view(line).substr(1 + (line[0] == '/'))});
-			else
-				path = next;
+            std::string path;
+            if (*next == '%')
+                path = str::join("/", {bbsdir, next + 1 + (next[1] == '/')});
+            else if (!dir.empty())
+                path = str::join("/",
+                    {dir, std::string_view(line).substr(1 + (line[0] == '/'))});
+            else
+                path = next;
 
-			fp = mopen(path, O_R | O_SILENT);
-			if (fp == NULL) {
-				error("grabbing list ", path);
-				break;
-			}
+            fp = mopen(path, O_R | O_SILENT);
+            if (fp == NULL) {
+                error("grabbing list ", path);
+                break;
+            }
 
-			ngets(line, fp); /* read magic line */
-			if (debug & DB_LIB)
-				std::println("grab_list: magic {}", line);
+            ngets(line, fp); /* read magic line */
+            if (debug & DB_LIB)
+                std::println("grab_list: magic {}", line);
 
-		} else {
-			std::println(stderr, "Bad line read: {}", line);
-		}
-	}
-	mclose(fp);
+        } else {
+            std::println(stderr, "Bad line read: {}", line);
+        }
+    }
+    mclose(fp);
 
-	return v;
+    return v;
 }
 
 /******************************************************************************/
@@ -681,14 +676,14 @@ grab_list(const std::string_view &dir, const std::string_view &filename, int fla
 std::size_t
 get_idx(const std::string_view &elt, const std::vector<assoc_t> &list)
 {
-	if (list.empty())
-		return nidx;
-	if (!list[0].name.empty() && match(elt, list[0].name))
-		return 0; /* in case it's a list without default */
-	for (auto i = 1uz; i < list.size(); i++)
-		if (match(elt, list[i].name))
-			return i;
-	return nidx;
+    if (list.empty())
+        return nidx;
+    if (!list[0].name.empty() && match(elt, list[0].name))
+        return 0; /* in case it's a list without default */
+    for (auto i = 1uz; i < list.size(); i++)
+        if (match(elt, list[i].name))
+            return i;
+    return nidx;
 }
 
 // ARGUMENTS:
@@ -697,19 +692,19 @@ get_idx(const std::string_view &elt, const std::vector<assoc_t> &list)
 const assoc_t *
 assoc_list_find(const std::vector<assoc_t> &list, const std::string &key)
 {
-	if (list.empty())
-		return nullptr;
+    if (list.empty())
+        return nullptr;
 
-	// Special case for a list without a default.
-	auto ap = list.begin();
-	if (!ap->name.empty() && match(key, ap->name))
-		return &*ap;
-	while (++ap != list.end()) {
-		if (match(key, ap->name))
-			return &*ap;
-	}
+    // Special case for a list without a default.
+    auto ap = list.begin();
+    if (!ap->name.empty() && match(key, ap->name))
+        return &*ap;
+    while (++ap != list.end()) {
+        if (match(key, ap->name))
+            return &*ap;
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 /******************************************************************************/
@@ -721,49 +716,49 @@ assoc_list_find(const std::vector<assoc_t> &list, const std::string &key)
 std::string
 get_date(time_t t, int style)
 {
-	static const char *fmt[] = {
+    static const char *fmt[] = {
 #ifdef NOEDATE
-	    /* 0 */ "%a %b %d %H:%M:%S %Y", /* dates must be in 05
-	                                     * format */
-	    /* 1 */ "%a, %b %d, %Y (%H:%M)",
+        /* 0 */ "%a %b %d %H:%M:%S %Y", /* dates must be in 05
+                                         * format */
+        /* 1 */ "%a, %b %d, %Y (%H:%M)",
 #else
-	    /* 0 */ "%a %b %e %H:%M:%S %Y", /* dates need not have
-	                                     * leading 0 */
-	    /* 1 */ "%a, %b %e, %Y (%H:%M)",
+        /* 0 */ "%a %b %e %H:%M:%S %Y", /* dates need not have
+                                         * leading 0 */
+        /* 1 */ "%a, %b %e, %Y (%H:%M)",
 #endif
-	    /* 2 */ "%a",
-	    /* 3 */ "%b",
-	    /* 4 */ "%e",
-	    /* 5 */ "%y",
-	    /* 6 */ "%Y",
-	    /* 7 */ "%H",
-	    /* 8 */ "%M",
-	    /* 9 */ "%S",
-	    /* 10 */ "%I",
-	    /* 11 */ "%p",
-	    /* 12 */ "%p",
+        /* 2 */ "%a",
+        /* 3 */ "%b",
+        /* 4 */ "%e",
+        /* 5 */ "%y",
+        /* 6 */ "%Y",
+        /* 7 */ "%H",
+        /* 8 */ "%M",
+        /* 9 */ "%S",
+        /* 10 */ "%I",
+        /* 11 */ "%p",
+        /* 12 */ "%p",
 #ifdef NOEDATE
-	    /* 13 */ "(%H:%M:%S) %B %d, %Y",
+        /* 13 */ "(%H:%M:%S) %B %d, %Y",
 #else
-	    /* 13 */ "(%H:%M:%S) %B %e, %Y",
+        /* 13 */ "(%H:%M:%S) %B %e, %Y",
 #endif
-	    /* 14 */ "%Y%m%d%H%M%S",
-	    /* 15 */ "%a, %d %b %Y %H:%M:%S",
-	    /* 16 HEX */ "",
-	    /* 17 */
-	    "%m"
-	    /* 18 DEC */ "",
-	};
-	struct tm *tms = localtime(&t);
-	if (style < 0 || style == 16 || style > 18) /*		sty=0; */
-		return std::format("{:X}", t);
-	if (style == 18)
-		return std::format("{}", t);
+        /* 14 */ "%Y%m%d%H%M%S",
+        /* 15 */ "%a, %d %b %Y %H:%M:%S",
+        /* 16 HEX */ "",
+        /* 17 */
+        "%m"
+        /* 18 DEC */ "",
+    };
+    struct tm *tms = localtime(&t);
+    if (style < 0 || style == 16 || style > 18) /*		sty=0; */
+        return std::format("{:X}", t);
+    if (style == 18)
+        return std::format("{}", t);
 
-	char timestr[128];
-	strftime(timestr, sizeof(timestr), fmt[style], tms);
+    char timestr[128];
+    strftime(timestr, sizeof(timestr), fmt[style], tms);
 
-	return timestr;
+    return timestr;
 }
 /******************************************************************************/
 /* GENERATE STRING WITHOUT ANY "'_s IN IT                                     */
@@ -772,16 +767,16 @@ get_date(time_t t, int style)
 std::string
 noquote(const std::string_view &str)
 {
-	if (str.empty())
-		return "";
-	auto s = str.begin();
-	auto e = str.end();
-	if (*s == '"' || *s == '\'') {
-		if (str.back() == *s)
-			e--;
-		s++;
-	}
-	return std::string(s, e);
+    if (str.empty())
+        return "";
+    auto s = str.begin();
+    auto e = str.end();
+    if (*s == '"' || *s == '\'') {
+        if (str.back() == *s)
+            e--;
+        s++;
+    }
+    return std::string(s, e);
 }
 
 /******************************************************************************/
@@ -790,77 +785,75 @@ noquote(const std::string_view &str)
 std::string
 compress(const std::string_view &s)
 {
-	return str::strip(s, "_");
+    return str::strip(s, "_");
 }
 
 void
 error(const std::string_view &str1, const std::string_view &str2)
 {
-	if (errno)
-		std::println(stderr, "Got error {} ({}) in {}{}",
-		    errno, strerror(errno), str1, str2);
+    if (errno)
+        std::println(stderr, "Got error {} ({}) in {}{}", errno,
+            strerror(errno), str1, str2);
 
-	const auto errorlog = str::concat({bbsdir, "/errorlog"});
-	FILE *fp = fopen(errorlog.c_str(), "a");
-	if (fp == NULL)
-		return;
-	char timestamp[32];
-	time_t now;
-	time(&now);
-	ctime_r(&now, timestamp);
-	if (errno)
-		std::println(fp, "{:<8} {} Got error {} ({}) in {}{}",
-		    login, timestamp + 4, errno, strerror(errno),
-		    str1, str2);
-	else
-		std::println(fp, "{:<8} {} WARNING: {}{}",
-		    login, timestamp + 4, str1, str2);
-	fclose(fp);
+    const auto errorlog = str::concat({bbsdir, "/errorlog"});
+    FILE *fp = fopen(errorlog.c_str(), "a");
+    if (fp == NULL)
+        return;
+    char timestamp[32];
+    time_t now;
+    time(&now);
+    ctime_r(&now, timestamp);
+    if (errno)
+        std::println(fp, "{:<8} {} Got error {} ({}) in {}{}", login,
+            timestamp + 4, errno, strerror(errno), str1, str2);
+    else
+        std::println(
+            fp, "{:<8} {} WARNING: {}{}", login, timestamp + 4, str1, str2);
+    fclose(fp);
 }
 
 std::string &
 lower_case(std::string &str)
 {
-	return str::lowercase(str);
+    return str::lowercase(str);
 }
 
 void
 lower_case(std::span<char> &str)
 {
-	for (auto &c: str)
-		c = tolower(c);
+    for (auto &c : str) c = tolower(c);
 }
 
 char *
 lower_case(char *str)
 {
-	std::span s{str, std::strlen(str)};
-	lower_case(s);
-	return str;
+    std::span s{str, std::strlen(str)};
+    lower_case(s);
+    return str;
 }
 
 void
 mkdir_all(const std::string &fullpath, int mode)
 {
-	struct stat sb; /* Struct containing directory status */
+    struct stat sb; /* Struct containing directory status */
 
-	/* Make sure directory doesn't exist before creating it */
-	if (stat(fullpath.c_str(), &sb) == 0)
-		return;
+    /* Make sure directory doesn't exist before creating it */
+    if (stat(fullpath.c_str(), &sb) == 0)
+        return;
 
-	std::string dir(fullpath);
-	const char *path = dir.c_str();
-	for (char *p = dir.data(); *p != '\0'; p++) {
-		/* Make sure each piece of path  exists */
-		if (*p == '/' && p > path) {
-			*p = '\0';
-			mkdir(path, mode);
-			*p = '/';
-		}
-	}
+    std::string dir(fullpath);
+    const char *path = dir.c_str();
+    for (char *p = dir.data(); *p != '\0'; p++) {
+        /* Make sure each piece of path  exists */
+        if (*p == '/' && p > path) {
+            *p = '\0';
+            mkdir(path, mode);
+            *p = '/';
+        }
+    }
 
-	/* Create the entire directory before exit */
-	if (mkdir(path, mode) != 0) {
-		error("Creating directory ", fullpath);
-	}
+    /* Create the entire directory before exit */
+    if (mkdir(path, mode) != 0) {
+        error("Creating directory ", fullpath);
+    }
 }

--- a/license.cc
+++ b/license.cc
@@ -36,54 +36,54 @@ static std::vector<assoc_t> conf_params;
 static void
 read_config2(const std::string &filename)
 {
-	conf_params = grab_list("/etc", filename, GF_SILENT | GF_NOHEADER);
-	if (conf_params.empty())
-		conf_params =
-		    grab_list("/usr/local/etc", filename, GF_SILENT | GF_NOHEADER);
-	if (conf_params.empty())
-		conf_params =
-		    grab_list("/arbornet/m-net/bbs", filename, GF_SILENT | GF_NOHEADER);
-	if (conf_params.empty()) {
-		struct passwd *pwd = getpwuid(geteuid());
-		if (pwd != nullptr)
-			conf_params = grab_list(
-			    pwd->pw_dir, filename, GF_SILENT | GF_NOHEADER);
-	}
-	if (conf_params.empty())
-		conf_params = grab_list(".", filename, GF_SILENT | GF_NOHEADER);
+    conf_params = grab_list("/etc", filename, GF_SILENT | GF_NOHEADER);
+    if (conf_params.empty())
+        conf_params =
+            grab_list("/usr/local/etc", filename, GF_SILENT | GF_NOHEADER);
+    if (conf_params.empty())
+        conf_params =
+            grab_list("/arbornet/m-net/bbs", filename, GF_SILENT | GF_NOHEADER);
+    if (conf_params.empty()) {
+        struct passwd *pwd = getpwuid(geteuid());
+        if (pwd != nullptr)
+            conf_params =
+                grab_list(pwd->pw_dir, filename, GF_SILENT | GF_NOHEADER);
+    }
+    if (conf_params.empty())
+        conf_params = grab_list(".", filename, GF_SILENT | GF_NOHEADER);
 }
 
 void
 read_config(void)
 {
-	read_config2("yapp3.1.conf");
-	if (conf_params.empty())
-		read_config2("yapp.conf");
+    read_config2("yapp3.1.conf");
+    if (conf_params.empty())
+        read_config2("yapp.conf");
 }
 
 std::string
 get_conf_param(const std::string_view &name, const std::string_view &def)
 {
-	if (conf_params.empty())
-		return std::string(def);
-	auto i = get_idx(name, conf_params);
-	if (i == ~0z)
-		return std::string(def);
-	return conf_params[i].location;
+    if (conf_params.empty())
+        return std::string(def);
+    auto i = get_idx(name, conf_params);
+    if (i == ~0z)
+        return std::string(def);
+    return conf_params[i].location;
 }
 
 void
 free_config(void)
 {
-	conf_params.clear();
+    conf_params.clear();
 }
 
 int
 get_hits_today(void)
 {
-	const auto dir = get_conf_param("licensedir", LICENSEDIR);
-	const auto file = grab_file(dir, "registered", GF_NOHEADER);
-	if (file.size() < 3)
-		return 0;
-	return std::stoi(file[2]);
+    const auto dir = get_conf_param("licensedir", LICENSEDIR);
+    const auto file = grab_file(dir, "registered", GF_NOHEADER);
+    if (file.size() < 3)
+        return 0;
+    return std::stoi(file[2]);
 }

--- a/log.cc
+++ b/log.cc
@@ -22,20 +22,20 @@
 std::string
 expand_sep(const std::string_view &str, int fl, int type)
 {
-	const auto tmp_status = status;
-	const std::string oldeval(evalbuf);
-	evalbuf[0] = '\0';
-	status |= S_EXECUTE;
-	if (type == M_RFP)
-		itemsep(str, fl);
-	else
-		confsep(str, confidx, &st_glob, part, fl);
-	status &= ~S_EXECUTE;
-	std::string sepbuf(evalbuf);
-	strlcpy(evalbuf, oldeval.c_str(), sizeof(evalbuf));
-	status = tmp_status;
+    const auto tmp_status = status;
+    const std::string oldeval(evalbuf);
+    evalbuf[0] = '\0';
+    status |= S_EXECUTE;
+    if (type == M_RFP)
+        itemsep(str, fl);
+    else
+        confsep(str, confidx, &st_glob, part, fl);
+    status &= ~S_EXECUTE;
+    std::string sepbuf(evalbuf);
+    strlcpy(evalbuf, oldeval.c_str(), sizeof(evalbuf));
+    status = tmp_status;
 
-	return sepbuf;
+    return sepbuf;
 }
 
 /* IN : event name */
@@ -43,27 +43,27 @@ expand_sep(const std::string_view &str, int fl, int type)
 static std::string
 find_event(const std::string_view &event, std::string &logfile)
 {
-	/* Look up variables: <event>log, <event>logsep */
-	auto var = str::concat({event, "log"});
-	const auto exp = expand(var, DM_VAR);
-	if (exp.empty())
-		return "";
-	logfile = exp;
-	var.append("sep");
-	return expand(var, DM_VAR);
+    /* Look up variables: <event>log, <event>logsep */
+    auto var = str::concat({event, "log"});
+    const auto exp = expand(var, DM_VAR);
+    if (exp.empty())
+        return "";
+    logfile = exp;
+    var.append("sep");
+    return expand(var, DM_VAR);
 }
 
 void
 custom_log(const char *event, int type)
 {
-	std::string logfile;
-	const auto sepstr = find_event(event, logfile);
-	if (sepstr.empty())
-		return;
-	const auto file = expand_sep(logfile, 1, type);
-	const auto str =  expand_sep(sepstr, 0, type);
-	if (!file.empty() && !str.empty())
-		write_file(file, str);
+    std::string logfile;
+    const auto sepstr = find_event(event, logfile);
+    if (sepstr.empty())
+        return;
+    const auto file = expand_sep(logfile, 1, type);
+    const auto str = expand_sep(sepstr, 0, type);
+    if (!file.empty() && !str.empty())
+        write_file(file, str);
 }
 
 /******************************************************************************/
@@ -73,17 +73,19 @@ logevent(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc != 4) {
-		std::println("usage: log <event> <filename> <sepstring>");
-		return 1;
-	}
+    if (argc != 4) {
+        std::println("usage: log <event> <filename> <sepstring>");
+        return 1;
+    }
 
-	const char *q = (argv[2][0] == '"') ? "" : "\"";
-	const auto logconst = std::format("constant {}log {}{}{}", argv[1], q, argv[2], q);
-	command(logconst.c_str(), 0);
-	q = (argv[3][0] == '"') ? "" : "\"";
-	const auto logsep = std::format("constant {}logsep {}{}{}", argv[1], q, argv[3], q);
-	command(logsep.c_str(), 0);
+    const char *q = (argv[2][0] == '"') ? "" : "\"";
+    const auto logconst =
+        std::format("constant {}log {}{}{}", argv[1], q, argv[2], q);
+    command(logconst.c_str(), 0);
+    q = (argv[3][0] == '"') ? "" : "\"";
+    const auto logsep =
+        std::format("constant {}logsep {}{}{}", argv[1], q, argv[3], q);
+    command(logsep.c_str(), 0);
 
-	return 1;
+    return 1;
 }

--- a/macro.cc
+++ b/macro.cc
@@ -34,7 +34,8 @@
 #include "yapp.h"
 
 /* Message-Id: <%14D.%{uid}@%{hostname}>\n */
-#define MAILHEADER "\
+#define MAILHEADER                                                             \
+    "\
 Date: %15D\n\
 From: \"%{fullname}\" <%{email}>\n\
 Subject: %(pRe: %)%h\n\
@@ -42,205 +43,313 @@ Message-Id: <%14D.%{uid}@%{hostname}>\n\
 To: %{address}\n\
 %(rIn-Reply-To: <%m> from \"%a\" at %d\n%)"
 
-#define MAILSEP "\
+#define MAILSEP                                                                \
+    "\
 %(1x%a writes:%)\
 %(2x> %L%)\
 %(4x%)"
 
-extern int exit_status;  // XXX
+extern int exit_status; // XXX
 
-namespace {
+namespace
+{
 
 // The current set of macros.
 // XXX: Should be a trie.
 std::vector<macro_t> macros;
 
 const std::unordered_set<std::string_view> rovars{
-    "fullname", "login", "uid", "work", "home", "hostname", "address",
-    "mailheader", "pathinfo", "requestmethod", "pid", "exit", "version",
-    "status", "mode", "lowresp", "fwlist", "remotehost", "querystring",
-    "confname", "bbsdir", "wwwdir", "sysop", "cflist", "conflist", "fromlogin",
-    "cgidir", "euid", "nobody", "partdir", "remoteaddr", "racl", "wacl", "cacl",
-    "aacl", "cursubj", "hitstoday", "newresps", "confdir", "isnew",
-    "isbrandnew", "isnewresp", "canracl", "canwacl", "cancacl", "canaacl",
-    "userfile", "verifyemail", "userdbm",
+    "fullname",
+    "login",
+    "uid",
+    "work",
+    "home",
+    "hostname",
+    "address",
+    "mailheader",
+    "pathinfo",
+    "requestmethod",
+    "pid",
+    "exit",
+    "version",
+    "status",
+    "mode",
+    "lowresp",
+    "fwlist",
+    "remotehost",
+    "querystring",
+    "confname",
+    "bbsdir",
+    "wwwdir",
+    "sysop",
+    "cflist",
+    "conflist",
+    "fromlogin",
+    "cgidir",
+    "euid",
+    "nobody",
+    "partdir",
+    "remoteaddr",
+    "racl",
+    "wacl",
+    "cacl",
+    "aacl",
+    "cursubj",
+    "hitstoday",
+    "newresps",
+    "confdir",
+    "isnew",
+    "isbrandnew",
+    "isnewresp",
+    "canracl",
+    "canwacl",
+    "cancacl",
+    "canaacl",
+    "userfile",
+    "verifyemail",
+    "userdbm",
     "ticket",
 };
 
 inline std::string
 getenv_or(const char *name, const std::string_view &def)
 {
-	if (const char *val = getenv(name); val != nullptr)
-		return val;
-	return std::string(def);
+    if (const char *val = getenv(name); val != nullptr)
+        return val;
+    return std::string(def);
 }
 
 inline std::string
 getconf_or(const std::size_t ci, const std::string_view &def)
 {
-	const auto config = get_config(confidx);
-	if (config.size() > ci)
-		return config[ci];
-	return std::string(def);
+    const auto config = get_config(confidx);
+    if (config.size() > ci)
+        return config[ci];
+    return std::string(def);
 }
 
-const std::unordered_map<std::string_view, std::function<std::string()>> defaults{
-    {"aacl",         []{ load_acl(confidx); return acl_list[CHACL_RIGHT]; }},
-    {"alpha",        []{ return getenv_or("ALPHA", ""); }},
-    {"address",      []{ return getconf_or(CF_EMAIL, ""); }},
-    {"beta",         []{ return getenv_or("BETA", ""); }},
-    {"bufdel",       []{ return BUFDEL; }},
-    {"bullmsg",      []{ return BULLMSG; }},
-    {"brandnew",     []{ return std::to_string(st_glob.i_brandnew); }},
-    {"bbsdir",       []{ return get_conf_param("bbsdir", BBSDIR); }},
-    {"conference",   []{ return CONFERENCE; }},
-    {"cmddel",       []{ return CMDDEL; }},
-    {"censored",     []{ return CENSORED; }},
-    {"checkmsg",     []{ return CHECKMSG; }},
-    {"confindexmsg", []{ return CONFINDEXMSG; }},
-    {"confmsg",      []{ return CONFMSG; }},
-    {"curitem",      []{ return std::to_string(st_glob.i_current); }},
-    {"curresp",      []{ return std::to_string(st_glob.r_current); }},
-    {"curline",      []{ return std::to_string(st_glob.l_current); }},
-    {"cfadm",        []{ return get_conf_param("cfadm", CFADM); }},
-    {"cflist",       []{ return cfliststr; }},
-    {"cursubj",      []{ if (confidx >= 0 && st_glob.i_current <= st_glob.i_last)
-				return get_subj(confidx, st_glob.i_current - 1, sum);
-			 return ""; }},
-    {"confname",     []{ return confidx < 0 ? "noconf" : compress(conflist[confidx].name); }},
-    {"confdir",	     []{ return (confidx >= 0) ? conflist[confidx].location : "noconf"; }},
-    {"conflist",     []{ std::string out = " ";
-			 for (const auto &conf: conflist)
-				out.append(compress(conf.name)).append(" ");
-			 return out; }},
-    {"cgidir",       []{ auto name= getenv_or("SCRIPT_NAME", ".");
-			 if (const auto pos = name.rfind("/"); pos != std::string::npos)
-				name.erase(pos);
-			 return name; }},
-    {"cacl",         []{ load_acl(confidx);
-			 return acl_list[ENTER_RIGHT]; }},
-    {"canaacl",      []{ return std::to_string(check_acl(CHACL_RIGHT, confidx)); }},
-    {"canracl",      []{ return std::to_string(check_acl(JOIN_RIGHT, confidx)); }},
-    {"canwacl",      []{ return std::to_string(check_acl(RESPOND_RIGHT, confidx)); }},
-    {"cancacl",      []{ return std::to_string(check_acl(ENTER_RIGHT, confidx)); }},
-    {"delta",        []{ return getenv_or("DELTA", ""); }},
-    {"editor",       []{ return getenv_or("EDITOR", EDITOR); }},
-    {"edbprompt",    []{ return EDBPROMPT; }},
-    {"escape",       []{ return ESCAPE; }},
-    {"email",        []{ return email; }},
-    {"euid",         []{ return std::to_string(geteuid()); }},
-    {"exit",         []{ return std::to_string(exit_status); }},
-    {"fairwitness",  []{ return FAIRWITNESS; }},
-    {"fsep",         []{ return FSEP; }},
-    {"firstitem",    []{ return std::to_string(st_glob.i_first); }},
-    {"fromlogin",    []{ return re[st_glob.r_current].login; }},
-    {"fullname",     []{ return std::string(fullname_in_conference(&st_glob)); }},
-    {"fwlist",       []{ return getconf_or(CF_FWLIST, ""); }},
-    {"gamma",        []{ return getenv_or("GAMMA", ""); }},
-    {"gecos",        []{ return GECOS; }},
-    {"groupindexmsg",[]{ return GROUPINDEXMSG; }},
-    {"hitstoday",    []{ return std::to_string(get_hits_today()); }},
-    {"highresp",     []{ return std::to_string(st_glob.r_last); }},
-    {"home",         []{ return home; }},
-    {"hostname",     []{ return hostname; }},
-    {"item",         []{ return ITEM; }},
-    {"ishort",       []{ return Iint; }},
-    {"isep",         []{ return ISEP; }},
-    {"indxmsg",      []{ return INDXMSG; }},
-    {"isbrandnew",   []{ auto i = st_glob.i_current - 1;
-			 return std::to_string(is_brandnew(&part[i], &sum[i])); }},
-    {"isnewresp",    []{ auto i = st_glob.i_current - 1;
-			 return std::to_string(is_newresp(&part[i], &sum[i])); }},
-    {"isnew",        []{ auto i = st_glob.i_current - 1;
-			 return std::to_string(is_newresp(&part[i], &sum[i]) ||
-			    is_brandnew(&part[i], &sum[i])); }},
-    {"joqprompt",    []{ return JOQPROMPT; }},
-    {"joinmsg",      []{ return JOINMSG; }},
-    {"linmsg",       []{ return LINMSG; }},
-    {"loutmsg",      []{ return LOUTMSG; }},
-    {"listmsg",      []{ return LISTMSG; }},
-    {"lastitem",     []{ return std::to_string(st_glob.i_last); }},
-    {"lowresp",      []{ return std::to_string(st_glob.r_first); }},
-    {"lastresp",     []{ return std::to_string(sum[st_glob.i_current - 1].nr - 1); }},
-    {"login",        []{ return login; }},
-    {"mailmsg",      []{ return MAILMSG; }},
-    {"mailsep",      []{ return MAILSEP; }},
-    {"mailheader",   []{ return MAILHEADER; }},
-    {"mode",         []{ return std::to_string((int)mode); }},
-    {"noconfp",      []{ return NOCONFP; }},
-    {"nsep",         []{ return NSEP; }},
-    {"newssep",      []{ return NEWSSEP; }},
-    {"nextconf",     []{ return nextconf(); }},
-    {"nextnewconf",  []{ return nextnewconf(); }},
-    {"nextitem",     []{ return std::to_string(st_glob.i_next); }},
-    {"newresp",      []{ return std::to_string(st_glob.i_newresp); }},
-    {"numitems",     []{ return std::to_string(st_glob.i_numitems); }},
-    {"newresps",     []{ auto i = st_glob.i_current - 1;
-			 return std::to_string(sum[i].nr - abs(part[i].nr)); }},
-    {"nobody",       []{ return get_conf_param("nobody", NOBODY); }},
-    {"obvprompt",    []{ return OBVPROMPT; }},
-    {"pathinfo",     []{ auto info = getenv_or("PATH_INFO", " ");
-                         info.erase(0, 1);
-			 return info; }},
-    {"pid",          []{ return std::to_string(getpid()); }},
-    {"printmsg",     []{ return PRINTMSG; }},
-    {"partmsg",      []{ return PARTMSG; }},
-    {"prevconf",     []{ return prevconf(); }},
-    {"previtem",     []{ return std::to_string(st_glob.i_prev); }},
-    {"partdir",      []{ return partdir; }},
-    {"prompt",       []{ return PROMPT; }},
-    {"querystring",  []{ return getenv_or("QUERY_STRING", ""); }},
-    {"remotehost",   []{ if (getuid() != get_nobody_uid())
-				return hostname; /* localhost */
-			 return getenv_or("REMOTE_HOST", ""); }},
-    {"remoteaddr",   []{ if (getuid() != get_nobody_uid()) // localaddr
-			 return std::string("127.0.0.1");
-			 return getenv_or("REMOTE_ADDR", ""); }},
-    {"requestmethod",[]{ return getenv_or("REQUEST_METHOD", ""); }},
-    {"racl",         []{ load_acl(confidx);
-			 return acl_list[JOIN_RIGHT]; }},
-    {"rfpprompt",    []{ return RFPPROMPT; }},
-    {"rsep",         []{ return RSEP; }},
-    {"replysep",     []{ return REPLYSEP; }},
-    {"subject",      []{ return SUBJECT; }},
-    {"scribbled",    []{ return SCRIBBLED; }},
-    {"scribok",      []{ return SCRIBOK; }},
-    {"shell",        []{ return getenv_or("SHELL", SHELL); }},
-    {"status",       []{ return std::format("0x{:x}", status); }},
-    {"seenresp",     []{ return std::to_string(abs(part[st_glob.i_current - 1].nr)); }},
-    {"sysop",        []{ return get_sysop_login(); }},
-    {"ticket",       []{ return get_ticket(0, login); }},
-    {"text",         []{ return TEXT; }},
-    {"txtsep",       []{ return TXTSEP; }},
-    {"totalnewresp", []{ return std::to_string(st_glob.r_totalnewresp); }},
-    {"unseen",       []{ return std::to_string(st_glob.i_unseen); }},
-    {"userdbm",      []{ return get_conf_param("userdbm", USERDBM); }},
-    {"uid",          []{ return std::to_string(uid); }},
-    {"userfile",     []{ return get_userfile(login); }},
-    {"visual",       []{ if (const auto *vis = getenv("VISUAL"); vis != nullptr)
-				return std::string(vis);
-			 return expand("editor", DM_VAR); }},
-    {"verifyemail",  []{ return get_conf_param( "verifyemail", VERIFY_EMAIL); }},
-    {"version",      []{ return VERSION; }},
-    {"wacl",         []{ load_acl(confidx);
-			 return acl_list[RESPOND_RIGHT]; }},
-    {"wellmsg",      []{ return WELLMSG; }},
-    {"work",         []{ return work; }},
-    {"wwwdir",       []{ const auto wwwdef = get_conf_param("bbsdir", BBSDIR) + "/www";
-			 return get_conf_param("wwwdir", wwwdef); }},
-    {"zsep",         []{ return ZSEP; }},
+const std::unordered_map<std::string_view, std::function<std::string()>>
+    defaults{
+        {"aacl",
+         [] {
+                load_acl(confidx);
+                return acl_list[CHACL_RIGHT];
+            }                                                                  },
+        {"alpha",         [] { return getenv_or("ALPHA", ""); }                },
+        {"address",       [] { return getconf_or(CF_EMAIL, ""); }              },
+        {"beta",          [] { return getenv_or("BETA", ""); }                 },
+        {"bufdel",        [] { return BUFDEL; }                                },
+        {"bullmsg",       [] { return BULLMSG; }                               },
+        {"brandnew",      [] { return std::to_string(st_glob.i_brandnew); }    },
+        {"bbsdir",        [] { return get_conf_param("bbsdir", BBSDIR); }      },
+        {"conference",    [] { return CONFERENCE; }                            },
+        {"cmddel",        [] { return CMDDEL; }                                },
+        {"censored",      [] { return CENSORED; }                              },
+        {"checkmsg",      [] { return CHECKMSG; }                              },
+        {"confindexmsg",  [] { return CONFINDEXMSG; }                          },
+        {"confmsg",       [] { return CONFMSG; }                               },
+        {"curitem",       [] { return std::to_string(st_glob.i_current); }     },
+        {"curresp",       [] { return std::to_string(st_glob.r_current); }     },
+        {"curline",       [] { return std::to_string(st_glob.l_current); }     },
+        {"cfadm",         [] { return get_conf_param("cfadm", CFADM); }        },
+        {"cflist",        [] { return cfliststr; }                             },
+        {"cursubj",
+         [] {
+                if (confidx >= 0 && st_glob.i_current <= st_glob.i_last)
+                    return get_subj(confidx, st_glob.i_current - 1, sum);
+                return "";
+            }                                                                  },
+        {"confname",
+         [] {
+                return confidx < 0 ? "noconf"
+                                   : compress(conflist[confidx].name);
+            }                                                                  },
+        {"confdir",
+         [] {
+                return (confidx >= 0) ? conflist[confidx].location : "noconf";
+            }                                                                  },
+        {"conflist",
+         [] {
+                std::string out = " ";
+                for (const auto &conf : conflist)
+                    out.append(compress(conf.name)).append(" ");
+                return out;
+            }                                                                  },
+        {"cgidir",
+         [] {
+                auto name = getenv_or("SCRIPT_NAME", ".");
+                if (const auto pos = name.rfind("/"); pos != std::string::npos)
+                    name.erase(pos);
+                return name;
+            }                                                                  },
+        {"cacl",
+         [] {
+                load_acl(confidx);
+                return acl_list[ENTER_RIGHT];
+            }                                                                  },
+        {"canaacl",
+         [] { return std::to_string(check_acl(CHACL_RIGHT, confidx)); }        },
+        {"canracl",
+         [] { return std::to_string(check_acl(JOIN_RIGHT, confidx)); }         },
+        {"canwacl",
+         [] { return std::to_string(check_acl(RESPOND_RIGHT, confidx)); }      },
+        {"cancacl",
+         [] { return std::to_string(check_acl(ENTER_RIGHT, confidx)); }        },
+        {"delta",         [] { return getenv_or("DELTA", ""); }                },
+        {"editor",        [] { return getenv_or("EDITOR", EDITOR); }           },
+        {"edbprompt",     [] { return EDBPROMPT; }                             },
+        {"escape",        [] { return ESCAPE; }                                },
+        {"email",         [] { return email; }                                 },
+        {"euid",          [] { return std::to_string(geteuid()); }             },
+        {"exit",          [] { return std::to_string(exit_status); }           },
+        {"fairwitness",   [] { return FAIRWITNESS; }                           },
+        {"fsep",          [] { return FSEP; }                                  },
+        {"firstitem",     [] { return std::to_string(st_glob.i_first); }       },
+        {"fromlogin",     [] { return re[st_glob.r_current].login; }           },
+        {"fullname",
+         [] { return std::string(fullname_in_conference(&st_glob)); }          },
+        {"fwlist",        [] { return getconf_or(CF_FWLIST, ""); }             },
+        {"gamma",         [] { return getenv_or("GAMMA", ""); }                },
+        {"gecos",         [] { return GECOS; }                                 },
+        {"groupindexmsg", [] { return GROUPINDEXMSG; }                         },
+        {"hitstoday",     [] { return std::to_string(get_hits_today()); }      },
+        {"highresp",      [] { return std::to_string(st_glob.r_last); }        },
+        {"home",          [] { return home; }                                  },
+        {"hostname",      [] { return hostname; }                              },
+        {"item",          [] { return ITEM; }                                  },
+        {"ishort",        [] { return Iint; }                                  },
+        {"isep",          [] { return ISEP; }                                  },
+        {"indxmsg",       [] { return INDXMSG; }                               },
+        {"isbrandnew",
+         [] {
+                auto i = st_glob.i_current - 1;
+                return std::to_string(is_brandnew(&part[i], &sum[i]));
+            }                                                                  },
+        {"isnewresp",
+         [] {
+                auto i = st_glob.i_current - 1;
+                return std::to_string(is_newresp(&part[i], &sum[i]));
+            }                                                                  },
+        {"isnew",
+         [] {
+                auto i = st_glob.i_current - 1;
+                return std::to_string(is_newresp(&part[i], &sum[i]) ||
+                                      is_brandnew(&part[i], &sum[i]));
+            }                                                                  },
+        {"joqprompt",     [] { return JOQPROMPT; }                             },
+        {"joinmsg",       [] { return JOINMSG; }                               },
+        {"linmsg",        [] { return LINMSG; }                                },
+        {"loutmsg",       [] { return LOUTMSG; }                               },
+        {"listmsg",       [] { return LISTMSG; }                               },
+        {"lastitem",      [] { return std::to_string(st_glob.i_last); }        },
+        {"lowresp",       [] { return std::to_string(st_glob.r_first); }       },
+        {"lastresp",
+         [] { return std::to_string(sum[st_glob.i_current - 1].nr - 1); }      },
+        {"login",         [] { return login; }                                 },
+        {"mailmsg",       [] { return MAILMSG; }                               },
+        {"mailsep",       [] { return MAILSEP; }                               },
+        {"mailheader",    [] { return MAILHEADER; }                            },
+        {"mode",          [] { return std::to_string((int)mode); }             },
+        {"noconfp",       [] { return NOCONFP; }                               },
+        {"nsep",          [] { return NSEP; }                                  },
+        {"newssep",       [] { return NEWSSEP; }                               },
+        {"nextconf",      [] { return nextconf(); }                            },
+        {"nextnewconf",   [] { return nextnewconf(); }                         },
+        {"nextitem",      [] { return std::to_string(st_glob.i_next); }        },
+        {"newresp",       [] { return std::to_string(st_glob.i_newresp); }     },
+        {"numitems",      [] { return std::to_string(st_glob.i_numitems); }    },
+        {"newresps",
+         [] {
+                auto i = st_glob.i_current - 1;
+                return std::to_string(sum[i].nr - abs(part[i].nr));
+            }                                                                  },
+        {"nobody",        [] { return get_conf_param("nobody", NOBODY); }      },
+        {"obvprompt",     [] { return OBVPROMPT; }                             },
+        {"pathinfo",
+         [] {
+                auto info = getenv_or("PATH_INFO", " ");
+                info.erase(0, 1);
+                return info;
+            }                                                                  },
+        {"pid",           [] { return std::to_string(getpid()); }              },
+        {"printmsg",      [] { return PRINTMSG; }                              },
+        {"partmsg",       [] { return PARTMSG; }                               },
+        {"prevconf",      [] { return prevconf(); }                            },
+        {"previtem",      [] { return std::to_string(st_glob.i_prev); }        },
+        {"partdir",       [] { return partdir; }                               },
+        {"prompt",        [] { return PROMPT; }                                },
+        {"querystring",   [] { return getenv_or("QUERY_STRING", ""); }         },
+        {"remotehost",
+         [] {
+                if (getuid() != get_nobody_uid())
+                    return hostname; /* localhost */
+                return getenv_or("REMOTE_HOST", "");
+            }                                                                  },
+        {"remoteaddr",
+         [] {
+                if (getuid() != get_nobody_uid()) // localaddr
+                    return std::string("127.0.0.1");
+                return getenv_or("REMOTE_ADDR", "");
+            }                                                                  },
+        {"requestmethod", [] { return getenv_or("REQUEST_METHOD", ""); }       },
+        {"racl",
+         [] {
+                load_acl(confidx);
+                return acl_list[JOIN_RIGHT];
+            }                                                                  },
+        {"rfpprompt",     [] { return RFPPROMPT; }                             },
+        {"rsep",          [] { return RSEP; }                                  },
+        {"replysep",      [] { return REPLYSEP; }                              },
+        {"subject",       [] { return SUBJECT; }                               },
+        {"scribbled",     [] { return SCRIBBLED; }                             },
+        {"scribok",       [] { return SCRIBOK; }                               },
+        {"shell",         [] { return getenv_or("SHELL", SHELL); }             },
+        {"status",        [] { return std::format("0x{:x}", status); }         },
+        {"seenresp",
+         [] { return std::to_string(abs(part[st_glob.i_current - 1].nr)); }    },
+        {"sysop",         [] { return get_sysop_login(); }                     },
+        {"ticket",        [] { return get_ticket(0, login); }                  },
+        {"text",          [] { return TEXT; }                                  },
+        {"txtsep",        [] { return TXTSEP; }                                },
+        {"totalnewresp",  [] { return std::to_string(st_glob.r_totalnewresp); }},
+        {"unseen",        [] { return std::to_string(st_glob.i_unseen); }      },
+        {"userdbm",       [] { return get_conf_param("userdbm", USERDBM); }    },
+        {"uid",           [] { return std::to_string(uid); }                   },
+        {"userfile",      [] { return get_userfile(login); }                   },
+        {"visual",
+         [] {
+                if (const auto *vis = getenv("VISUAL"); vis != nullptr)
+                    return std::string(vis);
+                return expand("editor", DM_VAR);
+            }                                                                  },
+        {"verifyemail",
+         [] { return get_conf_param("verifyemail", VERIFY_EMAIL); }            },
+        {"version",       [] { return VERSION; }                               },
+        {"wacl",
+         [] {
+                load_acl(confidx);
+                return acl_list[RESPOND_RIGHT];
+            }                                                                  },
+        {"wellmsg",       [] { return WELLMSG; }                               },
+        {"work",          [] { return work; }                                  },
+        {"wwwdir",
+         [] {
+                const auto wwwdef = get_conf_param("bbsdir", BBSDIR) + "/www";
+                return get_conf_param("wwwdir", wwwdef);
+            }                                                                  },
+        {"zsep",          [] { return ZSEP; }                                  },
 };
 
-}  // anonymous namespace
+} // anonymous namespace
 
 std::optional<std::reference_wrapper<macro_t>>
 find_macro(const std::string_view &name, mask_t mask)
 {
-	for (auto &m: macros) {
-		if ((mask & m.mask) != 0 && match(name, m.name))
-			return m;
-	}
-	return {};
+    for (auto &m : macros) {
+        if ((mask & m.mask) != 0 && match(name, m.name))
+            return m;
+    }
+    return {};
 }
 
 /******************************************************************************/
@@ -253,18 +362,18 @@ find_macro(const std::string_view &name, mask_t mask)
 std::string
 expand(const std::string_view &macro, mask_t mask)
 {
-	mask &= ~DM_CONSTANT;
-	if (debug & DB_MACRO)
-		std::println("expand: '{}' {}", macro, mask);
-	const auto mac = find_macro(macro, mask);
-	if (mac)
-		return mac->get().value;
-	if (mask & DM_VAR) {
-		const auto entry = defaults.find(str::lowercase(macro));
-		if (entry != defaults.end())
-			return entry->second();
-	}
-	return "";
+    mask &= ~DM_CONSTANT;
+    if (debug & DB_MACRO)
+        std::println("expand: '{}' {}", macro, mask);
+    const auto mac = find_macro(macro, mask);
+    if (mac)
+        return mac->get().value;
+    if (mask & DM_VAR) {
+        const auto entry = defaults.find(str::lowercase(macro));
+        if (entry != defaults.end())
+            return entry->second();
+    }
+    return "";
 }
 
 // ARGUMENTS:
@@ -274,30 +383,30 @@ expand(const std::string_view &macro, mask_t mask)
 std::string
 capexpand(const std::string_view &mac, mask_t mask, bool capitalize)
 {
-	auto expanded = expand(mac, mask);
-	if (!expanded.empty() && capitalize)
-		expanded[0] = toupper(expanded[0]);
-	return expanded;
+    auto expanded = expand(mac, mask);
+    if (!expanded.empty() && capitalize)
+        expanded[0] = toupper(expanded[0]);
+    return expanded;
 }
 
 static int
 print_macros(void)
 {
-	FILE *fp;
+    FILE *fp;
 
-	/* Display current macros */
-	open_pipe();
-	if (status & S_PAGER)
-		fp = st_glob.outp;
-	else
-		fp = stdout;
-	std::println(fp, "What       Is Short For\n");
-	for (const auto &m: std::views::reverse(macros)) {
-		if ((status & S_INT) != 0)
-			break;
-		std::println(fp, "{:<10} {:3} {}", m.name, m.mask, m.value);
-	}
-	return 1;
+    /* Display current macros */
+    open_pipe();
+    if (status & S_PAGER)
+        fp = st_glob.outp;
+    else
+        fp = stdout;
+    std::println(fp, "What       Is Short For\n");
+    for (const auto &m : std::views::reverse(macros)) {
+        if ((status & S_INT) != 0)
+            break;
+        std::println(fp, "{:<10} {:3} {}", m.name, m.mask, m.value);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* PROCESS MACRO DEFINES AND UNDEFINES                                        */
@@ -305,118 +414,119 @@ print_macros(void)
 int
 define(int argc, char **argv)
 {
-	int con = 0;
-	if (match(argv[0], "const_ant"))
-		con = DM_CONSTANT;
-	if (argc <= 1) /* Display current macros */
-		return print_macros();
-	const std::string_view name{argv[1], strlen(argv[1])};
-	if (argc == 2) {
-		/* remove name from macro table */
-		undef_name(name);
-		return 1;
-	}
-	if (argc == 3) {
-		def_macro(name, DM_VAR | con, argv[2]);
-		return 1;
-	}
-	std::string value(argv[3]);
-	for (auto i = 4; i < argc; i++) {
-		value.push_back(' ');
-		value.append(argv[i]);
-	}
-	def_macro(name, atoi(argv[2]) | con, value);
-	return 1;
+    int con = 0;
+    if (match(argv[0], "const_ant"))
+        con = DM_CONSTANT;
+    if (argc <= 1) /* Display current macros */
+        return print_macros();
+    const std::string_view name{argv[1], strlen(argv[1])};
+    if (argc == 2) {
+        /* remove name from macro table */
+        undef_name(name);
+        return 1;
+    }
+    if (argc == 3) {
+        def_macro(name, DM_VAR | con, argv[2]);
+        return 1;
+    }
+    std::string value(argv[3]);
+    for (auto i = 4; i < argc; i++) {
+        value.push_back(' ');
+        value.append(argv[i]);
+    }
+    def_macro(name, atoi(argv[2]) | con, value);
+    return 1;
 }
 
 // Defines or updates a macro definition.  Takes the
 // alias/variable name, the macro type, and a string
 // that the macro expands to.
 void
-def_macro(const std::string_view &name, mask_t mask, const std::string_view &val)
+def_macro(
+    const std::string_view &name, mask_t mask, const std::string_view &val)
 {
-	if (mask == 0) {
-		std::println("Bad mask value.");
-		return;
-	}
-	if (rovars.contains(name)) {
-		std::println("Variable '{}' is readonly.", name);
-		return;
-	}
-	auto value = str::unquote(val);
-	if ((mask & DM_ENVAR) != 0) {
-		const std::string name0(name);
-		setenv(name0.c_str(), value.c_str(), 1);
-		return;
-	}
+    if (mask == 0) {
+        std::println("Bad mask value.");
+        return;
+    }
+    if (rovars.contains(name)) {
+        std::println("Variable '{}' is readonly.", name);
+        return;
+    }
+    auto value = str::unquote(val);
+    if ((mask & DM_ENVAR) != 0) {
+        const std::string name0(name);
+        setenv(name0.c_str(), value.c_str(), 1);
+        return;
+    }
 
-	// Add name to macro table
-	if (orig_stdin[stdin_stack_top].type & STD_SUPERSANE)
-		mask |= DM_SUPERSANE;
-	auto m = find_macro(name, mask);
-	if (!m) {
-		// Create new element
-		macro_t nmac{};
-		nmac.name.assign(name);
-		nmac.mask = mask;
-		nmac.value = value;
-		macros.push_back(nmac);
-		return;
-	}
-	// already defined
-	auto &mac = m->get();
-	if ((mac.mask & DM_CONSTANT) != 0) {
-		if ((flags & O_QUIET) == 0 && !str::eq(mac.value, value))
-			std::println("Can't redefine constant '{}'", mac.name);
-		return;
-	}
-	if ((mac.mask & (DM_SANE | DM_SUPERSANE)) != 0 ||
-	    (mask & (DM_SANE | DM_SUPERSANE)) == 0) {
+    // Add name to macro table
+    if (orig_stdin[stdin_stack_top].type & STD_SUPERSANE)
+        mask |= DM_SUPERSANE;
+    auto m = find_macro(name, mask);
+    if (!m) {
+        // Create new element
+        macro_t nmac{};
+        nmac.name.assign(name);
+        nmac.mask = mask;
+        nmac.value = value;
+        macros.push_back(nmac);
+        return;
+    }
+    // already defined
+    auto &mac = m->get();
+    if ((mac.mask & DM_CONSTANT) != 0) {
+        if ((flags & O_QUIET) == 0 && !str::eq(mac.value, value))
+            std::println("Can't redefine constant '{}'", mac.name);
+        return;
+    }
+    if ((mac.mask & (DM_SANE | DM_SUPERSANE)) != 0 ||
+        (mask & (DM_SANE | DM_SUPERSANE)) == 0) {
 
-		mac.mask = mask;
-		mac.value = value;
-	}
+        mac.mask = mask;
+        mac.value = value;
+    }
 }
 
 // Removes all macros matching the given mask.
 void
 undefine(std::uint16_t mask)
 {
-	if (debug & DB_MACRO)
-		std::println("undefine: mask={}", mask);
-	std::erase_if(macros,
-	    [=](const auto &mac) { return (mac.mask & mask) != 0; });
+    if (debug & DB_MACRO)
+        std::println("undefine: mask={}", mask);
+    std::erase_if(
+        macros, [=](const auto &mac) { return (mac.mask & mask) != 0; });
 }
 
 void
 undef_name(const std::string_view &name)
 {
-	if (debug & DB_MACRO)
-		std::println("undef name={}", name);
-	std::erase_if(macros,
-	    [&](const auto &mac) { return match(name, mac.name); });
+    if (debug & DB_MACRO)
+        std::println("undef name={}", name);
+    std::erase_if(
+        macros, [&](const auto &mac) { return match(name, mac.name); });
 }
 
 std::string
 conference(bool cap)
 {
-	return capexpand("conference", DM_VAR, cap);
+    return capexpand("conference", DM_VAR, cap);
 }
 
 std::string
 fairwitness(bool cap)
 {
-	return capexpand("fairwitness", DM_VAR, cap);
+    return capexpand("fairwitness", DM_VAR, cap);
 }
 
 std::string
 topic(bool cap)
 {
-	return capexpand("item", DM_VAR, cap);
+    return capexpand("item", DM_VAR, cap);
 }
 
 std::string
 subject(bool cap)
 {
-	return capexpand("subject", DM_VAR, cap);
+    return capexpand("subject", DM_VAR, cap);
 }

--- a/main.cc
+++ b/main.cc
@@ -28,17 +28,16 @@ Description: This function parses the command line arguments,
 int
 main(int argc, char **argv)
 {
-	if (!strncmp(argv[0] + strlen(argv[0]) - 9, "yappdebug", 9)) {
-		std::println("Content-type: text/plain\n\nSTART OF OUTPUT:");
-		fflush(stdout);
-	}
-	init(argc, argv); /* set up globals */
+    if (!strncmp(argv[0] + strlen(argv[0]) - 9, "yappdebug", 9)) {
+        std::println("Content-type: text/plain\n\nSTART OF OUTPUT:");
+        fflush(stdout);
+    }
+    init(argc, argv); /* set up globals */
 
-	while (get_command("", 0))
-		;
-	endbbs(0);
+    while (get_command("", 0));
+    endbbs(0);
 
-	return 0;
+    return 0;
 }
 
 /******************************************************************************/
@@ -48,7 +47,7 @@ main(int argc, char **argv)
 void
 wputs(const std::string_view &s)
 {
-	fwrite(s.data(), s.size(), 1, stdout);
+    fwrite(s.data(), s.size(), 1, stdout);
 }
 
 extern char evalbuf[MAX_LINE_LENGTH];
@@ -58,18 +57,18 @@ extern char evalbuf[MAX_LINE_LENGTH];
 void
 wfputs(const std::string_view &s, FILE *stream)
 {
-	if (stream)
-		fwrite(s.data(), s.size(), 1, stream);
-	else {
-		const size_t max = std::min(s.size() + 1, MAX_LINE_LENGTH);
-		strlcat(evalbuf, s.data(), max);
-	}
+    if (stream)
+        fwrite(s.data(), s.size(), 1, stream);
+    else {
+        const size_t max = std::min(s.size() + 1, MAX_LINE_LENGTH);
+        strlcat(evalbuf, s.data(), max);
+    }
 }
 
 void
 wputchar(int c)
 {
-	putchar(c);
+    putchar(c);
 }
 
 /* WARNING: the caller is responsible for doing an fflush on the stream
@@ -78,13 +77,13 @@ wputchar(int c)
 void
 wfputc(int c, FILE *fp)
 {
-	if (fp)
-		fputc(c, fp);
-	else {
-		size_t len = strlen(evalbuf);
-		if (len != MAX_LINE_LENGTH) {
-			evalbuf[len] = c;
-			evalbuf[len + 1] = 0;
-		}
-	}
+    if (fp)
+        fputc(c, fp);
+    else {
+        size_t len = strlen(evalbuf);
+        if (len != MAX_LINE_LENGTH) {
+            evalbuf[len] = c;
+            evalbuf[len + 1] = 0;
+        }
+    }
 }

--- a/mem.cc
+++ b/mem.cc
@@ -16,49 +16,49 @@
 static void *
 notnull(void *ptr)
 {
-	if (ptr == NULL) {
-		perror("out of memory");
-		exit(EXIT_FAILURE);
-	}
-	return ptr;
+    if (ptr == NULL) {
+        perror("out of memory");
+        exit(EXIT_FAILURE);
+    }
+    return ptr;
 }
 
 void *
 emalloc(const size_t size)
 {
-	if (size == 0) {
-		fprintf(stderr, "emalloc(0): empty alloc\n");
-		exit(EXIT_FAILURE);
-	}
-	return notnull(malloc(size));
+    if (size == 0) {
+        fprintf(stderr, "emalloc(0): empty alloc\n");
+        exit(EXIT_FAILURE);
+    }
+    return notnull(malloc(size));
 }
 
 void *
 emalloz(const size_t size)
 {
-	void *ptr = emalloc(size);
-	memset(ptr, 0, size);
-	return ptr;
+    void *ptr = emalloc(size);
+    memset(ptr, 0, size);
+    return ptr;
 }
 
 void *
 erealloc(void *ptr, size_t size)
 {
-	if (size == 0) {
-		fprintf(stderr, "erealloc(0): empty alloc\n");
-		exit(EXIT_FAILURE);
-	}
-	return notnull(realloc(ptr, size));
+    if (size == 0) {
+        fprintf(stderr, "erealloc(0): empty alloc\n");
+        exit(EXIT_FAILURE);
+    }
+    return notnull(realloc(ptr, size));
 }
 
 char *
 estrdup(const char *str)
 {
-	return (char *)notnull(strdup(str));
+    return (char *)notnull(strdup(str));
 }
 
 char *
 estrndup(const char *str, const size_t len)
 {
-	return (char *)notnull(strndup(str, len));
+    return (char *)notnull(strndup(str, len));
 }

--- a/misc.cc
+++ b/misc.cc
@@ -47,63 +47,63 @@
 
 /* Misc. commands available at all modes */
 static dispatch_t misc_cmd[] = {
-    { "chfn", chfn, },
-    { "newuser", newuser, },
-    { "passw_d", passwd, },
-    { "arg_set", argset, },
-    { "www_parsepost", www_parse_post, },
-    { "url_encode", url_encode, },
-    { "if", do_if, },
-    { "else", do_else, },
-    { "endif", do_endif, },
-    { "for_each", foreach, },
-    { "c_hange", change, },
-    { "se_t", change, },
-    { "?", help, },
-    { "h_elp", help, },
-    { "exp_lain", help, },
-    { "al_ias", define, },
-    { "def_ine", define, },
-    { "una_lias", define, },
-    { "und_efine", define, },
-    { "const_ant", define, },
-    { "log", logevent, },
-    { "ec_ho", echo, },
-    { "echoe", echo, },
-    { "echon", echo, },
-    { "echoen", echo, },
-    { "echone", echo, },
-    { "m_ail", mail, },
-    { "t_ransmit", mail, },
-    { "sen_dmail", mail, },
-    { "d_isplay", display, },
-    { "que_ry", display, },
-    { "sh_ow", display, },
-    { "load", load_values, },
-    { "save", save_values, },
-    { "t_est", test, },
-    { "rm", do_rm, },
-    { "cd", cd, },
-    { "chd_ir", cd, },
-    { "uma_sk", do_umask, },
-    { "cdate", date, },
-    { "da_te", date, },
+    {"chfn",          chfn          },
+    {"newuser",       newuser       },
+    {"passw_d",       passwd        },
+    {"arg_set",       argset        },
+    {"www_parsepost", www_parse_post},
+    {"url_encode",    url_encode    },
+    {"if",            do_if         },
+    {"else",          do_else       },
+    {"endif",         do_endif      },
+    {"for_each",      foreach       },
+    {"c_hange",       change        },
+    {"se_t",          change        },
+    {"?",             help          },
+    {"h_elp",         help          },
+    {"exp_lain",      help          },
+    {"al_ias",        define        },
+    {"def_ine",       define        },
+    {"una_lias",      define        },
+    {"und_efine",     define        },
+    {"const_ant",     define        },
+    {"log",           logevent      },
+    {"ec_ho",         echo          },
+    {"echoe",         echo          },
+    {"echon",         echo          },
+    {"echoen",        echo          },
+    {"echone",        echo          },
+    {"m_ail",         mail          },
+    {"t_ransmit",     mail          },
+    {"sen_dmail",     mail          },
+    {"d_isplay",      display       },
+    {"que_ry",        display       },
+    {"sh_ow",         display       },
+    {"load",          load_values   },
+    {"save",          save_values   },
+    {"t_est",         test          },
+    {"rm",            do_rm         },
+    {"cd",            cd            },
+    {"chd_ir",        cd            },
+    {"uma_sk",        do_umask      },
+    {"cdate",         date          },
+    {"da_te",         date          },
 /* "clu_ster",  cluster,  */
 #ifdef INCLUDE_EXTRA_COMMANDS
-    { "cfdir", set_cfdir, },
+    {"cfdir",         set_cfdir     },
 #endif
-    { "eval_uate", eval, },
-    { "evali_n", eval, },
-    { "source", do_source, },
-    { "debug", set_debug, },
-    { "cf_list", do_cflist, },
+    {"eval_uate",     eval          },
+    {"evali_n",       eval          },
+    {"source",        do_source     },
+    {"debug",         set_debug     },
+    {"cf_list",       do_cflist     },
     /* ex_it q_uit st_op good_bye log_off log_out h_elp exp_lain sy_stem unix
      * al_ias def_ine una_lias und_efine ec_ho echoe echon echoen echone so_urce
      * m_ail t_ransmit sen_dmail chat write d_isplay que_ry p_articipants
      * w_hoison am_superuser resign chd_ir uma_sk sh_ell f_iles dir_ectory ty_pe
      * e_dit cdate da_te t_est clu_ster
      */
-    { 0, 0 },
+    {0,               0             },
 };
 /******************************************************************************/
 /* DISPATCH CONTROL TO APPROPRIATE MISC. COMMAND FUNCTION                     */
@@ -114,85 +114,85 @@ misc_cmd_dispatch(/* ARGUMENTS:                 */
     char **argv   /* Argument list           */
 )
 {
-	for (auto i = 0; misc_cmd[i].name; i++)
-		if (match(argv[0], misc_cmd[i].name))
-			return misc_cmd[i].func(argc, argv);
+    for (auto i = 0; misc_cmd[i].name; i++)
+        if (match(argv[0], misc_cmd[i].name))
+            return misc_cmd[i].func(argc, argv);
 
-	/* Command dispatch */
-	if (match(argv[0], "q_uit") || match(argv[0], "st_op") ||
-	    match(argv[0], "ex_it")) {
-		status |= S_STOP;
-		return 0;
-	} else if (match(argv[0], "unix_cmd")) {
-		if (argc < 2)
-			std::println("syntax: unix_cmd \"command\"");
-		else {
-			std::string cmd;
-			std::string sep;
-			const auto begin = argv + 1;
-			const auto end = argv + argc;
-			for (auto it = begin; it != end; it++, sep =  " ") {
-				cmd.append(sep);
-				cmd.append(noquote(*it));
-				//sep = " ";
-			}
+    /* Command dispatch */
+    if (match(argv[0], "q_uit") || match(argv[0], "st_op") ||
+        match(argv[0], "ex_it")) {
+        status |= S_STOP;
+        return 0;
+    } else if (match(argv[0], "unix_cmd")) {
+        if (argc < 2)
+            std::println("syntax: unix_cmd \"command\"");
+        else {
+            std::string cmd;
+            std::string sep;
+            const auto begin = argv + 1;
+            const auto end = argv + argc;
+            for (auto it = begin; it != end; it++, sep = " ") {
+                cmd.append(sep);
+                cmd.append(noquote(*it));
+                // sep = " ";
+            }
 
-			/*
-			 * Undone at request of sno and jep
-			 * if (mode==M_SANE)
-			 *	std::println("{} rc cannot exec: {}",
-			 *	    Conference(), buff);
-			 * else
-			 */
-			unix_cmd(cmd);
-		}
-	} else if (argc) {
-		char *p;
-		/* Check for commands of the form:
-		 * variable=value */
-		p = strchr(argv[0], '=');
-		if (p || (argc > 1 && argv[1][0] == '=')) {
-			char *val; /* Arbitrary length value */
-			int i, vallen;
-			/* Compute max vallen */
-			if (p) {
-				vallen = strlen(p + 1) + 1;
-				i = 1;
-			} else {
-				i = 2;
-				vallen = strlen(argv[1] + 1) + 1;
-			}
-			while (i < argc) {
-				if (vallen > 1)
-					vallen++;
-				vallen += strlen(argv[i++]);
-			}
+            /*
+             * Undone at request of sno and jep
+             * if (mode==M_SANE)
+             *	std::println("{} rc cannot exec: {}",
+             *	    Conference(), buff);
+             * else
+             */
+            unix_cmd(cmd);
+        }
+    } else if (argc) {
+        char *p;
+        /* Check for commands of the form:
+         * variable=value */
+        p = strchr(argv[0], '=');
+        if (p || (argc > 1 && argv[1][0] == '=')) {
+            char *val; /* Arbitrary length value */
+            int i, vallen;
+            /* Compute max vallen */
+            if (p) {
+                vallen = strlen(p + 1) + 1;
+                i = 1;
+            } else {
+                i = 2;
+                vallen = strlen(argv[1] + 1) + 1;
+            }
+            while (i < argc) {
+                if (vallen > 1)
+                    vallen++;
+                vallen += strlen(argv[i++]);
+            }
 
-			/* Compose val */
-			val = (char *)emalloc(vallen);
-			if (p) {
-				*p = '\0';
-				strcpy(val, p + 1);
-				i = 1;
-			} else {
-				strcpy(val, argv[1] + 1);
-				i = 2;
-			}
-			while (i < argc) {
-				if (val[0])
-					strcat(val, " ");
-				strcat(val, argv[i++]);
-			}
+            /* Compose val */
+            val = (char *)emalloc(vallen);
+            if (p) {
+                *p = '\0';
+                strcpy(val, p + 1);
+                i = 1;
+            } else {
+                strcpy(val, argv[1] + 1);
+                i = 2;
+            }
+            while (i < argc) {
+                if (val[0])
+                    strcat(val, " ");
+                strcat(val, argv[i++]);
+            }
 
-			/* Execute command */
-			def_macro(argv[0], DM_VAR, val);
-			free(val);
+            /* Execute command */
+            def_macro(argv[0], DM_VAR, val);
+            free(val);
 
-		} else {
-			std::println("Invalid command: {}", argv[0]);
-		}
-	}
-	return 1;
+        } else {
+            std::println("Invalid command: {}", argv[0]);
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* SET UMASK VALUE                                                            */
@@ -203,17 +203,17 @@ do_umask(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	int i;
-	if (argc < 2) {
-		umask(i = umask(0));
-		std::println("{:03o}", i);
-	} else if (!isdigit(argv[1][0])) {
-		std::println("Bad umask \"{}\"specified (must be octal)", argv[1]);
-	} else {
-		sscanf(argv[1], "%o", &i);
-		umask(i);
-	}
-	return 1;
+    int i;
+    if (argc < 2) {
+        umask(i = umask(0));
+        std::println("{:03o}", i);
+    } else if (!isdigit(argv[1][0])) {
+        std::println("Bad umask \"{}\"specified (must be octal)", argv[1]);
+    } else {
+        sscanf(argv[1], "%o", &i);
+        umask(i);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* SEND MAIL TO ANOTHER USER                                                  */
@@ -224,26 +224,26 @@ mail(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc < 2) {
-		unix_cmd("mail");
-	} else if (flags & O_MAILTEXT) {
-		unix_cmd(str::concat({"mail ", argv[1]}));
-	} else {
-		/* dont clear buffer, for reply cmd */
-		const auto cfbuffer = str::concat({work, "/cf.buffer"});
-		if (text_loop(0, "mail")) {
-			std::string to(argv[1]);
-			while (!to.empty()) {
-				unix_cmd(std::format("mail {} < {}", to, cfbuffer));
-				std::println("Mail sent to {}.", to);
-				if (!(flags & O_QUIET))
-					std::println("More recipients (or <return>)? ");
-				ngets(to, st_glob.inp);
-			}
-		}
-		rm(cfbuffer, SL_USER);
-	}
-	return 1;
+    if (argc < 2) {
+        unix_cmd("mail");
+    } else if (flags & O_MAILTEXT) {
+        unix_cmd(str::concat({"mail ", argv[1]}));
+    } else {
+        /* dont clear buffer, for reply cmd */
+        const auto cfbuffer = str::concat({work, "/cf.buffer"});
+        if (text_loop(0, "mail")) {
+            std::string to(argv[1]);
+            while (!to.empty()) {
+                unix_cmd(std::format("mail {} < {}", to, cfbuffer));
+                std::println("Mail sent to {}.", to);
+                if (!(flags & O_QUIET))
+                    std::println("More recipients (or <return>)? ");
+                ngets(to, st_glob.inp);
+            }
+        }
+        rm(cfbuffer, SL_USER);
+    }
+    return 1;
 }
 
 int
@@ -252,18 +252,18 @@ do_rm(          /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	int i;
-	if (argc < 2) {
-		std::println("Usage: rm filename ...");
-		return 2;
-	}
-	for (i = 1; i < argc; i++) {
-		if (rm(argv[i], SL_USER)) {
-			if (!(flags & O_QUIET))
-				error("removing ", argv[1]);
-		}
-	}
-	return 1;
+    int i;
+    if (argc < 2) {
+        std::println("Usage: rm filename ...");
+        return 2;
+    }
+    for (i = 1; i < argc; i++) {
+        if (rm(argv[i], SL_USER)) {
+            if (!(flags & O_QUIET))
+                error("removing ", argv[1]);
+        }
+    }
+    return 1;
 }
 /******************************************************************************/
 /* CHANGE CURRENT WORKING DIRECTORY                                           */
@@ -274,12 +274,12 @@ cd(             /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	} else if (chdir((argc > 1) ? argv[1] : home.c_str()))
-		error("cd'ing to ", argv[1]);
-	return 1;
+    if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    } else if (chdir((argc > 1) ? argv[1] : home.c_str()))
+        error("cd'ing to ", argv[1]);
+    return 1;
 }
 /******************************************************************************/
 /* ECHO ARGUMENTS TO OUTPUT                                                   */
@@ -290,38 +290,38 @@ echo(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	short i;
-	FILE *fp;
-	/* If `echo...` but not `echo...|cmd`  (REDIRECT bit takes precedence)
-	 */
-	if ((status & S_EXECUTE) && !(status & S_REDIRECT)) {
-		fp = NULL;
-	} else if (match(argv[0], "echoe") || match(argv[0], "echoen") ||
-	           match(argv[0], "echone")) {
-		fp = stderr;
-	} else {
-		if (status & S_REDIRECT) {
-			fp = stdout;
-		} else {
-			open_pipe();
-			fp = st_glob.outp;
-			if (!fp) {
-				fp = stdout;
-			}
-		}
-	}
+    short i;
+    FILE *fp;
+    /* If `echo...` but not `echo...|cmd`  (REDIRECT bit takes precedence)
+     */
+    if ((status & S_EXECUTE) && !(status & S_REDIRECT)) {
+        fp = NULL;
+    } else if (match(argv[0], "echoe") || match(argv[0], "echoen") ||
+               match(argv[0], "echone")) {
+        fp = stderr;
+    } else {
+        if (status & S_REDIRECT) {
+            fp = stdout;
+        } else {
+            open_pipe();
+            fp = st_glob.outp;
+            if (!fp) {
+                fp = stdout;
+            }
+        }
+    }
 
-	for (i = 1; i < argc; i++) {
-		wfputs(argv[i], fp);
-		if (i + 1 < argc)
-			wfputc(' ', fp);
-	}
-	if (!strchr(argv[0], 'n'))
-		wfputc('\n', fp);
+    for (i = 1; i < argc; i++) {
+        wfputs(argv[i], fp);
+        if (i + 1 < argc)
+            wfputc(' ', fp);
+    }
+    if (!strchr(argv[0], 'n'))
+        wfputc('\n', fp);
 
-	if (fp)
-		fflush(fp); /* flush when done with wfput stuff */
-	return 1;
+    if (fp)
+        fflush(fp); /* flush when done with wfput stuff */
+    return 1;
 }
 /******************************************************************************/
 /* LOAD VALUES                                                                */
@@ -329,20 +329,20 @@ echo(           /* ARGUMENTS:             */
 int
 load_values(int argc, char **argv)
 {
-	int i;
-	char buff[MAX_LINE_LENGTH];
-	int suid;
-	const auto userfile = get_userfile(login, &suid);
+    int i;
+    char buff[MAX_LINE_LENGTH];
+    int suid;
+    const auto userfile = get_userfile(login, &suid);
 #ifdef HAVE_DBM_OPEN
-	for (i = 1; i < argc; i++) {
-		const auto value = get_dbm(userfile, argv[i], SL_USER);
-		if (buff[0])
-			def_macro(argv[i], DM_VAR, value);
-		else
-			undef_name(argv[i]);
-	}
+    for (i = 1; i < argc; i++) {
+        const auto value = get_dbm(userfile, argv[i], SL_USER);
+        if (buff[0])
+            def_macro(argv[i], DM_VAR, value);
+        else
+            undef_name(argv[i]);
+    }
 #endif
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* SAVE VALUES                                                                */
@@ -353,20 +353,20 @@ save_values(    /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	int i;
-	int suid;
-	const auto userfile = get_userfile(login, &suid);
+    int i;
+    int suid;
+    const auto userfile = get_userfile(login, &suid);
 #ifdef HAVE_DBM_OPEN
 
-	for (i = 1; i < argc; i++) {
-		const auto var = expand(argv[i], DM_VAR);
-		if (!var.empty() && !save_dbm(userfile, argv[i], var, SL_USER)) {
-			error("modifying userfile ", userfile);
-			return 1;
-		}
-	}
+    for (i = 1; i < argc; i++) {
+        const auto var = expand(argv[i], DM_VAR);
+        if (!var.empty() && !save_dbm(userfile, argv[i], var, SL_USER)) {
+            error("modifying userfile ", userfile);
+            return 1;
+        }
+    }
 #endif
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* CHECK THE DATE                                                             */
@@ -377,18 +377,17 @@ date(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	std::vector<std::string> args;
-	for (auto i = 0; i < argc; i++)
-		args.push_back(argv[i]);
-	time_t t = since(args);
-	if (t < LONG_MAX) {
-		if (argv[0][0] == 'c')
-			std::println("{:X}", t); /* cdate command */
-		else
-			std::println("\nDate is: {}", get_date(t, 13));
-	}
+    std::vector<std::string> args;
+    for (auto i = 0; i < argc; i++) args.push_back(argv[i]);
+    time_t t = since(args);
+    if (t < LONG_MAX) {
+        if (argv[0][0] == 'c')
+            std::println("{:X}", t); /* cdate command */
+        else
+            std::println("\nDate is: {}", get_date(t, 13));
+    }
 
-	return 1;
+    return 1;
 }
 
 /******************************************************************************/
@@ -400,27 +399,27 @@ do_source(      /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	short i;
-	int ok = 1;
-	if (argc < 2 || argc > 20)
-		std::println("usage: source filename [arg ...]");
-	else {
-		for (i = 1; i < argc; i++) {
-			const auto arg = std::format("arg{}", i - 1);
-			def_macro(arg, DM_VAR, argv[i]);
-		}
+    short i;
+    int ok = 1;
+    if (argc < 2 || argc > 20)
+        std::println("usage: source filename [arg ...]");
+    else {
+        for (i = 1; i < argc; i++) {
+            const auto arg = std::format("arg{}", i - 1);
+            def_macro(arg, DM_VAR, argv[i]);
+        }
 
-		ok = source(argv[1], "", 0, SL_USER);
-		if (!ok && !(flags & O_QUIET))
-			std::println("Cannot access {}", argv[1]);
+        ok = source(argv[1], "", 0, SL_USER);
+        if (!ok && !(flags & O_QUIET))
+            std::println("Cannot access {}", argv[1]);
 
-		for (i = 1; i < argc; i++) {
-			const auto arg = std::format("arg{}", i - 1);
-			if (find_macro(arg, DM_VAR))
-				undef_name(arg);
-		}
-	}
-	return (ok < 0) ? 0 : 1;
+        for (i = 1; i < argc; i++) {
+            const auto arg = std::format("arg{}", i - 1);
+            if (find_macro(arg, DM_VAR))
+                undef_name(arg);
+        }
+    }
+    return (ok < 0) ? 0 : 1;
 }
 /******************************************************************************/
 /* TEST RANGES                                                                */
@@ -431,47 +430,47 @@ test(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	int i;
-	char act[MAX_ITEMS];
-	short j, k = 0, fl = 0;
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
+    int i;
+    char act[MAX_ITEMS];
+    short j, k = 0, fl = 0;
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
 
-	if (argc > 1) /* Process argc */
-		range(argc, argv, &fl, act, sum, &st_glob, 0);
-	if (!(fl & OF_RANGE)) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic());
-		return 1;
-	}
-	j = A_SKIP;
-	for (i = 0; i < MAX_ITEMS; i++) {
-		if (act[i] == A_SKIP && j == A_COVER)
-			std::print("{}]", i);
-		if (act[i] == A_FORCE)
-			std::print("{}{}", (k++) ? "," : "", i + 1);
-		if (act[i] == A_COVER && j != A_COVER)
-			std::print("{}[{}-", (k++) ? "," : "", i + 1);
-		j = act[i];
-	}
-	if (j == A_COVER)
-		std::print("{}]", i);
-	std::println(".");
-	std::println("newflag: {}", fl);
-	std::print("since  date is {}", ctime(&(st_glob.since)));
-	std::print("before date is {}", ctime(&(st_glob.before)));
-	if (!st_glob.string.empty())
-		std::println("String is: {}", st_glob.string);
-	if (!st_glob.author.empty())
-		std::println("Author is: {}", st_glob.author);
+    if (argc > 1) /* Process argc */
+        range(argc, argv, &fl, act, sum, &st_glob, 0);
+    if (!(fl & OF_RANGE)) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic());
+        return 1;
+    }
+    j = A_SKIP;
+    for (i = 0; i < MAX_ITEMS; i++) {
+        if (act[i] == A_SKIP && j == A_COVER)
+            std::print("{}]", i);
+        if (act[i] == A_FORCE)
+            std::print("{}{}", (k++) ? "," : "", i + 1);
+        if (act[i] == A_COVER && j != A_COVER)
+            std::print("{}[{}-", (k++) ? "," : "", i + 1);
+        j = act[i];
+    }
+    if (j == A_COVER)
+        std::print("{}]", i);
+    std::println(".");
+    std::println("newflag: {}", fl);
+    std::print("since  date is {}", ctime(&(st_glob.since)));
+    std::print("before date is {}", ctime(&(st_glob.before)));
+    if (!st_glob.string.empty())
+        std::println("String is: {}", st_glob.string);
+    if (!st_glob.author.empty())
+        std::println("Author is: {}", st_glob.author);
 
-	return 1;
+    return 1;
 }
 
 static void
 print_dopt(const option_t &opt)
 {
-	std::println("{} {}", compress(opt.name),
-	    (debug & opt.mask) != 0 ? "on" : "off");
+    std::println(
+        "{} {}", compress(opt.name), (debug & opt.mask) != 0 ? "on" : "off");
 }
 
 int
@@ -480,23 +479,22 @@ set_debug(      /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	if (argc < 2) {
-		for (const auto &dopt : debug_opt)
-			print_dopt(dopt);
-		return 1;
-	}
-	for (auto j = 1; j < argc; j++) {
-		if (str::eq(argv[j], "off")) {
-			debug = 0;
-			continue;
-		}
-		for (const auto &dopt : debug_opt)
-			if (match(argv[j], dopt.name)) {
-				debug ^= dopt.mask;
-				print_dopt(dopt);
-			}
-	}
-	return 1;
+    if (argc < 2) {
+        for (const auto &dopt : debug_opt) print_dopt(dopt);
+        return 1;
+    }
+    for (auto j = 1; j < argc; j++) {
+        if (str::eq(argv[j], "off")) {
+            debug = 0;
+            continue;
+        }
+        for (const auto &dopt : debug_opt)
+            if (match(argv[j], dopt.name)) {
+                debug ^= dopt.mask;
+                print_dopt(dopt);
+            }
+    }
+    return 1;
 }
 
 #ifdef INCLUDE_EXTRA_COMMANDS
@@ -506,21 +504,21 @@ set_cfdir(      /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	(void)argc;
-	(void)argv;
+    (void)argc;
+    (void)argv;
 
-	if (!(flags & O_QUIET)) {
-		std::print("User name: ");
-		std::fflush(stdout);
-	}
-	std::string buff;
-	ngets(buff, st_glob.inp);
-	const auto path = str::join("/", {home, buff});
-	if (access(path.c_str(), X_OK))
-		std::println("No such directory.");
-	else
-		work = path;
-	return 1;
+    if (!(flags & O_QUIET)) {
+        std::print("User name: ");
+        std::fflush(stdout);
+    }
+    std::string buff;
+    ngets(buff, st_glob.inp);
+    const auto path = str::join("/", {home, buff});
+    if (access(path.c_str(), X_OK))
+        std::println("No such directory.");
+    else
+        work = path;
+    return 1;
 }
 #endif
 
@@ -531,175 +529,164 @@ eval(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	int i;
-	char act[MAX_ITEMS], *str;
-	short i_s, i_i, i_lastseen, shown = 0, rfirst = 0;
-	FILE *fp;
-	status_t tmp;
-	/* Save state */
-	memcpy(&tmp, &st_glob, sizeof(status_t));
+    int i;
+    char act[MAX_ITEMS], *str;
+    short i_s, i_i, i_lastseen, shown = 0, rfirst = 0;
+    FILE *fp;
+    status_t tmp;
+    /* Save state */
+    memcpy(&tmp, &st_glob, sizeof(status_t));
 
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	for (i = 0; i < MAX_ITEMS; i++) act[i] = 0;
-	st_glob.string.clear();
-	st_glob.since = st_glob.before = st_glob.r_first = 0;
-	st_glob.opt_flags = 0;
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    for (i = 0; i < MAX_ITEMS; i++) act[i] = 0;
+    st_glob.string.clear();
+    st_glob.since = st_glob.before = st_glob.r_first = 0;
+    st_glob.opt_flags = 0;
 
-	if (argc < 2) {
+    if (argc < 2) {
 
-		/* Read from stdin until EOF */
-		while ((str = xgets(st_glob.inp, stdin_stack_top)) != NULL) {
-			if (mode == M_OK || mode == M_JOQ)
-				confsep(str, confidx, &st_glob, part, 0);
-			else if (mode == M_RFP || mode == M_EDB ||
-			         mode == M_TEXT)
-				itemsep(str, 0);
-			else
-				std::println("Unknown mode");
-			free(str);
-		}
-		if (debug & DB_IOREDIR)
-			std::println("Detected end of eval input");
-		return 1;
-	}
-	if (match(argv[0], "evali_n")) {
-		str = NULL;
-		range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
-	} else {
-		str = argv[argc - 1];
+        /* Read from stdin until EOF */
+        while ((str = xgets(st_glob.inp, stdin_stack_top)) != NULL) {
+            if (mode == M_OK || mode == M_JOQ)
+                confsep(str, confidx, &st_glob, part, 0);
+            else if (mode == M_RFP || mode == M_EDB || mode == M_TEXT)
+                itemsep(str, 0);
+            else
+                std::println("Unknown mode");
+            free(str);
+        }
+        if (debug & DB_IOREDIR)
+            std::println("Detected end of eval input");
+        return 1;
+    }
+    if (match(argv[0], "evali_n")) {
+        str = NULL;
+        range(argc, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    } else {
+        str = argv[argc - 1];
 
-		/* Strip quotes */
-		if (str[0] == '"') {
-			str++;
-			if (str[strlen(str) - 1] == '"')
-				str[strlen(str) - 1] = '\0';
-		}
-		if (argc > 2) /* Process argc */
-			range(argc - 1, argv, &st_glob.opt_flags, act, sum,
-			    &st_glob, 0);
-	}
+        /* Strip quotes */
+        if (str[0] == '"') {
+            str++;
+            if (str[strlen(str) - 1] == '"')
+                str[strlen(str) - 1] = '\0';
+        }
+        if (argc > 2) /* Process argc */
+            range(argc - 1, argv, &st_glob.opt_flags, act, sum, &st_glob, 0);
+    }
 
-	open_pipe();
+    open_pipe();
 
-	/* Transfer current pipe info to global saved state */
-	tmp.outp = st_glob.outp;
+    /* Transfer current pipe info to global saved state */
+    tmp.outp = st_glob.outp;
 
-	if (str && !(st_glob.opt_flags & OF_RANGE)) {
+    if (str && !(st_glob.opt_flags & OF_RANGE)) {
 
-		if (mode == M_OK || mode == M_JOQ)
-			confsep(str, confidx, &st_glob, part, 0);
-		else if (mode == M_RFP || mode == M_EDB || mode == M_TEXT)
-			itemsep(str, 0);
-		else
-			std::println("Unknown mode");
+        if (mode == M_OK || mode == M_JOQ)
+            confsep(str, confidx, &st_glob, part, 0);
+        else if (mode == M_RFP || mode == M_EDB || mode == M_TEXT)
+            itemsep(str, 0);
+        else
+            std::println("Unknown mode");
 
-	} else {
+    } else {
 
-		if (mode == M_OK) {
+        if (mode == M_OK) {
 
-			/* Removed 4/11/96 because eval 4 'christmas'
-			 * "%{nextitem}" wasn't processing the search string.
-			 *       st_glob.string.clear();
-			 */
-			if (st_glob.opt_flags & OF_REVERSE) {
-				i_s = st_glob.i_last;
-				i_i = -1;
-			} else {
-				i_s = st_glob.i_first;
-				i_i = 1;
-			}
+            /* Removed 4/11/96 because eval 4 'christmas'
+             * "%{nextitem}" wasn't processing the search string.
+             *       st_glob.string.clear();
+             */
+            if (st_glob.opt_flags & OF_REVERSE) {
+                i_s = st_glob.i_last;
+                i_i = -1;
+            } else {
+                i_s = st_glob.i_first;
+                i_i = 1;
+            }
 
-			/* Process items */
-			sepinit(IS_START);
-			fp = NULL;
-			for (st_glob.i_current = i_s;
-			     st_glob.i_current >= st_glob.i_first &&
-			     st_glob.i_current <= st_glob.i_last &&
-			     !(status & S_INT);
-			     st_glob.i_current += i_i) {
-				if (cover(st_glob.i_current, confidx,
-				        st_glob.opt_flags,
-				        act[st_glob.i_current - 1], sum, part,
-				        &st_glob)) {
-					st_glob.i_next = nextitem(1);
-					st_glob.i_prev = nextitem(-1);
-					st_glob.r_first = rfirst;
+            /* Process items */
+            sepinit(IS_START);
+            fp = NULL;
+            for (st_glob.i_current = i_s;
+                st_glob.i_current >= st_glob.i_first &&
+                st_glob.i_current <= st_glob.i_last && !(status & S_INT);
+                st_glob.i_current += i_i) {
+                if (cover(st_glob.i_current, confidx, st_glob.opt_flags,
+                        act[st_glob.i_current - 1], sum, part, &st_glob)) {
+                    st_glob.i_next = nextitem(1);
+                    st_glob.i_prev = nextitem(-1);
+                    st_glob.r_first = rfirst;
 
-					if (match(argv[0], "evali_n")) {
-						while (
-						    (str = xgets(st_glob.inp,
-						         stdin_stack_top)) !=
-						    NULL) {
-							itemsep(str, 0);
-							free(str);
-						}
-					} else
-						itemsep(str, 0);
-					shown++;
-				}
-			}
-			if (!shown && (st_glob.opt_flags & (OF_BRANDNEW | OF_NEWRESP))) {
-				wputs(std::format("No new {}s matched.\n", topic()));
-			}
-		} else if (mode == M_RFP) {
-			/* Open file */
+                    if (match(argv[0], "evali_n")) {
+                        while ((str = xgets(st_glob.inp, stdin_stack_top)) !=
+                               NULL) {
+                            itemsep(str, 0);
+                            free(str);
+                        }
+                    } else
+                        itemsep(str, 0);
+                    shown++;
+                }
+            }
+            if (!shown && (st_glob.opt_flags & (OF_BRANDNEW | OF_NEWRESP))) {
+                wputs(std::format("No new {}s matched.\n", topic()));
+            }
+        } else if (mode == M_RFP) {
+            /* Open file */
 
-			const auto path = std::format("{}/_{}",
-			    conflist[confidx].location, st_glob.i_current);
+            const auto path = std::format(
+                "{}/_{}", conflist[confidx].location, st_glob.i_current);
 
-			fp = mopen(path, O_R);
-			if (fp == nullptr)
-				return 1;
+            fp = mopen(path, O_R);
+            if (fp == nullptr)
+                return 1;
 
-			i_lastseen = st_glob.i_current - 1;
-			if (st_glob.opt_flags & (OF_NEWRESP | OF_NORESPONSE))
-				st_glob.r_first = part[i_lastseen].nr;
-			else if (st_glob.since) {
-				st_glob.r_first = 0;
-				while (
-				    st_glob.since > re[st_glob.r_first].date) {
-					st_glob.r_first++;
-					get_resp(fp, &(re[st_glob.r_first]),
-					    (short)GR_HEADER, st_glob.r_first);
-					if (st_glob.r_first >=
-					    sum[i_lastseen].nr)
-						break;
-				}
-			}
-			st_glob.r_last = MAX_RESPONSES;
-			st_glob.r_max = sum[i_lastseen].nr - 1;
+            i_lastseen = st_glob.i_current - 1;
+            if (st_glob.opt_flags & (OF_NEWRESP | OF_NORESPONSE))
+                st_glob.r_first = part[i_lastseen].nr;
+            else if (st_glob.since) {
+                st_glob.r_first = 0;
+                while (st_glob.since > re[st_glob.r_first].date) {
+                    st_glob.r_first++;
+                    get_resp(fp, &(re[st_glob.r_first]), (short)GR_HEADER,
+                        st_glob.r_first);
+                    if (st_glob.r_first >= sum[i_lastseen].nr)
+                        break;
+                }
+            }
+            st_glob.r_last = MAX_RESPONSES;
+            st_glob.r_max = sum[i_lastseen].nr - 1;
 
-			/* For each response */
-			for (st_glob.r_current = st_glob.r_first;
-			     st_glob.r_current <= st_glob.r_last &&
-			     st_glob.r_current <= st_glob.r_max &&
-			     !(status & S_INT);
-			     st_glob.r_current++) {
-				get_resp(fp, &(re[st_glob.r_current]),
-				    (short)GR_HEADER, st_glob.r_current);
-				itemsep(str, 0);
-			}
+            /* For each response */
+            for (st_glob.r_current = st_glob.r_first;
+                st_glob.r_current <= st_glob.r_last &&
+                st_glob.r_current <= st_glob.r_max && !(status & S_INT);
+                st_glob.r_current++) {
+                get_resp(fp, &(re[st_glob.r_current]), (short)GR_HEADER,
+                    st_glob.r_current);
+                itemsep(str, 0);
+            }
 
-			mclose(fp);
-		} else
-			std::println("bad mode");
-	}
+            mclose(fp);
+        } else
+            std::println("bad mode");
+    }
 
-	/* Restore state */
-	{
-		FILE *inp = st_glob.inp;
-		memcpy(&st_glob, &tmp, sizeof(status_t));
-		st_glob.inp = inp;
-	}
-	/*
-	std::println("eval: fdnext={}", fdnext());
-	if (!fdnext())
-	   abort();
-	*/
+    /* Restore state */
+    {
+        FILE *inp = st_glob.inp;
+        memcpy(&st_glob, &tmp, sizeof(status_t));
+        st_glob.inp = inp;
+    }
+    /*
+    std::println("eval: fdnext={}", fdnext());
+    if (!fdnext())
+       abort();
+    */
 
-	return 1;
+    return 1;
 }
-
 
 /*****************************************************************************/
 /* FUNCTIONS FOR CONDITIONAL EXPRESSIONS                                     */
@@ -709,9 +696,9 @@ static int if_stat[100], if_depth = -1;
 int
 test_if(void)
 {
-	if (if_depth < 0)
-		if_stat[++if_depth] = 1;
-	return if_stat[if_depth];
+    if (if_depth < 0)
+        if_stat[++if_depth] = 1;
+    return if_stat[if_depth];
 }
 
 int
@@ -720,40 +707,39 @@ do_if(          /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char buff[MAX_LINE_LENGTH];
-	const char *sp = buff;
+    char buff[MAX_LINE_LENGTH];
+    const char *sp = buff;
 
-	if (!test_if()) {
-		if_stat[++if_depth] = 0;
-		return 1;
-	}
+    if (!test_if()) {
+        if_stat[++if_depth] = 0;
+        return 1;
+    }
 
-	/* Put buffer together */
-	buff[0] = '\0';
-	for (int i = 1; i < argc; i++)
-		strlcat(buff, argv[i], sizeof(buff));
+    /* Put buffer together */
+    buff[0] = '\0';
+    for (int i = 1; i < argc; i++) strlcat(buff, argv[i], sizeof(buff));
 
-	if (if_depth == 99) {
-		std::println("Too many nested if's");
-		return 0;
-	}
+    if (if_depth == 99) {
+        std::println("Too many nested if's");
+        return 0;
+    }
 
-	init_show();
-	switch (mode) {
-	case M_RFP:
-	case M_TEXT:
-	case M_EDB:
-		if_stat[++if_depth] = itemcond(&sp, st_glob.opt_flags);
-		break;
+    init_show();
+    switch (mode) {
+    case M_RFP:
+    case M_TEXT:
+    case M_EDB:
+        if_stat[++if_depth] = itemcond(&sp, st_glob.opt_flags);
+        break;
 
-	case M_OK:
-	case M_JOQ:
-	default:
-		if_stat[++if_depth] = confcond(&sp, confidx, &st_glob);
-		break;
-	}
+    case M_OK:
+    case M_JOQ:
+    default:
+        if_stat[++if_depth] = confcond(&sp, confidx, &st_glob);
+        break;
+    }
 
-	return 1;
+    return 1;
 }
 
 int
@@ -762,13 +748,13 @@ do_endif(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	(void)argc;
-	(void)argv;
-	if (if_depth)
-		if_depth--;
-	else
-		std::println("Parse error: endif outside if construct");
-	return 1;
+    (void)argc;
+    (void)argv;
+    if (if_depth)
+        if_depth--;
+    else
+        std::println("Parse error: endif outside if construct");
+    return 1;
 }
 
 int
@@ -777,13 +763,13 @@ do_else(        /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	(void)argc;
-	(void)argv;
-	if (!if_depth)
-		std::println("Parse error: else outside if construct");
-	else if (if_stat[if_depth - 1])
-		if_stat[if_depth] = !if_stat[if_depth];
-	return 1;
+    (void)argc;
+    (void)argv;
+    if (!if_depth)
+        std::println("Parse error: else outside if construct");
+    else if (if_stat[if_depth - 1])
+        if_stat[if_depth] = !if_stat[if_depth];
+    return 1;
 }
 
 /* ARGUMENTS:             */
@@ -791,19 +777,19 @@ do_else(        /* ARGUMENTS:             */
 /* Argument list       */
 int foreach (int argc, char **argv)
 {
-	if (argc != 6) {
-		std::println("usage: foreach <varname> in <listvar> do \"command\"");
-		return 1;
-	}
+    if (argc != 6) {
+        std::println("usage: foreach <varname> in <listvar> do \"command\"");
+        return 1;
+    }
 
-	/* Get list */
-	const auto vars = str::split(expand(argv[3], DM_VAR), ", ");
-	for (const auto &var: vars) {
-		def_macro(argv[1], DM_VAR, var);
-		command(argv[5], 1);
-	}
+    /* Get list */
+    const auto vars = str::split(expand(argv[3], DM_VAR), ", ");
+    for (const auto &var : vars) {
+        def_macro(argv[1], DM_VAR, var);
+        command(argv[5], 1);
+    }
 
-	return 1;
+    return 1;
 }
 
 /* ARGUMENTS:             */
@@ -812,23 +798,23 @@ int foreach (int argc, char **argv)
 int
 argset(int argc, char **argv)
 {
-	if (argc < 3) {
-		/*std::println("usage: argset delimeter string");*/
-		def_macro("argc", DM_VAR, "0");
-		return 1;
-	}
+    if (argc < 3) {
+        /*std::println("usage: argset delimeter string");*/
+        def_macro("argc", DM_VAR, "0");
+        return 1;
+    }
 
-	const auto setargs = str::split(argv[2], argv[1], false);
+    const auto setargs = str::split(argv[2], argv[1], false);
 
-	/*std::println("pi=!{}! fields={}", argv[2], setargs.size());*/
+    /*std::println("pi=!{}! fields={}", argv[2], setargs.size());*/
 
-	// XXX: really want `std::views::enumerate` here.
-	for (auto i = 0uz; i < setargs.size(); ++i) {
-		const auto &arg = setargs[i];
-		const auto name = "arg" + std::to_string(i);
-		def_macro(name, DM_VAR, arg);
-	}
-	def_macro("argc", DM_VAR, std::to_string(setargs.size()));
+    // XXX: really want `std::views::enumerate` here.
+    for (auto i = 0uz; i < setargs.size(); ++i) {
+        const auto &arg = setargs[i];
+        const auto name = "arg" + std::to_string(i);
+        def_macro(name, DM_VAR, arg);
+    }
+    def_macro("argc", DM_VAR, std::to_string(setargs.size()));
 
-	return 1;
+    return 1;
 }

--- a/news.cc
+++ b/news.cc
@@ -47,44 +47,42 @@
 int
 make_emtail(void)
 {
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	/* Fork & setuid down when creating cf.buffer */
-	auto cpid = fork();
-	if (cpid < 0)
-		return -1; /* error: couldn't fork */
-	if (cpid) { /* parent */
-		pid_t wpid;
-		int statusp;
-		while ((wpid = wait(&statusp)) != cpid && wpid != -1)
-			;
-		/* post = !statusp; */
-	} else { /* child */
-		if (setuid(getuid()))
-			error("setuid", "");
-		setgid(getgid());
+    /* Fork & setuid down when creating cf.buffer */
+    auto cpid = fork();
+    if (cpid < 0)
+        return -1; /* error: couldn't fork */
+    if (cpid) {    /* parent */
+        pid_t wpid;
+        int statusp;
+        while ((wpid = wait(&statusp)) != cpid && wpid != -1);
+        /* post = !statusp; */
+    } else { /* child */
+        if (setuid(getuid()))
+            error("setuid", "");
+        setgid(getgid());
 
-		/* Save to cf.buffer */
-		const auto cfbuffer = str::concat({work, "/cf.buffer"});
-		FILE *fp = mopen(cfbuffer, O_A);
-		if (fp == NULL)
-			return 1;
+        /* Save to cf.buffer */
+        const auto cfbuffer = str::concat({work, "/cf.buffer"});
+        FILE *fp = mopen(cfbuffer, O_A);
+        if (fp == NULL)
+            return 1;
 
-		const auto sigpath = str::concat({home, "/.signature"});
-		FILE *sp = mopen(sigpath, O_R | O_SILENT);
-		if (sp != NULL) {
-			std::println(fp, "--");
-			std::string buff;
-			while (ngets(buff, sp))
-				std::println(fp, "{}", buff);
-			mclose(sp);
-		}
-		mclose(fp);
-		exit(0);
-	}
-	return 1;
+        const auto sigpath = str::concat({home, "/.signature"});
+        FILE *sp = mopen(sigpath, O_R | O_SILENT);
+        if (sp != NULL) {
+            std::println(fp, "--");
+            std::string buff;
+            while (ngets(buff, sp)) std::println(fp, "{}", buff);
+            mclose(sp);
+        }
+        mclose(fp);
+        exit(0);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* CREATE EMAIL HEADER                                                        */
@@ -92,58 +90,57 @@ make_emtail(void)
 int
 make_emhead(response_t *re, int par)
 {
-	FILE *fp, *pp;
-	flag_t ss;
-	int cpid, wpid;
-	int statusp;
+    FILE *fp, *pp;
+    flag_t ss;
+    int cpid, wpid;
+    int statusp;
 
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	/* Fork & setuid down when creating cf.buffer */
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		while ((wpid = wait(&statusp)) != cpid && wpid != -1)
-			;
-		/* post = !statusp; */
-	} else { /* child */
-		if (setuid(getuid()))
-			error("setuid", "");
-		setgid(getgid());
+    /* Fork & setuid down when creating cf.buffer */
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return -1; /* error: couldn't fork */
+        while ((wpid = wait(&statusp)) != cpid && wpid != -1);
+        /* post = !statusp; */
+    } else { /* child */
+        if (setuid(getuid()))
+            error("setuid", "");
+        setgid(getgid());
 
-		/* Save to cf.buffer */
-		const auto cfbuffer = str::concat({work, "/cf.buffer"});
-		if ((fp = mopen(cfbuffer, O_W)) == NULL) {
-			/*
-			 * re[i].text.clear();
-			 */
-			return 1;
-		}
-		pp = st_glob.outp;
-		ss = status;
-		st_glob.r_current = par - 1;
-		st_glob.outp = fp;
-		status |= S_PAGER;
+        /* Save to cf.buffer */
+        const auto cfbuffer = str::concat({work, "/cf.buffer"});
+        if ((fp = mopen(cfbuffer, O_W)) == NULL) {
+            /*
+             * re[i].text.clear();
+             */
+            return 1;
+        }
+        pp = st_glob.outp;
+        ss = status;
+        st_glob.r_current = par - 1;
+        st_glob.outp = fp;
+        status |= S_PAGER;
 
-		itemsep(expand("mailheader", DM_VAR), 0);
-		if (par)
-			dump_reply("mailsep");
+        itemsep(expand("mailheader", DM_VAR), 0);
+        if (par)
+            dump_reply("mailsep");
 
-		st_glob.outp = pp;
-		status = ss;
-		mclose(fp);
-		exit(0);
-	}
-	return 1;
+        st_glob.outp = pp;
+        status = ss;
+        mclose(fp);
+        exit(0);
+    }
+    return 1;
 }
 /*
-	if (par>0)
-		std::println(fp, "References: <{}>",
-		    message_id(compress(conflist[confidx].name),
-		        st_glob.i_current, curr, re));
+    if (par>0)
+        std::println(fp, "References: <{}>",
+            message_id(compress(conflist[confidx].name),
+                st_glob.i_current, curr, re));
 */
 
 #ifdef NEWS
@@ -156,93 +153,91 @@ make_emhead(response_t *re, int par)
 int
 make_rnhead(response_t *re, int par)
 {
-	flag_t ss;
-	short curr;
-	int statusp;
+    flag_t ss;
+    short curr;
+    int statusp;
 
-	const char *sub = get_subj(confidx, st_glob.i_current - 1, sum);
-	const auto config = get_config(confidx);
-	if (config.size() <= CF_NEWSGROUP)
-		return 0;
+    const char *sub = get_subj(confidx, st_glob.i_current - 1, sum);
+    const auto config = get_config(confidx);
+    if (config.size() <= CF_NEWSGROUP)
+        return 0;
 
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	/* Fork & setuid down when creating .rnhead */
-	auto cpid = fork();
-	if (cpid < 0)
-		return -1; /* error: couldn't fork */
-	if (cpid != 0) { /* parent */
-		pid_t wpid;
-		while ((wpid = wait(&statusp)) != cpid && wpid != -1)
-			;
-		/* post = !statusp; */
-	} else { /* child */
-		if (setuid(getuid()))
-			error("setuid", "");
-		setgid(getgid());
+    /* Fork & setuid down when creating .rnhead */
+    auto cpid = fork();
+    if (cpid < 0)
+        return -1;   /* error: couldn't fork */
+    if (cpid != 0) { /* parent */
+        pid_t wpid;
+        while ((wpid = wait(&statusp)) != cpid && wpid != -1);
+        /* post = !statusp; */
+    } else { /* child */
+        if (setuid(getuid()))
+            error("setuid", "");
+        setgid(getgid());
 
-		const auto path = str::concat({home, "/.rnhead"});
-		FILE *fp = mopen(path, O_W);
-		if (fp == nullptr)
-			exit(1);
-		std::println(fp, "Newsgroups: {}", config[CF_NEWSGROUP]);
-		std::println(fp, "Subject: {}{}",
-		    (sub) ? "Re: " : "", (sub) ? sub : "");
-		std::println(fp, "Summary: ");
-		std::println(fp, "Expires: ");
+        const auto path = str::concat({home, "/.rnhead"});
+        FILE *fp = mopen(path, O_W);
+        if (fp == nullptr)
+            exit(1);
+        std::println(fp, "Newsgroups: {}", config[CF_NEWSGROUP]);
+        std::println(
+            fp, "Subject: {}{}", (sub) ? "Re: " : "", (sub) ? sub : "");
+        std::println(fp, "Summary: ");
+        std::println(fp, "Expires: ");
 
-		curr = par - 1;
-		/* add parents mids:
-		 * std::println(fp, "References:");
-		 * std::vector<std::string> refs;
-		 * for (auto i = par - 1; i >= 0; i = re[i].parent - 1) {
-		 *	refs.push_back(std::format("<{}>",
-		 *	    message_id(compress(conflist[confidx].name)),
-		 *	        st_glob.i_current,curr,re));
-		 * }
-		 * for (const auto &ref: std::ranges::reverse_view(refs))
-		 * 	std:print(fp, "{}", ref);
-		 * std::println(fp,"{}");
-		 */
-		if (par > 0)
-			std::println(fp, "References: <{}>",
-			    message_id(compress(conflist[confidx].name),
-			        st_glob.i_current, curr, re));
-		std::println(fp, "Sender: ");
-		std::println(fp, "Followup-To: ");
-		std::println(fp, "Distribution: world");
-		std::println(fp, "Organization: ");
-		std::println(fp, "Keywords: ");
-		std::println(fp, "");
-		if (par > 0) { /* response to something? */
-			FILE *pp = st_glob.outp;
-			ss = status;
-			st_glob.r_current = par - 1;
-			st_glob.outp = fp;
-			status |= S_PAGER;
+        curr = par - 1;
+        /* add parents mids:
+         * std::println(fp, "References:");
+         * std::vector<std::string> refs;
+         * for (auto i = par - 1; i >= 0; i = re[i].parent - 1) {
+         *	refs.push_back(std::format("<{}>",
+         *	    message_id(compress(conflist[confidx].name)),
+         *	        st_glob.i_current,curr,re));
+         * }
+         * for (const auto &ref: std::ranges::reverse_view(refs))
+         * 	std:print(fp, "{}", ref);
+         * std::println(fp,"{}");
+         */
+        if (par > 0)
+            std::println(fp, "References: <{}>",
+                message_id(compress(conflist[confidx].name), st_glob.i_current,
+                    curr, re));
+        std::println(fp, "Sender: ");
+        std::println(fp, "Followup-To: ");
+        std::println(fp, "Distribution: world");
+        std::println(fp, "Organization: ");
+        std::println(fp, "Keywords: ");
+        std::println(fp, "");
+        if (par > 0) { /* response to something? */
+            FILE *pp = st_glob.outp;
+            ss = status;
+            st_glob.r_current = par - 1;
+            st_glob.outp = fp;
+            status |= S_PAGER;
 
-			dump_reply("newssep");
+            dump_reply("newssep");
 
-			st_glob.outp = pp;
-			status = ss;
+            st_glob.outp = pp;
+            status = ss;
 
-			/* dump_reply("newssep"); don't dump to screen */
-		}
-		const auto sigpath = str::concat({home, "/.signature"});
-		FILE *sp = mopen(sigpath, O_R | O_SILENT);
-		if (sp != nullptr) {
-			std::println(fp, "--");
-			std::string buff;
-			while (ngets(buff, sp))
-				std::println(fp, "{}s", buff);
-			mclose(sp);
-		}
-		mclose(fp);
-		exit(0);
-	}
-	return 1;
+            /* dump_reply("newssep"); don't dump to screen */
+        }
+        const auto sigpath = str::concat({home, "/.signature"});
+        FILE *sp = mopen(sigpath, O_R | O_SILENT);
+        if (sp != nullptr) {
+            std::println(fp, "--");
+            std::string buff;
+            while (ngets(buff, sp)) std::println(fp, "{}s", buff);
+            mclose(sp);
+        }
+        mclose(fp);
+        exit(0);
+    }
+    return 1;
 }
 #endif
 
@@ -252,107 +247,103 @@ make_rnhead(response_t *re, int par)
  * bit set, make sure the author is a registered user first.
  */
 static void
-incorporate2(long art,          /* Article number to incorporate */
-    sumentry_t *sum,            /* Item summary array to fill in */
-    partentry_t *part,          /* Participation info            */
-    status_t *stt, int idx,     /* Conference index              */
-    sumentry_t *thiss, char *sj, /* Subject */
+incorporate2(long art,                    /* Article number to incorporate */
+    sumentry_t *sum,                      /* Item summary array to fill in */
+    partentry_t *part,                    /* Participation info            */
+    status_t *stt, int idx,               /* Conference index              */
+    sumentry_t *thiss, char *sj,          /* Subject */
     const std::vector<std::string> &text, /* The actual body of text */
-    char *mid,                  /* Unique message ID */
-    char *fromL,                /* Login of author */
-    char *fromF                 /* Fullname of author */
+    char *mid,                            /* Unique message ID */
+    char *fromL,                          /* Login of author */
+    char *fromF                           /* Fullname of author */
 )
 {
-	int i, sec;
-	const auto config = get_config(idx);
+    int i, sec;
+    const auto config = get_config(idx);
 
-	if (config.empty())
-		return;
+    if (config.empty())
+        return;
 
-	/* Get conference security type */
-	sec = security_type(config, idx);
+    /* Get conference security type */
+    sec = security_type(config, idx);
 
-	/* If registered bit is set, make sure fromL is a registered user */
-	if (sec & CT_REGISTERED) {
-		const auto parts = str::split(fromL, "@");
-		std::string fullname;
-		std::string home;
-		std::string email;
-		int found = 0;
-		uid_t uid = 0;
+    /* If registered bit is set, make sure fromL is a registered user */
+    if (sec & CT_REGISTERED) {
+        const auto parts = str::split(fromL, "@");
+        std::string fullname;
+        std::string home;
+        std::string email;
+        int found = 0;
+        uid_t uid = 0;
 
-		/* Check if fromL is a Unix user */
-		std::string login_part(parts[0]);
-		if (get_user(&uid, login_part, fullname, home, email)) {
-			/* a local user was found with that login */
+        /* Check if fromL is a Unix user */
+        std::string login_part(parts[0]);
+        if (get_user(&uid, login_part, fullname, home, email)) {
+            /* a local user was found with that login */
 
-			if (parts.size() < 2 || str::eqcase(parts[1], hostname)) {
-				/* Unix user found */
-				found = 1;
-			} else if (str::eqcase(fromL, email)) {
-				/* Local user found the fast way:
-				 * local login == remote login */
-				found = 2;
-			}
-		}
+            if (parts.size() < 2 || str::eqcase(parts[1], hostname)) {
+                /* Unix user found */
+                found = 1;
+            } else if (str::eqcase(fromL, email)) {
+                /* Local user found the fast way:
+                 * local login == remote login */
+                found = 2;
+            }
+        }
 
-		/* Check if fromL is a registered user with that email address
-		 */
-		if (!found && email2login(fromL))
-			found = 3;
+        /* Check if fromL is a registered user with that email address
+         */
+        if (!found && email2login(fromL))
+            found = 3;
 
-		/* If not registered, skip this conference (don't post) */
-		if (!found)
-			return;
-	}
+        /* If not registered, skip this conference (don't post) */
+        if (!found)
+            return;
+    }
 
-	/* Find what item it should go in */
-	i = stt->i_last + 1;
-	/* Duplicate subjects are separate items */
-	/* if (!strncmp(sj,"Re: ",4)) */
-	for (i = stt->i_first;
-	     i <= stt->i_last &&
-	     (!sum[i - 1].nr || !sum[i - 1].flags ||
-	         (strncasecmp(
-	              sj + 4, get_subj(idx, i - 1, sum), MAX_LINE_LENGTH) &&
-	             strncasecmp(
-	                 sj, get_subj(idx, i - 1, sum), MAX_LINE_LENGTH)));
-	     i++)
-		;
-	/*
-	 * Duplicate subjects in same item
-	 * for (i = stt->i_first;
-	 *    i <= stt->i_last &&
-	 *         (sum[i-1].nr == 0 ||
-	 *            ((!str::eq(sj+4, get_subj(idx,i-1,sum)) || strncmp(sj,"Re: ",4)) &&
-	 *             str::eq(sj, get_subj(idx, i-1, sum))));
-	 *    i++);
-	 */
-	if (i > stt->i_last) {
-		i = stt->i_last + 1;
+    /* Find what item it should go in */
+    i = stt->i_last + 1;
+    /* Duplicate subjects are separate items */
+    /* if (!strncmp(sj,"Re: ",4)) */
+    for (i = stt->i_first;
+        i <= stt->i_last &&
+        (!sum[i - 1].nr || !sum[i - 1].flags ||
+            (strncasecmp(sj + 4, get_subj(idx, i - 1, sum), MAX_LINE_LENGTH) &&
+                strncasecmp(sj, get_subj(idx, i - 1, sum), MAX_LINE_LENGTH)));
+        i++);
+    /*
+     * Duplicate subjects in same item
+     * for (i = stt->i_first;
+     *    i <= stt->i_last &&
+     *         (sum[i-1].nr == 0 ||
+     *            ((!str::eq(sj+4, get_subj(idx,i-1,sum)) || strncmp(sj,"Re:
+     * ",4)) && str::eq(sj, get_subj(idx, i-1, sum)))); i++);
+     */
+    if (i > stt->i_last) {
+        i = stt->i_last + 1;
 
-		/* Enter a new item */
-		/* std::println("{} Subject '{}' is new {} {}", art, sj, topic(), i); */
-		if (!(flags & O_INCORPORATE))
-			std::print(".");
-		thiss->nr = 1;
-		thiss->flags = IF_ACTIVE;
-		do_enter(thiss, sj, text, idx, sum, part, stt, art, mid, uid,
-		    fromL, fromF);
-		store_subj(idx, i - 1, sj);
-	} else {
-		short resp = 0;
-		/* KKK Find previous reference for parent */
-		/* Response to item i */
-		/* std::println("{} Subject '{}' is response to {} {}",
-		 *     art, sj, topic(), i);
-		 */
-		if (!(flags & O_INCORPORATE))
-			std::print(".");
-		stt->i_current = i;
-		add_response(thiss, text, idx, sum, part, stt, art, mid, uid,
-		    fromL, fromF, resp);
-	}
+        /* Enter a new item */
+        /* std::println("{} Subject '{}' is new {} {}", art, sj, topic(), i); */
+        if (!(flags & O_INCORPORATE))
+            std::print(".");
+        thiss->nr = 1;
+        thiss->flags = IF_ACTIVE;
+        do_enter(
+            thiss, sj, text, idx, sum, part, stt, art, mid, uid, fromL, fromF);
+        store_subj(idx, i - 1, sj);
+    } else {
+        short resp = 0;
+        /* KKK Find previous reference for parent */
+        /* Response to item i */
+        /* std::println("{} Subject '{}' is response to {} {}",
+         *     art, sj, topic(), i);
+         */
+        if (!(flags & O_INCORPORATE))
+            std::print(".");
+        stt->i_current = i;
+        add_response(thiss, text, idx, sum, part, stt, art, mid, uid, fromL,
+            fromF, resp);
+    }
 }
 /******************************************************************************/
 /* INCORPORATE: Incorporate a new article (art) into an item                */
@@ -365,190 +356,186 @@ incorporate(               /* ARGUMENTS: */
     status_t *stt, int idx /* Conference index              */
 )
 {
-	FILE *fp = NULL;
-	std::string line;
-	char sj2[MAX_LINE_LENGTH], mid[MAX_LINE_LENGTH], *sj,
-	    fromF[MAX_LINE_LENGTH], fromL[MAX_LINE_LENGTH];
-	short i, j, k;
-	sumentry_t thiss;
-	std::vector<std::string_view> tolist[3];
-	std::vector<std::string> text;
-	std::vector<assoc_t> maillist;
-	int placed = 0;
+    FILE *fp = NULL;
+    std::string line;
+    char sj2[MAX_LINE_LENGTH], mid[MAX_LINE_LENGTH], *sj,
+        fromF[MAX_LINE_LENGTH], fromL[MAX_LINE_LENGTH];
+    short i, j, k;
+    sumentry_t thiss;
+    std::vector<std::string_view> tolist[3];
+    std::vector<std::string> text;
+    std::vector<assoc_t> maillist;
+    int placed = 0;
 
-	if (flags & O_INCORPORATE) {
-		maillist = grab_list(bbsdir, "maillist", 0);
-		fp = st_glob.inp; /* st_glob.inp; */
+    if (flags & O_INCORPORATE) {
+        maillist = grab_list(bbsdir, "maillist", 0);
+        fp = st_glob.inp; /* st_glob.inp; */
 #ifdef NEWS
-	} else {
-		/* Load in Subject and Date */
-		const auto config = get_config(idx);
-		if (config.size() <= CF_NEWSGROUP)
-			return 0;
-		const auto path = std::format("{}/{}/{}",
-		    get_conf_param("newsdir", NEWSDIR),
-		    dot2slash(config[CF_NEWSGROUP]), art);
-		if ((fp = mopen(path, O_R)) == NULL)
-			return 0;
+    } else {
+        /* Load in Subject and Date */
+        const auto config = get_config(idx);
+        if (config.size() <= CF_NEWSGROUP)
+            return 0;
+        const auto path =
+            std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+                dot2slash(config[CF_NEWSGROUP]), art);
+        if ((fp = mopen(path, O_R)) == NULL)
+            return 0;
 #endif
-	}
+    }
 
-	sj = sj2;
-	do {
-		ngets(line, fp);
-		char *buff = line.data();
-		if (!strncmp(buff, "Subject: ", 9)) {
-			if (!strncasecmp(buff + 9, "Re: ", 4))
-				strcpy(sj, buff + 13);
-			else
-				strcpy(sj, buff + 9);
-			while (sj[strlen(sj) - 1] == ' ')
-				sj[strlen(sj) - 1] = 0;
-			while (*sj == ' ') sj++;
+    sj = sj2;
+    do {
+        ngets(line, fp);
+        char *buff = line.data();
+        if (!strncmp(buff, "Subject: ", 9)) {
+            if (!strncasecmp(buff + 9, "Re: ", 4))
+                strcpy(sj, buff + 13);
+            else
+                strcpy(sj, buff + 9);
+            while (sj[strlen(sj) - 1] == ' ') sj[strlen(sj) - 1] = 0;
+            while (*sj == ' ') sj++;
 
-		} else if ((flags & O_INCORPORATE) &&
-		           !strncmp(buff, "To: ", 3)) {
-			tolist[0] = str::split(buff + 4, ", ");
-		} else if ((flags & O_INCORPORATE) &&
-		           !strncmp(buff, "Cc: ", 3)) {
-			tolist[1] = str::split(buff + 4, ", ");
-		} else if ((flags & O_INCORPORATE) &&
-		           !strncmp(buff, "Resent-To: ", 10)) {
-			tolist[2] = str::split(buff + 11, ", ");
-			/* KKK similarly for
-			 * newsgroups? */
+        } else if ((flags & O_INCORPORATE) && !strncmp(buff, "To: ", 3)) {
+            tolist[0] = str::split(buff + 4, ", ");
+        } else if ((flags & O_INCORPORATE) && !strncmp(buff, "Cc: ", 3)) {
+            tolist[1] = str::split(buff + 4, ", ");
+        } else if ((flags & O_INCORPORATE) &&
+                   !strncmp(buff, "Resent-To: ", 10)) {
+            tolist[2] = str::split(buff + 11, ", ");
+            /* KKK similarly for
+             * newsgroups? */
 
-		} else if (!strncmp(buff, "Date: ", 6)) {
-			do_getdate(&(thiss.last), buff + 6);
-			thiss.first = thiss.last;
-		} else if (!strncmp(buff, "From: ", 6)) {
-			char *from = buff + 6;
-			char *p, *q;
-			if ((p = strchr(from, '(')) != NULL) {
-				/* login (fullname) */
-				sscanf(from, "%s", fromL);
-				q = strchr(p, ')');
-				strncpy(fromF, p + 1, q - p - 1);
-				fromF[q - p - 1] = '\0';
-			} else if ((p = strchr(from, '<')) != NULL) {
-				/* "fullname" <login> */
-				char path[MAX_LINE_LENGTH];
-				strncpy(path, from, p - from - 1);
-				path[p - from - 1] = '\0';
-				auto s = noquote(path);
-				strcpy(fromF, s.c_str());
-				q = strchr(p, '>');
-				strncpy(fromL, p + 1, q - p - 1);
-				fromL[q - p - 1] = '\0';
-			} else { /* login */
-				strcpy(fromL, from);
-				strcpy(fromF, fromL);
-			}
-		} else if (!strncasecmp(buff, "Message-ID: <", 13)) {
-			char *p;
-			p = strchr(buff, '>');
-			*p = '\0';
-			strcpy(mid, buff + 13);
-		}
-	} while (!line.empty()); /* until blank line */
-	if (flags & O_INCORPORATE)
-		text = grab_more(fp, NULL, NULL);
-	else /* for INCORPORATE, fp is stdin */
-		mclose(fp);
+        } else if (!strncmp(buff, "Date: ", 6)) {
+            do_getdate(&(thiss.last), buff + 6);
+            thiss.first = thiss.last;
+        } else if (!strncmp(buff, "From: ", 6)) {
+            char *from = buff + 6;
+            char *p, *q;
+            if ((p = strchr(from, '(')) != NULL) {
+                /* login (fullname) */
+                sscanf(from, "%s", fromL);
+                q = strchr(p, ')');
+                strncpy(fromF, p + 1, q - p - 1);
+                fromF[q - p - 1] = '\0';
+            } else if ((p = strchr(from, '<')) != NULL) {
+                /* "fullname" <login> */
+                char path[MAX_LINE_LENGTH];
+                strncpy(path, from, p - from - 1);
+                path[p - from - 1] = '\0';
+                auto s = noquote(path);
+                strcpy(fromF, s.c_str());
+                q = strchr(p, '>');
+                strncpy(fromL, p + 1, q - p - 1);
+                fromL[q - p - 1] = '\0';
+            } else { /* login */
+                strcpy(fromL, from);
+                strcpy(fromF, fromL);
+            }
+        } else if (!strncasecmp(buff, "Message-ID: <", 13)) {
+            char *p;
+            p = strchr(buff, '>');
+            *p = '\0';
+            strcpy(mid, buff + 13);
+        }
+    } while (!line.empty()); /* until blank line */
+    if (flags & O_INCORPORATE)
+        text = grab_more(fp, NULL, NULL);
+    else /* for INCORPORATE, fp is stdin */
+        mclose(fp);
 
-	/* Incorporate message into each conference */
-	if (flags & O_INCORPORATE) {
-		for (k = 0; k <= 2; k++) {
-			if (tolist[k].empty())
-				continue;
+    /* Incorporate message into each conference */
+    if (flags & O_INCORPORATE) {
+        for (k = 0; k <= 2; k++) {
+            if (tolist[k].empty())
+                continue;
 
-			for (j = 0; j < tolist[k].size(); j++) {
-				auto s = str::ltrim(tolist[k][j], "<");
-				s = str::rtrim(s, ">");
-				i = get_idx(s, maillist);
-				if (i < 0)
-					continue;
-				idx = get_idx(maillist[i].location, conflist);
-				if (idx < 0)
-					continue;
+            for (j = 0; j < tolist[k].size(); j++) {
+                auto s = str::ltrim(tolist[k][j], "<");
+                s = str::rtrim(s, ">");
+                i = get_idx(s, maillist);
+                if (i < 0)
+                    continue;
+                idx = get_idx(maillist[i].location, conflist);
+                if (idx < 0)
+                    continue;
 
-				/* read in sumfile */
-				get_status(&st_glob, sum, part, idx);
-				incorporate2(art, sum, part, stt, idx, &thiss,
-				    sj, text, mid, fromL, fromF);
-				placed = 1;
-			}
-		}
-		if (!placed) {
-			if ((idx = get_idx(maillist[0].location, conflist)) > 0) {
-				/* read in sumfile */
-				get_status(&st_glob, sum, part, idx);
-				incorporate2(art, sum, part, stt, idx, &thiss,
-				    sj, text, mid, fromL, fromF);
-			}
-		}
-	} else
-		incorporate2(art, sum, part, stt, idx, &thiss, sj, text,
-		    mid, fromL, fromF);
+                /* read in sumfile */
+                get_status(&st_glob, sum, part, idx);
+                incorporate2(art, sum, part, stt, idx, &thiss, sj, text, mid,
+                    fromL, fromF);
+                placed = 1;
+            }
+        }
+        if (!placed) {
+            if ((idx = get_idx(maillist[0].location, conflist)) > 0) {
+                /* read in sumfile */
+                get_status(&st_glob, sum, part, idx);
+                incorporate2(art, sum, part, stt, idx, &thiss, sj, text, mid,
+                    fromL, fromF);
+            }
+        }
+    } else
+        incorporate2(
+            art, sum, part, stt, idx, &thiss, sj, text, mid, fromL, fromF);
 
-	return 1;
+    return 1;
 }
 
 #ifdef NEWS
 void
 news_show_header(void)
 {
-	short pr;
+    short pr;
 
-	open_pipe();
-	const auto config = get_config(confidx);
-	if (config.size() <= CF_NEWSGROUP)
-		return;
-	const auto path = std::format("{}/{}/{}",
-	    get_conf_param("newsdir", NEWSDIR),
-	    dot2slash(config[CF_NEWSGROUP]),
-	    st_glob.i_current);
-	FILE *fp = mopen(path, O_R);
-	if (fp == nullptr)
-		return;
-	/* current resp = header */
-	st_glob.r_current = 0;
-	/* Get header of #0 */
-	get_resp(fp, re, (short)GR_HEADER, (short)0);
-	/* The problem here is that itemsep uses r_current as an index
-	   to the information in re, so we can't show # new responses
-	      st_glob.r_current = sum[st_glob.i_current-1].nr
-	       - abs(part[st_glob.i_current-1].nr);
-	 */
+    open_pipe();
+    const auto config = get_config(confidx);
+    if (config.size() <= CF_NEWSGROUP)
+        return;
+    const auto path =
+        std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+            dot2slash(config[CF_NEWSGROUP]), st_glob.i_current);
+    FILE *fp = mopen(path, O_R);
+    if (fp == nullptr)
+        return;
+    /* current resp = header */
+    st_glob.r_current = 0;
+    /* Get header of #0 */
+    get_resp(fp, re, (short)GR_HEADER, (short)0);
+    /* The problem here is that itemsep uses r_current as an index
+       to the information in re, so we can't show # new responses
+          st_glob.r_current = sum[st_glob.i_current-1].nr
+           - abs(part[st_glob.i_current-1].nr);
+     */
 
-	/* Get info about the actual item text if possible */
-	if (re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED))
-		pr = 0;
-	else if (re[st_glob.r_current].flags & RF_CENSORED)
-		pr = ((st_glob.opt_flags & OF_NOFORGET) ||
-		      !(flags & O_FORGET));
-	else
-		pr = 1;
+    /* Get info about the actual item text if possible */
+    if (re[st_glob.r_current].flags & (RF_EXPIRED | RF_SCRIBBLED))
+        pr = 0;
+    else if (re[st_glob.r_current].flags & RF_CENSORED)
+        pr = ((st_glob.opt_flags & OF_NOFORGET) || !(flags & O_FORGET));
+    else
+        pr = 1;
 
-	std::string buff;
-	if (pr)
-		get_resp(fp, &(re[st_glob.r_current]), (short)GR_ALL,
-		    st_glob.r_current);
-	if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
-	    re[st_glob.r_current].numchars > 7) {
-		fseek(fp, re[st_glob.r_current].textoff, 0);
-		ngets(buff, fp);
-		re[st_glob.r_current].text.clear();
-		re[st_glob.r_current].text.push_back(buff);
-	}
-	if (flags & O_LABEL)
-		sepinit(IS_CENSORED | IS_UID | IS_DATE);
-	itemsep(expand((st_glob.opt_flags & OF_int) ? "ishort" : "isep", DM_VAR), 0);
-	if (pr) {
-		re[st_glob.r_current].text.clear();
-	}
-	st_glob.r_current = 0; /* current resp = header */
-	mclose(fp);
+    std::string buff;
+    if (pr)
+        get_resp(
+            fp, &(re[st_glob.r_current]), (short)GR_ALL, st_glob.r_current);
+    if ((re[st_glob.r_current].flags & RF_SCRIBBLED) &&
+        re[st_glob.r_current].numchars > 7) {
+        fseek(fp, re[st_glob.r_current].textoff, 0);
+        ngets(buff, fp);
+        re[st_glob.r_current].text.clear();
+        re[st_glob.r_current].text.push_back(buff);
+    }
+    if (flags & O_LABEL)
+        sepinit(IS_CENSORED | IS_UID | IS_DATE);
+    itemsep(
+        expand((st_glob.opt_flags & OF_int) ? "ishort" : "isep", DM_VAR), 0);
+    if (pr) {
+        re[st_glob.r_current].text.clear();
+    }
+    st_glob.r_current = 0; /* current resp = header */
+    mclose(fp);
 }
 /******************************************************************************/
 /* GENERATE UNIQUE MESSAGE ID FOR A RESPONSE                                  */
@@ -557,11 +544,11 @@ news_show_header(void)
 const std::string &
 message_id(const std::string_view &c, int i, int r, response_t *re)
 {
-	if (re[r].mid.empty()) {
-		re[r].mid = std::format("{}.{}@{}",
-		    get_date(re[r].date, 14), re[r].uid, hostname);
-	}
-	return re[r].mid;
+    if (re[r].mid.empty()) {
+        re[r].mid = std::format(
+            "{}.{}@{}", get_date(re[r].date, 14), re[r].uid, hostname);
+    }
+    return re[r].mid;
 }
 /******************************************************************************/
 /* GET AN ACTUAL ARTICLE                                                      */
@@ -571,66 +558,65 @@ get_article(       /* ARGUMENTS                      */
     response_t *re /* Response to fill in         */
 )
 {
-	/* LOCAL VARIABLES:               */
-	char done = 0;
+    /* LOCAL VARIABLES:               */
+    char done = 0;
 
-	re->text.clear();
-	const auto config = get_config(confidx);
-	if (config.size() <= CF_NEWSGROUP) {
-		re->flags |= RF_EXPIRED;
-		return;
-	}
-	const auto path = std::format("{}/{}/{}",
-	    get_conf_param("newsdir", NEWSDIR),
-	    dot2slash(config[CF_NEWSGROUP]),
-	    re->article);
-	/* Article file pointer        */
-	FILE *fp = mopen(path, O_R | O_SILENT);
-	if (fp == nullptr) {
-		re->flags |= RF_EXPIRED;
-		/* anything else? */
-		return;
-	}
+    re->text.clear();
+    const auto config = get_config(confidx);
+    if (config.size() <= CF_NEWSGROUP) {
+        re->flags |= RF_EXPIRED;
+        return;
+    }
+    const auto path =
+        std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+            dot2slash(config[CF_NEWSGROUP]), re->article);
+    /* Article file pointer        */
+    FILE *fp = mopen(path, O_R | O_SILENT);
+    if (fp == nullptr) {
+        re->flags |= RF_EXPIRED;
+        /* anything else? */
+        return;
+    }
 
-	/* Get response */
-	re->flags = 0;
-	re->mid.clear();
-	re->parent = re->article = 0;
+    /* Get response */
+    re->flags = 0;
+    re->mid.clear();
+    re->parent = re->article = 0;
 
-	while (!done && !(status & S_INT)) {
-		std::string line;
-		if (!ngets(line, fp)) {
-			done = 1;
-			break;
-		}
-		char *buff = line.data();
-		if (!strncmp(buff, "Message-ID: <", 13)) {
-			char *p;
-			p = strchr(buff, '>');
-			*p = '\0';
-			re->mid = buff + 13;
-		} else if (!strlen(buff)) {
-			long textoff;
-			textoff = ftell(fp);
-			re->text = grab_more(fp, (flags & O_SIGNATURE) ? NULL : "--", NULL);
-			re->numchars = ftell(fp) - textoff;
-			done = 1;
-			break;
-		}
-	}
-	mclose(fp);
+    while (!done && !(status & S_INT)) {
+        std::string line;
+        if (!ngets(line, fp)) {
+            done = 1;
+            break;
+        }
+        char *buff = line.data();
+        if (!strncmp(buff, "Message-ID: <", 13)) {
+            char *p;
+            p = strchr(buff, '>');
+            *p = '\0';
+            re->mid = buff + 13;
+        } else if (!strlen(buff)) {
+            long textoff;
+            textoff = ftell(fp);
+            re->text = grab_more(fp, (flags & O_SIGNATURE) ? NULL : "--", NULL);
+            re->numchars = ftell(fp) - textoff;
+            done = 1;
+            break;
+        }
+    }
+    mclose(fp);
 }
 /******************************************************************************/
 /* DOT2SLASH: Return directory/string/form of news.group.string passed in     */
 /******************************************************************************/
 std::string
-dot2slash(    /* ARGUMENTS:                      */
+dot2slash(                      /* ARGUMENTS:                      */
     const std::string_view &str /* Dot-separated string         */
 )
 {
-	std::string out(str);
-	std::replace(out.begin(), out.end(), '.', '/');
-	return out;
+    std::string out(str);
+    std::replace(out.begin(), out.end(), '.', '/');
+    return out;
 }
 /******************************************************************************/
 /* REFRESH_NEWS: Look for any new articles, and if any are found, incorporate */
@@ -644,97 +630,95 @@ refresh_news(          /* ARGUMENTS:                     */
     int idx            /* Conference index to update  */
 )
 {
-	struct stat st;
-	long article;
-	DIR *fp;
-	FILE *artp;
-	struct dirent *dp;
-	int i;
+    struct stat st;
+    long article;
+    DIR *fp;
+    FILE *artp;
+    struct dirent *dp;
+    int i;
 
-	const auto config = get_config(idx);
-	if (config.size() <= CF_NEWSGROUP)
-		return;
+    const auto config = get_config(idx);
+    if (config.size() <= CF_NEWSGROUP)
+        return;
 
-	const auto path = str::join("/",
-	    {get_conf_param("newsdir", NEWSDIR),
-	    dot2slash(config[CF_NEWSGROUP])});
-	if (stat(path.c_str(), &st)) {
-		error("refreshing ", path);
-		return;
-	}
+    const auto path = str::join("/",
+        {get_conf_param("newsdir", NEWSDIR), dot2slash(config[CF_NEWSGROUP])});
+    if (stat(path.c_str(), &st)) {
+        error("refreshing ", path);
+        return;
+    }
 
-	/* Is there new stuff? */
-	if (st.st_mtime != stt->sumtime) {
-		long mod;
-		struct stat artst;
-		const auto artpath = str::concat({conflist[idx].location, "/article"});
+    /* Is there new stuff? */
+    if (st.st_mtime != stt->sumtime) {
+        long mod;
+        struct stat artst;
+        const auto artpath = str::concat({conflist[idx].location, "/article"});
 
-		/* Create if doesn't exist, else update */
-		if (stat(artpath.c_str(), &artst))
-			mod = O_W;
-		else
-			mod = O_RPLUS;
+        /* Create if doesn't exist, else update */
+        if (stat(artpath.c_str(), &artst))
+            mod = O_W;
+        else
+            mod = O_RPLUS;
 
-		/* if (stt->c_security & CT_BASIC) mod |= O_PRIVATE; */
-		if ((artp = mopen(artpath, mod)) == NULL)
-			return; /* can't lock */
+        /* if (stt->c_security & CT_BASIC) mod |= O_PRIVATE; */
+        if ((artp = mopen(artpath, mod)) == NULL)
+            return; /* can't lock */
 
-		if ((fp = opendir(path.c_str())) == NULL) {
-			error("opening ", path);
-			return;
-		}
-		refresh_stats(sum, part, stt); /* update stt */
+        if ((fp = opendir(path.c_str())) == NULL) {
+            error("opening ", path);
+            return;
+        }
+        refresh_stats(sum, part, stt); /* update stt */
 
-		/* Load in stats 1 piece at a time - the slow stuff */
-		article = stt->c_article;
-		for (dp = readdir(fp); dp != NULL && !(status & S_INT);
-		     dp = readdir(fp)) {
-			long i2;
-			if (sscanf(dp->d_name, "%ld", &i2) == 1 &&
-			    i2 > stt->c_article) {
-				incorporate(i2, sum, part, stt, idx);
-				if (i2 > article) {
-					article = i2;
-					fseek(artp, 0L, 0);
-					std::println(artp, "{}", article);
-				}
-				refresh_stats(sum, part, stt); /* update stt */
-			}
-		}
-		closedir(fp);
+        /* Load in stats 1 piece at a time - the slow stuff */
+        article = stt->c_article;
+        for (dp = readdir(fp); dp != NULL && !(status & S_INT);
+            dp = readdir(fp)) {
+            long i2;
+            if (sscanf(dp->d_name, "%ld", &i2) == 1 && i2 > stt->c_article) {
+                incorporate(i2, sum, part, stt, idx);
+                if (i2 > article) {
+                    article = i2;
+                    fseek(artp, 0L, 0);
+                    std::println(artp, "{}", article);
+                }
+                refresh_stats(sum, part, stt); /* update stt */
+            }
+        }
+        closedir(fp);
 
-		/* Check for expired */
-		for (i = stt->i_first; i <= stt->i_last; i++) {
-			response_t re;
-			const auto path = std::format("{}/_{}", conflist[idx].location, i);
-			FILE *fp2 = mopen(path, O_R);
-			if (fp2 != nullptr) {
-				re.fullname.clear();
-				re.login.clear();
-				re.mid.clear();
-				re.text.clear();
-				re.offset = -1;
+        /* Check for expired */
+        for (i = stt->i_first; i <= stt->i_last; i++) {
+            response_t re;
+            const auto path = std::format("{}/_{}", conflist[idx].location, i);
+            FILE *fp2 = mopen(path, O_R);
+            if (fp2 != nullptr) {
+                re.fullname.clear();
+                re.login.clear();
+                re.mid.clear();
+                re.text.clear();
+                re.offset = -1;
 
-				get_resp(fp2, &re, GR_ALL, 0);
-				if (re.flags & RF_EXPIRED) {
-					sum[i - 1].flags |= IF_EXPIRED;
-					dirty_sum(i - 1);
-				}
-				mclose(fp2);
+                get_resp(fp2, &re, GR_ALL, 0);
+                if (re.flags & RF_EXPIRED) {
+                    sum[i - 1].flags |= IF_EXPIRED;
+                    dirty_sum(i - 1);
+                }
+                mclose(fp2);
 
-				re.fullname.clear();
-				re.login.clear();
-				re.text.clear();
-				re.mid.clear();
-			}
-		}
+                re.fullname.clear();
+                re.login.clear();
+                re.text.clear();
+                re.mid.clear();
+            }
+        }
 
-		stt->sumtime = st.st_mtime;
-		stt->c_article = article;
-		refresh_stats(sum, part, stt); /* update stt */
-		save_sum(sum, 0, idx, stt);
+        stt->sumtime = st.st_mtime;
+        stt->c_article = article;
+        refresh_stats(sum, part, stt); /* update stt */
+        save_sum(sum, 0, idx, stt);
 
-		mclose(artp); /* release lock on article file */
-	}
+        mclose(artp); /* release lock on article file */
+    }
 }
 #endif

--- a/range.cc
+++ b/range.cc
@@ -65,11 +65,11 @@ Problem is that item comes up as new when there are no new responses.
 int
 is_newresp(partentry_t *p, sumentry_t *s)
 {
-	if ((flags & O_SENSITIVE) && p->nr && (p->last < s->last))
-		return 1;
-	if (p->nr && (abs(p->nr) < s->nr) && (p->last < s->last))
-		return 1;
-	return 0;
+    if ((flags & O_SENSITIVE) && p->nr && (p->last < s->last))
+        return 1;
+    if (p->nr && (abs(p->nr) < s->nr) && (p->last < s->last))
+        return 1;
+    return 0;
 }
 /*
  * if (part[i].last < sum[i].last) *
@@ -82,7 +82,7 @@ is_newresp(partentry_t *p, sumentry_t *s)
 int
 is_brandnew(partentry_t *p, sumentry_t *s)
 {
-	return ((!p->nr && s->nr) && (p->last < s->last));
+    return ((!p->nr && s->nr) && (p->last < s->last));
 }
 /*****************************************************************************/
 /* TEST WHETHER ITEM IS COVERED BY THE SPECIFIED SUBSET PARAMETERS           */
@@ -97,71 +97,71 @@ cover(                 /* ARGUMENTS: */
     partentry_t *part, /* User participation info      */
     status_t *st)
 {
-	sumentry_t *s;
-	partentry_t *p;
-	/* if (spec & OF_NONE) return 0; */
-	if (act == A_SKIP)
-		return 0;
+    sumentry_t *s;
+    partentry_t *p;
+    /* if (spec & OF_NONE) return 0; */
+    if (act == A_SKIP)
+        return 0;
 
-	/* I'm guessing the following refresh is so we catch changes while
-	 * reading items. -dgt 8/22/97 */
-	refresh_sum(i, idx, sum, part, st); /* added for sno */
+    /* I'm guessing the following refresh is so we catch changes while
+     * reading items. -dgt 8/22/97 */
+    refresh_sum(i, idx, sum, part, st); /* added for sno */
 
-	s = &(sum[i - 1]);
-	p = &(part[i - 1]);
-	if (!s->flags)
-		return 0;
-	if (!st->string.empty()) {
-		auto newstring = st->string;
-		lower_case(newstring);
-		std::string subjstring = get_subj(idx, i - 1, sum);
-		lower_case(subjstring);
-		if (subjstring.find(newstring) == std::string::npos)
-			return 0;
-	}
-	if (!st->author.empty() && !str::eq(get_auth(idx, i - 1, sum), st->author))
-		return 0;
-	if (st->since > s->last)
-		return 0;
-	if (st->before < s->last && st->before > 0)
-		return 0;
-	if (st->rng_flags && !(s->flags & st->rng_flags))
-		return 0;
-	if (act == A_FORCE) {
-		/* force takes precedence over forgotten */
-		return 1;
-		/*
-		if (s->flags & IF_FORGOTTEN)
-			std::print("<{}:{}:{}:}{}",
-			    i, spec & (OF_NOFORGET|OF_FORGOTTEN|OF_RETIRED),
-			    flags & O_FORGET,
-			    s->flags & (IF_FORGOTTEN|IF_RETIRED));
-		*/
-	}
-	if (!(spec & (OF_NOFORGET | OF_FORGOTTEN)) && (flags & O_FORGET) &&
-	    (s->flags & IF_FORGOTTEN))
-		return 0;
-	if (!(spec & (OF_NOFORGET | OF_RETIRED)) && (s->flags & IF_RETIRED))
-		return 0;
-	if (!(spec & (OF_NOFORGET | OF_EXPIRED)) && (s->flags & IF_EXPIRED))
-		return 0;
+    s = &(sum[i - 1]);
+    p = &(part[i - 1]);
+    if (!s->flags)
+        return 0;
+    if (!st->string.empty()) {
+        auto newstring = st->string;
+        lower_case(newstring);
+        std::string subjstring = get_subj(idx, i - 1, sum);
+        lower_case(subjstring);
+        if (subjstring.find(newstring) == std::string::npos)
+            return 0;
+    }
+    if (!st->author.empty() && !str::eq(get_auth(idx, i - 1, sum), st->author))
+        return 0;
+    if (st->since > s->last)
+        return 0;
+    if (st->before < s->last && st->before > 0)
+        return 0;
+    if (st->rng_flags && !(s->flags & st->rng_flags))
+        return 0;
+    if (act == A_FORCE) {
+        /* force takes precedence over forgotten */
+        return 1;
+        /*
+        if (s->flags & IF_FORGOTTEN)
+            std::print("<{}:{}:{}:}{}",
+                i, spec & (OF_NOFORGET|OF_FORGOTTEN|OF_RETIRED),
+                flags & O_FORGET,
+                s->flags & (IF_FORGOTTEN|IF_RETIRED));
+        */
+    }
+    if (!(spec & (OF_NOFORGET | OF_FORGOTTEN)) && (flags & O_FORGET) &&
+        (s->flags & IF_FORGOTTEN))
+        return 0;
+    if (!(spec & (OF_NOFORGET | OF_RETIRED)) && (s->flags & IF_RETIRED))
+        return 0;
+    if (!(spec & (OF_NOFORGET | OF_EXPIRED)) && (s->flags & IF_EXPIRED))
+        return 0;
 
-	/* Process NEW limitations */
-	if ((spec & OF_NEWRESP) && is_newresp(p, s))
-		return 1;
-	if ((spec & OF_BRANDNEW) && is_brandnew(p, s))
-		return 1;
-	if (spec & (OF_NEWRESP | OF_BRANDNEW))
-		return 0;
-	if ((spec & OF_UNSEEN) && p->nr)
-		return 0;
-	if ((spec & OF_FORGOTTEN) && !(s->flags & IF_FORGOTTEN))
-		return 0;
-	if ((spec & OF_RETIRED) && !(s->flags & IF_RETIRED))
-		return 0;
+    /* Process NEW limitations */
+    if ((spec & OF_NEWRESP) && is_newresp(p, s))
+        return 1;
+    if ((spec & OF_BRANDNEW) && is_brandnew(p, s))
+        return 1;
+    if (spec & (OF_NEWRESP | OF_BRANDNEW))
+        return 0;
+    if ((spec & OF_UNSEEN) && p->nr)
+        return 0;
+    if ((spec & OF_FORGOTTEN) && !(s->flags & IF_FORGOTTEN))
+        return 0;
+    if ((spec & OF_RETIRED) && !(s->flags & IF_RETIRED))
+        return 0;
 
-	/* if (spec & OF_NEXT) spec |= OF_NONE; */
-	return 1;
+    /* if (spec & OF_NEXT) spec |= OF_NONE; */
+    return 1;
 }
 /*****************************************************************************/
 /* MARK A RANGE OF ITEMS TO BE ACTED UPON                                    */
@@ -176,74 +176,70 @@ markrange(                     /* ARGUMENTS: */
     int val                    /* Action value to set */
 )
 {
-	if (bg < st->i_first)
-		std::println("{} #{} is too small (first {})",
-		    topic(1), bg, st->i_first);
-	else if (nd > st->i_last)
-		std::println("{} #{} is too big (last {})",
-		    topic(1), nd, st->i_last);
-	else {
-		for (auto j = bg; j <= nd; j++)
-			if (sum[j - 1].flags)
-				act[j - 1] = val;
-		if (bg == nd && !sum[bg - 1].flags)
-			std::println("No such {}!", topic());
-	}
+    if (bg < st->i_first)
+        std::println(
+            "{} #{} is too small (first {})", topic(1), bg, st->i_first);
+    else if (nd > st->i_last)
+        std::println("{} #{} is too big (last {})", topic(1), nd, st->i_last);
+    else {
+        for (auto j = bg; j <= nd; j++)
+            if (sum[j - 1].flags)
+                act[j - 1] = val;
+        if (bg == nd && !sum[bg - 1].flags)
+            std::println("No such {}!", topic());
+    }
 }
 /*****************************************************************************/
 /* CONVERT A TOKEN TO AN INTEGER                                             */
 /*****************************************************************************/
 short
-get_number(      /* ARGUMENTS:                */
+get_number(                        /* ARGUMENTS:                */
     const std::string_view &token, /* Field to process      */
-    status_t *st /* Conference statistics */
+    status_t *st                   /* Conference statistics */
 )
 {
-	short a, b;
-	if (match(token, "fi_rst") || match(token, "^"))
-		return st->i_first;
-	if (match(token, "l_ast") || match(token, "$"))
-		return st->i_last;
-	if (match(token, "th_is") || match(token, "cu_rrent") ||
-	    match(token, "."))
-		return st->i_current;
-	std::string tok(token);
-	if (sscanf(tok.c_str(), "%hd.%hd", &a, &b) == 2) {
-		if (b >= 0 && b < sum[a - 1].nr)
-			st->r_first = b;
-		return a;
-	}
-	return str::toi(tok);
+    short a, b;
+    if (match(token, "fi_rst") || match(token, "^"))
+        return st->i_first;
+    if (match(token, "l_ast") || match(token, "$"))
+        return st->i_last;
+    if (match(token, "th_is") || match(token, "cu_rrent") || match(token, "."))
+        return st->i_current;
+    std::string tok(token);
+    if (sscanf(tok.c_str(), "%hd.%hd", &a, &b) == 2) {
+        if (b >= 0 && b < sum[a - 1].nr)
+            st->r_first = b;
+        return a;
+    }
+    return str::toi(tok);
 }
 
 static void
-rangearray(
-    const std::vector<std::string> &args,
-    std::size_t start,
-    short *fl,			/* Flags to use */
-    char act[MAX_ITEMS],	/* Action array to fill in */
-    sumentry_t sum[MAX_ITEMS],	/* Item summary info array */
-    status_t *st		/* Conference statistics */
+rangearray(const std::vector<std::string> &args, std::size_t start,
+    short *fl,                 /* Flags to use */
+    char act[MAX_ITEMS],       /* Action array to fill in */
+    sumentry_t sum[MAX_ITEMS], /* Item summary info array */
+    status_t *st               /* Conference statistics */
 )
 {
-	size_t i = start;
-	if (start >= args.size())
-		return;
-	for (auto it = args.begin() + start; it != args.end(); ++it) {
-		const auto &arg = *it;
-		if (match(arg, "si_nce") || match(arg, "S="))
-			st->since = since(args, &i);
-		else if (match(arg, "before") || match(arg, "B="))
-			st->before = since(args, &i);
-		else if (match(arg, "by") || match(arg, "A=")) {
-			if (it + 1 == args.end())
-				std::println("Invalid author specified.");
-			else
-				st->author = arg;
-		} else if (!match(arg, "F=")) /* skip "F=" */
-			rangetoken(arg.c_str(), fl, act, sum, st);
-		i++;
-	}
+    size_t i = start;
+    if (start >= args.size())
+        return;
+    for (auto it = args.begin() + start; it != args.end(); ++it) {
+        const auto &arg = *it;
+        if (match(arg, "si_nce") || match(arg, "S="))
+            st->since = since(args, &i);
+        else if (match(arg, "before") || match(arg, "B="))
+            st->before = since(args, &i);
+        else if (match(arg, "by") || match(arg, "A=")) {
+            if (it + 1 == args.end())
+                std::println("Invalid author specified.");
+            else
+                st->author = arg;
+        } else if (!match(arg, "F=")) /* skip "F=" */
+            rangetoken(arg.c_str(), fl, act, sum, st);
+        i++;
+    }
 }
 
 /*****************************************************************************/
@@ -258,136 +254,136 @@ rangetoken(                    /* ARGUMENTS: */
     status_t *st               /* Conference statistics */
 )
 {
-	short fl, a, b, c;
-	char buff[MAX_LINE_LENGTH];
+    short fl, a, b, c;
+    char buff[MAX_LINE_LENGTH];
 
-	if (debug & DB_RANGE)
-		std::println("rangetoken: '{}'", token);
-	const auto bp = expand(token, DM_PARAM);
-	if (!bp.empty()) {
-		const auto arr = str::splits(bp, " ");
-		rangearray(arr, 0, flg, act, sum, st);
-		return;
-	}
-	fl = *flg;
+    if (debug & DB_RANGE)
+        std::println("rangetoken: '{}'", token);
+    const auto bp = expand(token, DM_PARAM);
+    if (!bp.empty()) {
+        const auto arr = str::splits(bp, " ");
+        rangearray(arr, 0, flg, act, sum, st);
+        return;
+    }
+    fl = *flg;
 
-	if (match(token, "a_ll") || match(token, "*")) {
-		markrange(st->i_first, st->i_last, act, sum, st, A_COVER);
-		fl |= OF_RANGE;             /* items specified */
-	} else if (match(token, "nex_t")) { /* fl |=  OF_NEXT; */
-		markrange((short)(st->i_current + 1), st->i_last, act, sum, st,
-		    A_COVER);
-		fl |= OF_RANGE; /* KKK */
-	} else if (match(token, "pr_evious")) {
-		fl |= /* OF_NEXT | */ OF_REVERSE;
-		markrange(st->i_first, (short)(st->i_current - 1), act, sum, st,
-		    A_COVER);
-		fl |= OF_RANGE; /* KKK */
-	} else if (match(token, "n_ew")) {
-		fl |= OF_BRANDNEW | OF_NEWRESP;
-	} else if (match(token, "nof_orget")) {
-		fl |= OF_NOFORGET;
-	} else if (match(token, "p_ass")) {
-		fl |= OF_PASS;
-	} else if (match(token, "d_ate")) {
-		fl |= OF_DATE;
-	} else if (match(token, "nor_esponse")) {
-		fl |= OF_NORESPONSE;
-	} else if (match(token, "u_id")) {
-		fl |= OF_UID;
-	} else if (match(token, "nod_ate")) {
-		fl &= ~OF_DATE;
-	} else if (match(token, "nou_id")) {
-		fl &= ~OF_UID;
-	} else if (match(token, "bra_ndnew")) {
-		fl |= OF_BRANDNEW;
-	} else if (match(token, "newr_esponse")) {
-		fl |= OF_NEWRESP;
-	} else if (match(token, "r_everse")) {
-		fl |= OF_REVERSE;
-	} else if (match(token, "s_hort")) {
-		fl |= OF_int;
-	} else if (match(token, "nop_ass")) {
-		fl &= ~OF_PASS;
-	} else if (match(token, "nu_mbered")) {
-		fl |= OF_NUMBERED;
-	} else if (match(token, "nonu_mbered")) {
-		fl &= ~OF_NUMBERED;
-	} else if (match(token, "unn_umbered")) {
-		fl &= ~OF_NUMBERED;
-	} else if (match(token, "o_ld")) { /* xxxj */
-	} else if (match(token, "exp_ired")) {
-		fl |= OF_EXPIRED;
-	} else if (match(token, "ret_ired")) {
-		fl |= OF_RETIRED;
-	} else if (match(token, "for_gotten")) {
-		fl |= OF_FORGOTTEN;
-	} else if (match(token, "un_seen")) {
-		fl |= OF_UNSEEN;
-	} else if (match(token, "linked")) {
-		st->rng_flags |= IF_LINKED;
-	} else if (match(token, "frozen")) {
-		st->rng_flags |= IF_FROZEN;
-	} else if (match(token, "force_response") ||
-	           match(token, "force_respond")) {                   /* KKK */
-	} else if (match(token, "respond")) {                         /* KKK */
-	} else if (match(token, "form_feed") || match(token, "ff")) { /* KKK */
-	} else if (match(token, "lo_ng")) {
-		fl &= ~OF_int;
-	} else if (token[0] == '"') { /* "string" */
-		st->string = token + 1;
-		if (st->string[strlen(token) - 2] == '"')
-			st->string.erase(strlen(token) - 2);
-	} else if (strchr(token, ',')) {
-		const auto arr = str::splits(token, ",");
-		rangearray(arr, 0, flg, act, sum, st);
-		return;
-	} else if (token[0] == '-') {
-		a = get_number(token + 1, st);
-		markrange(st->i_first, a, act, sum, st, A_COVER);
-		fl |= OF_RANGE; /* range specified */
-	} else if (token[strlen(token) - 1] == '-') {
-		strcpy(buff, token);
-		buff[strlen(buff) - 1] = '\0';
-		a = get_number(buff, st);
-		markrange(a, st->i_last, act, sum, st, A_COVER);
-		fl |= OF_RANGE;
-	} else if (auto *bp = strchr(token, '-'); bp != NULL) {
-		strncpy(buff, token, bp - token);
-		buff[bp - token] = '\0';
-		a = get_number(buff, st);
-		b = get_number(bp + 1, st);
-		if (b < a) {
-			c = b;
-			b = a;
-			a = c;
-			fl ^= OF_REVERSE;
-		}
-		markrange(a, b, act, sum, st, A_COVER);
-		fl |= OF_RANGE;
-		/*
-		} else if (sscanf(token,"-%hd",&a)==1) {
-		        markrange(st->i_first,a,act,sum,st,A_COVER);
-		        fl |= OF_RANGE;
-		} else if (sscanf(token,"%hd-%hd",&a,&b)==2) {
-		        if (b<a) { c=b; b=a; a=c; fl ^= OF_REVERSE; }
-		        markrange(a,b,act,sum,st,A_COVER);
-		        fl |= OF_RANGE;
-		} else if (sscanf(token,"%hd%c",&a,&ch)==2 && ch=='-') {
-		        markrange(a,st->i_last,act,sum,st,A_COVER);
-		        fl |= OF_RANGE;
-		} else if (sscanf(token,"%hd",&a)==1) {
-		        markrange(a,a,act,sum,st,A_FORCE);
-		        fl |= OF_RANGE;
-		*/
-	} else if ((a = get_number(token, st)) != 0) {
-		markrange(a, a, act, sum, st, A_FORCE);
-		fl |= OF_RANGE;
-	} else {
-		st->string = token;
-		/* KKK std::println("Bad token type in getrange"); */
-	}
-	*flg = fl;
+    if (match(token, "a_ll") || match(token, "*")) {
+        markrange(st->i_first, st->i_last, act, sum, st, A_COVER);
+        fl |= OF_RANGE;                 /* items specified */
+    } else if (match(token, "nex_t")) { /* fl |=  OF_NEXT; */
+        markrange(
+            (short)(st->i_current + 1), st->i_last, act, sum, st, A_COVER);
+        fl |= OF_RANGE; /* KKK */
+    } else if (match(token, "pr_evious")) {
+        fl |= /* OF_NEXT | */ OF_REVERSE;
+        markrange(
+            st->i_first, (short)(st->i_current - 1), act, sum, st, A_COVER);
+        fl |= OF_RANGE; /* KKK */
+    } else if (match(token, "n_ew")) {
+        fl |= OF_BRANDNEW | OF_NEWRESP;
+    } else if (match(token, "nof_orget")) {
+        fl |= OF_NOFORGET;
+    } else if (match(token, "p_ass")) {
+        fl |= OF_PASS;
+    } else if (match(token, "d_ate")) {
+        fl |= OF_DATE;
+    } else if (match(token, "nor_esponse")) {
+        fl |= OF_NORESPONSE;
+    } else if (match(token, "u_id")) {
+        fl |= OF_UID;
+    } else if (match(token, "nod_ate")) {
+        fl &= ~OF_DATE;
+    } else if (match(token, "nou_id")) {
+        fl &= ~OF_UID;
+    } else if (match(token, "bra_ndnew")) {
+        fl |= OF_BRANDNEW;
+    } else if (match(token, "newr_esponse")) {
+        fl |= OF_NEWRESP;
+    } else if (match(token, "r_everse")) {
+        fl |= OF_REVERSE;
+    } else if (match(token, "s_hort")) {
+        fl |= OF_int;
+    } else if (match(token, "nop_ass")) {
+        fl &= ~OF_PASS;
+    } else if (match(token, "nu_mbered")) {
+        fl |= OF_NUMBERED;
+    } else if (match(token, "nonu_mbered")) {
+        fl &= ~OF_NUMBERED;
+    } else if (match(token, "unn_umbered")) {
+        fl &= ~OF_NUMBERED;
+    } else if (match(token, "o_ld")) { /* xxxj */
+    } else if (match(token, "exp_ired")) {
+        fl |= OF_EXPIRED;
+    } else if (match(token, "ret_ired")) {
+        fl |= OF_RETIRED;
+    } else if (match(token, "for_gotten")) {
+        fl |= OF_FORGOTTEN;
+    } else if (match(token, "un_seen")) {
+        fl |= OF_UNSEEN;
+    } else if (match(token, "linked")) {
+        st->rng_flags |= IF_LINKED;
+    } else if (match(token, "frozen")) {
+        st->rng_flags |= IF_FROZEN;
+    } else if (match(token, "force_response") ||
+               match(token, "force_respond")) {                   /* KKK */
+    } else if (match(token, "respond")) {                         /* KKK */
+    } else if (match(token, "form_feed") || match(token, "ff")) { /* KKK */
+    } else if (match(token, "lo_ng")) {
+        fl &= ~OF_int;
+    } else if (token[0] == '"') { /* "string" */
+        st->string = token + 1;
+        if (st->string[strlen(token) - 2] == '"')
+            st->string.erase(strlen(token) - 2);
+    } else if (strchr(token, ',')) {
+        const auto arr = str::splits(token, ",");
+        rangearray(arr, 0, flg, act, sum, st);
+        return;
+    } else if (token[0] == '-') {
+        a = get_number(token + 1, st);
+        markrange(st->i_first, a, act, sum, st, A_COVER);
+        fl |= OF_RANGE; /* range specified */
+    } else if (token[strlen(token) - 1] == '-') {
+        strcpy(buff, token);
+        buff[strlen(buff) - 1] = '\0';
+        a = get_number(buff, st);
+        markrange(a, st->i_last, act, sum, st, A_COVER);
+        fl |= OF_RANGE;
+    } else if (auto *bp = strchr(token, '-'); bp != NULL) {
+        strncpy(buff, token, bp - token);
+        buff[bp - token] = '\0';
+        a = get_number(buff, st);
+        b = get_number(bp + 1, st);
+        if (b < a) {
+            c = b;
+            b = a;
+            a = c;
+            fl ^= OF_REVERSE;
+        }
+        markrange(a, b, act, sum, st, A_COVER);
+        fl |= OF_RANGE;
+        /*
+        } else if (sscanf(token,"-%hd",&a)==1) {
+                markrange(st->i_first,a,act,sum,st,A_COVER);
+                fl |= OF_RANGE;
+        } else if (sscanf(token,"%hd-%hd",&a,&b)==2) {
+                if (b<a) { c=b; b=a; a=c; fl ^= OF_REVERSE; }
+                markrange(a,b,act,sum,st,A_COVER);
+                fl |= OF_RANGE;
+        } else if (sscanf(token,"%hd%c",&a,&ch)==2 && ch=='-') {
+                markrange(a,st->i_last,act,sum,st,A_COVER);
+                fl |= OF_RANGE;
+        } else if (sscanf(token,"%hd",&a)==1) {
+                markrange(a,a,act,sum,st,A_FORCE);
+                fl |= OF_RANGE;
+        */
+    } else if ((a = get_number(token, st)) != 0) {
+        markrange(a, a, act, sum, st, A_FORCE);
+        fl |= OF_RANGE;
+    } else {
+        st->string = token;
+        /* KKK std::println("Bad token type in getrange"); */
+    }
+    *flg = fl;
 }
 
 /* args -- IN : fields holding date spec */
@@ -395,51 +391,50 @@ rangetoken(                    /* ARGUMENTS: */
 time_t
 since(const std::vector<std::string> &args, size_t *ip)
 {
-	time_t t = 0;
-	auto i = ((ip == nullptr) ? 0 : *ip) + 1;
-	if (i >= args.size()) {
-		std::println("Bad date near \"<newline>\"");
-		return LONG_MAX; /* process nothing */
-	}
-	if (args[i][0] == '"') {
-		std::string arg(args[i].begin() + 1, args[i].end());
-		if (args[i].back() == '"')
-			arg.pop_back();
-		do_getdate(&t, arg.c_str() + 1);
-	} else {
-		size_t where[MAX_ARGS];
-		std::string concat;
-		const char *sep = "";
-		for (auto j = i; j < args.size(); j++) {
-			where[i] = concat.size();
-			concat.append(sep);
-			concat.append(args[i]);
-			sep = " ";
-		}
-		const char *cstr = concat.c_str();
-		const char *ptr = do_getdate(&t, cstr);
-		while (ptr - cstr > where[i] && i < args.size())
-			++i;
-		i--;
-	}
-	if (debug & DB_RANGE)
-		std::print("Since set to {}", ctime(&t));
-	if (ip != nullptr)
-		*ip = i;
-	return t;
+    time_t t = 0;
+    auto i = ((ip == nullptr) ? 0 : *ip) + 1;
+    if (i >= args.size()) {
+        std::println("Bad date near \"<newline>\"");
+        return LONG_MAX; /* process nothing */
+    }
+    if (args[i][0] == '"') {
+        std::string arg(args[i].begin() + 1, args[i].end());
+        if (args[i].back() == '"')
+            arg.pop_back();
+        do_getdate(&t, arg.c_str() + 1);
+    } else {
+        size_t where[MAX_ARGS];
+        std::string concat;
+        const char *sep = "";
+        for (auto j = i; j < args.size(); j++) {
+            where[i] = concat.size();
+            concat.append(sep);
+            concat.append(args[i]);
+            sep = " ";
+        }
+        const char *cstr = concat.c_str();
+        const char *ptr = do_getdate(&t, cstr);
+        while (ptr - cstr > where[i] && i < args.size()) ++i;
+        i--;
+    }
+    if (debug & DB_RANGE)
+        std::print("Since set to {}", ctime(&t));
+    if (ip != nullptr)
+        *ip = i;
+    return t;
 }
 
 void
 rangeinit(status_t *st, char act[MAX_ITEMS])
 {
-	short i;
-	st->string.clear();
-	st->author.clear();
-	st->since = st->before = st->opt_flags = 0;
-	st->rng_flags = 0;
-	/* flags |= O_FORGET;  commented out 8/18 since it breaks 'set
-	 * noforget;r' */
-	for (i = 0; i < MAX_ITEMS; i++) act[i] = 0;
+    short i;
+    st->string.clear();
+    st->author.clear();
+    st->since = st->before = st->opt_flags = 0;
+    st->rng_flags = 0;
+    /* flags |= O_FORGET;  commented out 8/18 since it breaks 'set
+     * noforget;r' */
+    for (i = 0; i < MAX_ITEMS; i++) act[i] = 0;
 }
 /*****************************************************************************/
 /* PARSE ONE FIELD OF A RANGE SPECIFICATION                                  */
@@ -456,8 +451,7 @@ range(                         /* ARGUMENTS: */
     status_t *st,              /* Conference statistics */
     int bef)
 {
-	std::vector<std::string> args;
-	for (auto i = 0; i < argc; i++)
-		args.push_back(argv[i]);
-	rangearray(args, bef + 1, fl, act, sum, st);
+    std::vector<std::string> args;
+    for (auto i = 0; i < argc; i++) args.push_back(argv[i]);
+    rangearray(args, bef + 1, fl, act, sum, st);
 }

--- a/receive_post.cc
+++ b/receive_post.cc
@@ -20,195 +20,204 @@
 #define MAX_ENTRIES 10000
 
 typedef struct {
-	char *name;
-	char *val;
+    char *name;
+    char *val;
 } entry;
 
-char *makeword(char *line, char stop);
-char *fmakeword(FILE *f, char stop, int *len);
-char x2c(char *what);
-void unescape_url(char *url);
-void plustospace(char *str);
+char *
+makeword(char *line, char stop);
+char *
+fmakeword(FILE *f, char stop, int *len);
+char
+x2c(char *what);
+void
+unescape_url(char *url);
+void
+plustospace(char *str);
 
 void
 ftextout(FILE *fp, char *buff)
 {
-	char *q = buff;
-	while (*q) {
-		/* Remove the Control M's from the post */
-		if (*q == '\r') {
-			q++;
-			continue;
-		}
-		fputc(*q, fp);
-		q++;
-	}
-	fputc('\n', fp);
+    char *q = buff;
+    while (*q) {
+        /* Remove the Control M's from the post */
+        if (*q == '\r') {
+            q++;
+            continue;
+        }
+        fputc(*q, fp);
+        q++;
+    }
+    fputc('\n', fp);
 }
 
 void
 usage(void)
 {
-	std::println(stderr, "Yapp {} (c)1996 Armidale Software\n", VERSION);
-	std::println(stderr, " usage: receive_post [-p pseudofile] [[-s] subjfile]");
-	std::println(stderr, " -p pseudofile  Save pseudonym (if any) to indicated file");
-	std::println(stderr, " -s subjfile    Save subject (if any) to indicated file");
-	exit(1);
+    std::println(stderr, "Yapp {} (c)1996 Armidale Software\n", VERSION);
+    std::println(
+        stderr, " usage: receive_post [-p pseudofile] [[-s] subjfile]");
+    std::println(
+        stderr, " -p pseudofile  Save pseudonym (if any) to indicated file");
+    std::println(
+        stderr, " -s subjfile    Save subject (if any) to indicated file");
+    exit(1);
 }
 
 int
 main(int argc, char **argv)
 {
 #ifdef LOG
-	FILE *fp;
+    FILE *fp;
 #endif
-	entry entries[MAX_ENTRIES];
-	int x, m = -1, i;
-	int cl;
-	char *env = getenv("REQUEST_METHOD");
-	char *subjfile = NULL;
-	char *pseudofile = NULL;
-	const char *options = "hvs:p:"; /* Command-line options */
-	extern char *optarg;
-	extern int optind, opterr;
-	while ((i = getopt(argc, argv, options)) != -1) {
-		switch (i) {
-		case 's':
-			subjfile = optarg;
-			break;
-		case 'p':
-			pseudofile = optarg;
-			break;
-		case 'v':
-		case 'h':
-		default:
-			usage();
-		}
-	}
-	argc -= optind;
-	argv += optind;
-	if (argc == 1 && !subjfile) {
-		subjfile = argv[0];
-		argc--;
-		argv++;
-	}
-	if (argc > 0)
-		usage();
+    entry entries[MAX_ENTRIES];
+    int x, m = -1, i;
+    int cl;
+    char *env = getenv("REQUEST_METHOD");
+    char *subjfile = NULL;
+    char *pseudofile = NULL;
+    const char *options = "hvs:p:"; /* Command-line options */
+    extern char *optarg;
+    extern int optind, opterr;
+    while ((i = getopt(argc, argv, options)) != -1) {
+        switch (i) {
+        case 's':
+            subjfile = optarg;
+            break;
+        case 'p':
+            pseudofile = optarg;
+            break;
+        case 'v':
+        case 'h':
+        default:
+            usage();
+        }
+    }
+    argc -= optind;
+    argv += optind;
+    if (argc == 1 && !subjfile) {
+        subjfile = argv[0];
+        argc--;
+        argv++;
+    }
+    if (argc > 0)
+        usage();
 
 #ifdef LOG
-	fp = fopen("/tmp/postlog", "a");
-	if (!fp)
-		exit(1);
-	std::println(fp, "receive_post began");
-	std::println(fp, "method={}", env);
-	fflush(fp);
+    fp = fopen("/tmp/postlog", "a");
+    if (!fp)
+        exit(1);
+    std::println(fp, "receive_post began");
+    std::println(fp, "method={}", env);
+    fflush(fp);
 #endif
 
-	if (!env || !str::eq(env, "POST")) {
-		std::println("This script should be referenced with a METHOD of POST.");
-		std::print("If you don't understand this, see this ");
-		std::println("<A HREF=\"http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/"
-		    "fill-out-forms/overview.html\">forms overview</A>.\n");
-		exit(1);
-	}
+    if (!env || !str::eq(env, "POST")) {
+        std::println("This script should be referenced with a METHOD of POST.");
+        std::print("If you don't understand this, see this ");
+        std::println(
+            "<A HREF=\"http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/"
+            "fill-out-forms/overview.html\">forms overview</A>.\n");
+        exit(1);
+    }
 #ifdef LOG
-	std::println(fp, "got past POST check");
-	fflush(fp);
+    std::println(fp, "got past POST check");
+    fflush(fp);
 #endif
 
-	env = getenv("CONTENT_TYPE");
-	if (!env || !str::eq(env, "application/x-www-form-urlencoded")) {
-		std::println("This script can only be used to decode form results.");
-		exit(1);
-	}
+    env = getenv("CONTENT_TYPE");
+    if (!env || !str::eq(env, "application/x-www-form-urlencoded")) {
+        std::println("This script can only be used to decode form results.");
+        exit(1);
+    }
 #ifdef LOG
-	std::println(fp, "got past content type");
-	fflush(fp);
+    std::println(fp, "got past content type");
+    fflush(fp);
 #endif
 
-	env = getenv("CONTENT_LENGTH");
-	if (!env)
-		cl = 0;
-	else
-		cl = atoi(env);
+    env = getenv("CONTENT_LENGTH");
+    if (!env)
+        cl = 0;
+    else
+        cl = atoi(env);
 
 #ifdef LOG
-	std::println(fp, "length={}", cl);
-	fflush(fp);
+    std::println(fp, "length={}", cl);
+    fflush(fp);
 #endif
 
-	for (x = 0; cl && (!feof(stdin)); x++) {
-		m = x;
-		entries[x].val = fmakeword(stdin, '&', &cl);
-		plustospace(entries[x].val);
-		unescape_url(entries[x].val);
-		entries[x].name = makeword(entries[x].val, '=');
-	}
+    for (x = 0; cl && (!feof(stdin)); x++) {
+        m = x;
+        entries[x].val = fmakeword(stdin, '&', &cl);
+        plustospace(entries[x].val);
+        unescape_url(entries[x].val);
+        entries[x].name = makeword(entries[x].val, '=');
+    }
 
 #ifdef LOG
-	std::println(fp, "lines={}", m);
-	fflush(fp);
+    std::println(fp, "lines={}", m);
+    fflush(fp);
 #endif
 
-	for (x = 0; x <= m; x++) {
-		if (str::eq(entries[x].name, "ticket") ||
-		    str::eq(entries[x].name, "tkt")) {
-			std::print("{}", entries[x].val);
+    for (x = 0; x <= m; x++) {
+        if (str::eq(entries[x].name, "ticket") ||
+            str::eq(entries[x].name, "tkt")) {
+            std::print("{}", entries[x].val);
 #ifdef LOG
-			std::println(fp, "ticket=!{}!", entries[x].val);
-			fflush(fp);
+            std::println(fp, "ticket=!{}!", entries[x].val);
+            fflush(fp);
 #endif
-		} else if (str::eq(entries[x].name, "text")) {
+        } else if (str::eq(entries[x].name, "text")) {
 #ifdef LOG
-			std::println(fp, "text=!{}!", entries[x].val);
-			fflush(fp);
+            std::println(fp, "text=!{}!", entries[x].val);
+            fflush(fp);
 #endif
-			ftextout(stderr, entries[x].val); /* to strip bad
-			                                   * characters */
-			/*std::println(stderr, "{}", entries[x].val);*/
+            ftextout(stderr, entries[x].val); /* to strip bad
+                                               * characters */
+            /*std::println(stderr, "{}", entries[x].val);*/
 #ifdef LOG
-			std::println(fp, "textok", entries[x].val);
-			fflush(fp);
+            std::println(fp, "textok", entries[x].val);
+            fflush(fp);
 #endif
-		} else if (str::eq(entries[x].name, "subj") && subjfile) {
-			FILE *sfp;
+        } else if (str::eq(entries[x].name, "subj") && subjfile) {
+            FILE *sfp;
 #ifdef LOG
-			std::println(fp, "subj=!{}!", entries[x].val);
-			fflush(fp);
+            std::println(fp, "subj=!{}!", entries[x].val);
+            fflush(fp);
 #endif
-			if ((sfp = fopen(subjfile, "w")) != NULL) {
-				std::println(sfp, "{}", entries[x].val);
-				fclose(sfp);
+            if ((sfp = fopen(subjfile, "w")) != NULL) {
+                std::println(sfp, "{}", entries[x].val);
+                fclose(sfp);
 #ifdef LOG
-				std::println(fp, "wrote subject to {}", subjfile);
-				fflush(fp);
+                std::println(fp, "wrote subject to {}", subjfile);
+                fflush(fp);
 #endif
-			} else {
-				std::println("Can't open {}", subjfile);
+            } else {
+                std::println("Can't open {}", subjfile);
 #ifdef LOG
-				std::println(fp, "can't open {}", subjfile);
-				fflush(fp);
+                std::println(fp, "can't open {}", subjfile);
+                fflush(fp);
 #endif
-				exit(1);
-			}
-		} else if (str::eq(entries[x].name, "pseudo") && pseudofile) {
-			FILE *sfp;
-			if ((sfp = fopen(pseudofile, "w")) != NULL) {
-				std::println(sfp, "{}", entries[x].val);
-				fclose(sfp);
-			} else {
-				std::println("Can't open {}", pseudofile);
-				exit(1);
-			}
-		}
+                exit(1);
+            }
+        } else if (str::eq(entries[x].name, "pseudo") && pseudofile) {
+            FILE *sfp;
+            if ((sfp = fopen(pseudofile, "w")) != NULL) {
+                std::println(sfp, "{}", entries[x].val);
+                fclose(sfp);
+            } else {
+                std::println("Can't open {}", pseudofile);
+                exit(1);
+            }
+        }
 #ifdef LOG
-		std::println(fp, "completed {}/{}", x, m);
-		fflush(fp);
+        std::println(fp, "completed {}/{}", x, m);
+        fflush(fp);
 #endif
-	}
+    }
 #ifdef LOG
-	std::println(fp, "exiting normally");
-	fclose(fp);
+    std::println(fp, "exiting normally");
+    fclose(fp);
 #endif
-	exit(0);
+    exit(0);
 }

--- a/rfp.cc
+++ b/rfp.cc
@@ -49,36 +49,36 @@ extern FILE *ext_fp;
 extern int ext_first, ext_last;
 /* Commands available in RFP mode */
 static dispatch_t rfp_cmd[] = {
-    { "edit", modify, },
-    { "cen_sor", censor, },
-    { "scr_ibble", censor, },
-    { "uncen_sor", uncensor, },
-    { "e_nter", enter, },
-    { "pr_eserve", preserve, },
-    { "po_stpone", preserve, },
-    { "hide", preserve, },
-    { "p_ass", preserve, },
-    { "n_ew", preserve, },
-    { "wait", preserve, },
+    {"edit",       modify     },
+    {"cen_sor",    censor     },
+    {"scr_ibble",  censor     },
+    {"uncen_sor",  uncensor   },
+    {"e_nter",     enter      },
+    {"pr_eserve",  preserve   },
+    {"po_stpone",  preserve   },
+    {"hide",       preserve   },
+    {"p_ass",      preserve   },
+    {"n_ew",       preserve   },
+    {"wait",       preserve   },
 #ifdef INCLUDE_EXTRA_COMMANDS
-    { "tree", tree, },
+    {"tree",       tree       },
 #endif
-    { "*freeze", freeze, },
-    { "*thaw", freeze, },
-    { "*forget", freeze, },
-    { "*retire", freeze, },
-    { "*unretire", freeze, },
-    { "r_espond", rfp_respond, },
-    { "ps_eudonym", rfp_respond, },
-    { "*retitle", retitle, },
-    { "*rem_ember", remember, },
-    { "*unfor_get", remember, },
-    { "*kill", do_kill, },
-    { "*f_ind", do_find, },
-    { "*lo_cate", do_find, },
+    {"*freeze",    freeze     },
+    {"*thaw",      freeze     },
+    {"*forget",    freeze     },
+    {"*retire",    freeze     },
+    {"*unretire",  freeze     },
+    {"r_espond",   rfp_respond},
+    {"ps_eudonym", rfp_respond},
+    {"*retitle",   retitle    },
+    {"*rem_ember", remember   },
+    {"*unfor_get", remember   },
+    {"*kill",      do_kill    },
+    {"*f_ind",     do_find    },
+    {"*lo_cate",   do_find    },
     /* "*fix_seen",  fixseen,  this by itself doesn't work */
-    { "reply", reply, },
-    { 0, 0 },
+    {"reply",      reply      },
+    {0,            0          },
 };
 /******************************************************************************/
 /* DISPATCH CONTROL TO APPROPRIATE RFP MODE FUNCTION                          */
@@ -89,271 +89,263 @@ rfp_cmd_dispatch(/* ARGUMENTS:                  */
     char **argv  /* Argument list            */
 )
 {
-	int a, b, c;
-	int i, j;
+    int a, b, c;
+    int i, j;
 
-	std::vector<std::string> args;
-	for (auto i = 0; i < argc; i++)
-		args.push_back(argv[i]);
+    std::vector<std::string> args;
+    for (auto i = 0; i < argc; i++) args.push_back(argv[i]);
 
-	for (i = 0; rfp_cmd[i].name; i++) {
-		if (match(argv[0], rfp_cmd[i].name))
-			return rfp_cmd[i].func(argc, argv);
-		if (rfp_cmd[i].name[0] == '*' &&
-		     match(argv[0], rfp_cmd[i].name + 1)) {
-			mode = M_OK;
-			st_glob.r_first = st_glob.r_last + 1;
-			auto cmd = std::format("{} {}",
-			    compress(rfp_cmd[i].name + 1),
-			    st_glob.i_current);
-			for (j = 1; j < argc; j++) {
-				cmd.append(" ");
-				cmd.append(argv[j]);
-			}
-			return command(cmd, 0);
-		}
-	}
+    for (i = 0; rfp_cmd[i].name; i++) {
+        if (match(argv[0], rfp_cmd[i].name))
+            return rfp_cmd[i].func(argc, argv);
+        if (rfp_cmd[i].name[0] == '*' && match(argv[0], rfp_cmd[i].name + 1)) {
+            mode = M_OK;
+            st_glob.r_first = st_glob.r_last + 1;
+            auto cmd = std::format(
+                "{} {}", compress(rfp_cmd[i].name + 1), st_glob.i_current);
+            for (j = 1; j < argc; j++) {
+                cmd.append(" ");
+                cmd.append(argv[j]);
+            }
+            return command(cmd, 0);
+        }
+    }
 
-	/* Command dispatch */
-	if (match(argv[0], "h_eader")) {
-		show_header();
-	} else if (match(argv[0], "text")) { /* re-read from 0 */
-		st_glob.r_first = 0;
-		st_glob.r_last = MAX_RESPONSES;
-		show_range();
-	} else if (match(argv[0], "a_gain")) { /* re-read same range */
-		sepinit(IS_ITEM);
-		if (flags & O_LABEL)
-			sepinit(IS_ALL);
-		show_header();
-		st_glob.r_first = ext_first;
-		st_glob.r_last = ext_last;
-		if (st_glob.r_first > 0)
-			show_nsep(ext_fp); /* nsep between header
-			                    * and responses */
-		show_range();
-	} else if (match(argv[0], "^") || match(argv[0], "fi_rst")) {
-		st_glob.r_first = 1;
-		st_glob.r_last = MAX_RESPONSES;
-		show_range();
-	} else if (match(argv[0], ".") || match(argv[0], "th_is") ||
-	           match(argv[0], "cu_rrent")) {
-		st_glob.r_first = st_glob.r_current;
-		st_glob.r_last = MAX_RESPONSES;
-		show_range();
-	} else if (match(argv[0], "$") || match(argv[0], "l_ast")) {
-		st_glob.r_first = st_glob.r_max;
-		st_glob.r_last = MAX_RESPONSES;
-		show_range();
-	}
+    /* Command dispatch */
+    if (match(argv[0], "h_eader")) {
+        show_header();
+    } else if (match(argv[0], "text")) { /* re-read from 0 */
+        st_glob.r_first = 0;
+        st_glob.r_last = MAX_RESPONSES;
+        show_range();
+    } else if (match(argv[0], "a_gain")) { /* re-read same range */
+        sepinit(IS_ITEM);
+        if (flags & O_LABEL)
+            sepinit(IS_ALL);
+        show_header();
+        st_glob.r_first = ext_first;
+        st_glob.r_last = ext_last;
+        if (st_glob.r_first > 0)
+            show_nsep(ext_fp); /* nsep between header
+                                * and responses */
+        show_range();
+    } else if (match(argv[0], "^") || match(argv[0], "fi_rst")) {
+        st_glob.r_first = 1;
+        st_glob.r_last = MAX_RESPONSES;
+        show_range();
+    } else if (match(argv[0], ".") || match(argv[0], "th_is") ||
+               match(argv[0], "cu_rrent")) {
+        st_glob.r_first = st_glob.r_current;
+        st_glob.r_last = MAX_RESPONSES;
+        show_range();
+    } else if (match(argv[0], "$") || match(argv[0], "l_ast")) {
+        st_glob.r_first = st_glob.r_max;
+        st_glob.r_last = MAX_RESPONSES;
+        show_range();
+    }
 #ifdef INCLUDE_EXTRA_COMMANDS
-	else if (match(argv[0], "up") || match(argv[0], "par_ent")) {
-		int a;
-		if ((a = parent(st_glob.r_current)) < 0)
-			std::println("No previous response");
-		else {
-			st_glob.r_first = a;
-			st_glob.r_last = a;
-			show_range();
-		}
-	} else if (match(argv[0], "chi_ldren") || match(argv[0], "do_wn")) {
-		int a;
-		/* Find 1st child */
-		if ((a = child(st_glob.r_current)) < 0)
-			std::println("No children");
-		else {
-			st_glob.r_first = a;
-			st_glob.r_last = a;
-			show_range();
-		}
-	} else if (match(argv[0], "sib_ling") || match(argv[0], "ri_ght")) {
-		int a;
-		/* Find  next sibling */
-		if ((a = sibling(st_glob.r_current)) < 0)
-			std::println("No more siblings");
-		else {
-			st_glob.r_first = a;
-			st_glob.r_last = a;
-			show_range();
-		}
-	} else if (match(argv[0], "sync_hronous")) {
-		mode = M_OK; /* KKK */
-	} else if (match(argv[0], "async_hronous")) {
-		mode = M_OK; /* KKK */
-	}
+    else if (match(argv[0], "up") || match(argv[0], "par_ent")) {
+        int a;
+        if ((a = parent(st_glob.r_current)) < 0)
+            std::println("No previous response");
+        else {
+            st_glob.r_first = a;
+            st_glob.r_last = a;
+            show_range();
+        }
+    } else if (match(argv[0], "chi_ldren") || match(argv[0], "do_wn")) {
+        int a;
+        /* Find 1st child */
+        if ((a = child(st_glob.r_current)) < 0)
+            std::println("No children");
+        else {
+            st_glob.r_first = a;
+            st_glob.r_last = a;
+            show_range();
+        }
+    } else if (match(argv[0], "sib_ling") || match(argv[0], "ri_ght")) {
+        int a;
+        /* Find  next sibling */
+        if ((a = sibling(st_glob.r_current)) < 0)
+            std::println("No more siblings");
+        else {
+            st_glob.r_first = a;
+            st_glob.r_last = a;
+            show_range();
+        }
+    } else if (match(argv[0], "sync_hronous")) {
+        mode = M_OK; /* KKK */
+    } else if (match(argv[0], "async_hronous")) {
+        mode = M_OK; /* KKK */
+    }
 #endif
-	else if (match(argv[0], "si_nce")) {
-		size_t i = 0;
-		time_t t = since(args, &i);
-		for (i = st_glob.r_max; i >= 0; i--) {
-			if (!re[i].date)
-				get_resp(ext_fp, &(re[i]), (int)GR_HEADER, i);
-			if (re[i].date < t)
-				break;
-		}
-		st_glob.r_first = i + 1;
-		st_glob.r_last = MAX_RESPONSES;
-		show_range();
-	} else if (match(argv[0], "onl_y")) {
-		if (argc > 2) {
-			std::println("Bad parameters near \"{}\"", argv[2]);
-			return 2;
-		} else if (argc > 1 && sscanf(argv[1], "%d", &a) == 1) {
-			int prev_opt_flags = st_glob.opt_flags;
-			st_glob.r_first = a;
-			st_glob.r_last = a;
-			st_glob.opt_flags |=
-			    OF_NOFORGET; /* force display of hidden resp */
-			show_range();
-			st_glob.opt_flags = prev_opt_flags;
-		} else
-			wputs("You must specify a comment number\n");
-	} else if (argc && sscanf(argv[0], "%d-%d", &a, &b) == 2) {
-		if (b < a) {
-			c = a;
-			a = b;
-			b = c;
-		}
-		if (a < 0) {
-			std::println("Response #{} is too small", a);
-		} else if (b > st_glob.r_max) {
-			std::println("Response #{} is too big (last {})", a,
-			    st_glob.r_max);
-		} else {
-			st_glob.r_first = a;
-			st_glob.r_last = b;
-			show_range();
-		}
-	} else if (argc &&
-	           (sscanf(argv[0], "%d", &a) == 1 || str::eq(argv[0], "-") ||
-	               str::eq(argv[0], "+"))) {
-		if (str::eq(argv[0], "-"))
-			a = -1;
-		if (str::eq(argv[0], "+"))
-			a = 1;
-		if (argv[0][0] == '+' || argv[0][0] == '-')
-			a += st_glob.r_current;
-		if (a < 0) {
-			std::println("Response #{} is too small", a);
-		} else if (a > st_glob.r_max) {
-			std::println("Response #{} is too big (last {})", a,
-			    st_glob.r_max);
-		} else {
-			st_glob.r_first = a;
-			st_glob.r_last = MAX_RESPONSES;
-			show_range();
-		}
-	} else {
-		a = misc_cmd_dispatch(argc, argv);
-		if (!a)
-			preserve(argc, argv);
-		return a;
-	}
+    else if (match(argv[0], "si_nce")) {
+        size_t i = 0;
+        time_t t = since(args, &i);
+        for (i = st_glob.r_max; i >= 0; i--) {
+            if (!re[i].date)
+                get_resp(ext_fp, &(re[i]), (int)GR_HEADER, i);
+            if (re[i].date < t)
+                break;
+        }
+        st_glob.r_first = i + 1;
+        st_glob.r_last = MAX_RESPONSES;
+        show_range();
+    } else if (match(argv[0], "onl_y")) {
+        if (argc > 2) {
+            std::println("Bad parameters near \"{}\"", argv[2]);
+            return 2;
+        } else if (argc > 1 && sscanf(argv[1], "%d", &a) == 1) {
+            int prev_opt_flags = st_glob.opt_flags;
+            st_glob.r_first = a;
+            st_glob.r_last = a;
+            st_glob.opt_flags |= OF_NOFORGET; /* force display of hidden resp */
+            show_range();
+            st_glob.opt_flags = prev_opt_flags;
+        } else
+            wputs("You must specify a comment number\n");
+    } else if (argc && sscanf(argv[0], "%d-%d", &a, &b) == 2) {
+        if (b < a) {
+            c = a;
+            a = b;
+            b = c;
+        }
+        if (a < 0) {
+            std::println("Response #{} is too small", a);
+        } else if (b > st_glob.r_max) {
+            std::println("Response #{} is too big (last {})", a, st_glob.r_max);
+        } else {
+            st_glob.r_first = a;
+            st_glob.r_last = b;
+            show_range();
+        }
+    } else if (argc && (sscanf(argv[0], "%d", &a) == 1 ||
+                           str::eq(argv[0], "-") || str::eq(argv[0], "+"))) {
+        if (str::eq(argv[0], "-"))
+            a = -1;
+        if (str::eq(argv[0], "+"))
+            a = 1;
+        if (argv[0][0] == '+' || argv[0][0] == '-')
+            a += st_glob.r_current;
+        if (a < 0) {
+            std::println("Response #{} is too small", a);
+        } else if (a > st_glob.r_max) {
+            std::println("Response #{} is too big (last {})", a, st_glob.r_max);
+        } else {
+            st_glob.r_first = a;
+            st_glob.r_last = MAX_RESPONSES;
+            show_range();
+        }
+    } else {
+        a = misc_cmd_dispatch(argc, argv);
+        if (!a)
+            preserve(argc, argv);
+        return a;
+    }
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* ADD A NEW RESPONSE                                                         */
 /******************************************************************************/
 void
-add_response(sumentry_t *sumthis, /* New item summary */
+add_response(sumentry_t *sumthis,         /* New item summary */
     const std::vector<std::string> &text, /* New item text    */
     int idx, sumentry_t *sum, partentry_t *part, status_t *stt, long art,
     const std::string_view &mid, int uid, const std::string_view &login,
     const std::string_view &fullname, int resp)
 {
-	int item, line, nr;
-	FILE *fp;
+    int item, line, nr;
+    FILE *fp;
 
-	item = stt->i_current;
-	nr = sum[item - 1].nr;
-	const auto path = std::format("{}/_{}", conflist[idx].location, item);
+    item = stt->i_current;
+    nr = sum[item - 1].nr;
+    const auto path = std::format("{}/_{}", conflist[idx].location, item);
 
-	/* Prevent duplicate responses: */
-	if ((fp = mopen(path, O_R)) != NULL) {
-		int prev, nl_prev, nl_new, dup;
-		prev = sum[item - 1].nr - 1;
-		get_resp(fp, &re[prev], (int)GR_ALL, sum[item - 1].nr - 1);
-		mclose(fp);
-		nl_prev = re[prev].text.size();
-		nl_new = text.size();
-		dup = (nl_prev == nl_new && str::eq(login, re[prev].login));
-		for (line = 0; dup && line < nl_new; line++)
-			dup = str::eq(text[line], re[prev].text[line]);
-		re[prev].text.clear();
-		if (dup) {
-			if (!(flags & O_QUIET))
-				std::println("Duplicate response aborted");
-			return;
-		}
-	}
+    /* Prevent duplicate responses: */
+    if ((fp = mopen(path, O_R)) != NULL) {
+        int prev, nl_prev, nl_new, dup;
+        prev = sum[item - 1].nr - 1;
+        get_resp(fp, &re[prev], (int)GR_ALL, sum[item - 1].nr - 1);
+        mclose(fp);
+        nl_prev = re[prev].text.size();
+        nl_new = text.size();
+        dup = (nl_prev == nl_new && str::eq(login, re[prev].login));
+        for (line = 0; dup && line < nl_new; line++)
+            dup = str::eq(text[line], re[prev].text[line]);
+        re[prev].text.clear();
+        if (dup) {
+            if (!(flags & O_QUIET))
+                std::println("Duplicate response aborted");
+            return;
+        }
+    }
 
-	/* Begin critical section */
-	if ((fp = mopen(path, O_A | O_NOCREATE)) != NULL) {
-		int n;
-		/* was: update before open, in case of a link - why? (was
-		 * wrong) */
-		if (!art)
-			refresh_sum(item, idx, sum, part, stt);
+    /* Begin critical section */
+    if ((fp = mopen(path, O_A | O_NOCREATE)) != NULL) {
+        int n;
+        /* was: update before open, in case of a link - why? (was
+         * wrong) */
+        if (!art)
+            refresh_sum(item, idx, sum, part, stt);
 
-		n = sum[item - 1].nr - nr;
-		if (n > 1) {
-			std::println(
-			    "Warning: {} comments slipped in ahead of yours at {}-{}!",
-			    n, nr, sum[item - 1].nr - 1);
-		} else if (n == 1) {
-			std::println(
-			    "Warning: a comment slipped in ahead of yours at {}!",
-			    sum[item - 1].nr - 1);
-		} else if (!(flags & O_STAY))
-			stt->r_last = -1;
+        n = sum[item - 1].nr - nr;
+        if (n > 1) {
+            std::println(
+                "Warning: {} comments slipped in ahead of yours at {}-{}!", n,
+                nr, sum[item - 1].nr - 1);
+        } else if (n == 1) {
+            std::println("Warning: a comment slipped in ahead of yours at {}!",
+                sum[item - 1].nr - 1);
+        } else if (!(flags & O_STAY))
+            stt->r_last = -1;
 
-		re[sum[item - 1].nr].offset = ftell(fp);
-		std::println(fp, ",R{:04}", RF_NORMAL);
-		std::println(fp, ",U{},{}", uid, login);
-	        std::println(fp, ",A{}", fullname);
-		std::println(fp, ",D{:08X}", (art) ? sumthis->last : time((time_t *)0));
-		if (resp)
-			std::println(fp, ",P{}", resp - 1);
-		std::println(fp, ",T");
-		re[sum[item - 1].nr].parent = resp;
-		re[sum[item - 1].nr].textoff = ftell(fp);
-		re[sum[item - 1].nr].numchars = -1;
-		if (art) {
-			std::println(fp, ",N{:06}", art);
-			std::println(fp, ",M{}", mid);
-		} else {
-			for (const auto &line: text) {
-				if (line[0] == ',')
-					std::print(fp, ",,");
-				std::println(fp, "{}", line);
-			}
-		}
-		std::println(fp, ",E{}",
-		    spaces(str::toi(get_conf_param("padding", PADDING))));
-		if (!ferror(fp)) {
-			/* Update seen */
-			stt->r_current = stt->r_max = sum[item - 1].nr;
-			/* if (!(flags & O_METOO) &&
-			 * stt->r_lastseen==sum[item-1].nr)  */
-			time(&(part[item - 1].last));
-			if (!(flags & O_METOO)) {
-				part[item - 1].nr = sum[item - 1].nr;
-				stt->r_lastseen = stt->r_current + 1;
-			}
-			dirty_part(item - 1);
+        re[sum[item - 1].nr].offset = ftell(fp);
+        std::println(fp, ",R{:04}", RF_NORMAL);
+        std::println(fp, ",U{},{}", uid, login);
+        std::println(fp, ",A{}", fullname);
+        std::println(fp, ",D{:08X}", (art) ? sumthis->last : time((time_t *)0));
+        if (resp)
+            std::println(fp, ",P{}", resp - 1);
+        std::println(fp, ",T");
+        re[sum[item - 1].nr].parent = resp;
+        re[sum[item - 1].nr].textoff = ftell(fp);
+        re[sum[item - 1].nr].numchars = -1;
+        if (art) {
+            std::println(fp, ",N{:06}", art);
+            std::println(fp, ",M{}", mid);
+        } else {
+            for (const auto &line : text) {
+                if (line[0] == ',')
+                    std::print(fp, ",,");
+                std::println(fp, "{}", line);
+            }
+        }
+        std::println(
+            fp, ",E{}", spaces(str::toi(get_conf_param("padding", PADDING))));
+        if (!ferror(fp)) {
+            /* Update seen */
+            stt->r_current = stt->r_max = sum[item - 1].nr;
+            /* if (!(flags & O_METOO) &&
+             * stt->r_lastseen==sum[item-1].nr)  */
+            time(&(part[item - 1].last));
+            if (!(flags & O_METOO)) {
+                part[item - 1].nr = sum[item - 1].nr;
+                stt->r_lastseen = stt->r_current + 1;
+            }
+            dirty_part(item - 1);
 
-			sum[item - 1].last = time((time_t *)0);
-			sum[item - 1].nr++;
-			save_sum(sum, (int)(item - 1), idx, stt);
-			dirty_sum(item - 1);
+            sum[item - 1].last = time((time_t *)0);
+            sum[item - 1].nr++;
+            save_sum(sum, (int)(item - 1), idx, stt);
+            dirty_sum(item - 1);
 
-			skip_new_response(confidx, item - 1, sum[item - 1].nr);
-		} else
-			error("writing response", "");
-		mclose(fp);
-	}
-	/* End critical section */
+            skip_new_response(confidx, item - 1, sum[item - 1].nr);
+        } else
+            error("writing response", "");
+        mclose(fp);
+    }
+    /* End critical section */
 }
 /******************************************************************************/
 /* ENTER A RESPONSE INTO THE CURRENT ITEM                                     */
@@ -364,134 +356,132 @@ do_respond(  /* ARGUMENTS:                      */
     int resp /* Response to prev. response # */
 )
 {
-	int nr;
-	unsigned char omode;
-	FILE *fp;
+    int nr;
+    unsigned char omode;
+    FILE *fp;
 
-	if (!check_acl(RESPOND_RIGHT, confidx)) {
-		std::println("You only have read access.");
-		return;
-	}
-	if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
-		wputs(std::format("{} is frozen!\n", Topic()));
-		return;
-	}
-	nr = sum[st_glob.i_current - 1].nr;
-	if (resp > nr) {
-		std::println("Highest response # is {}", nr - 1);
-		return;
-	}
+    if (!check_acl(RESPOND_RIGHT, confidx)) {
+        std::println("You only have read access.");
+        return;
+    }
+    if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
+        wputs(std::format("{} is frozen!\n", Topic()));
+        return;
+    }
+    nr = sum[st_glob.i_current - 1].nr;
+    if (resp > nr) {
+        std::println("Highest response # is {}", nr - 1);
+        return;
+    }
 
-	/* Get pseudo */
-	std::string pseudo;
-	if (ps) {
-		if (!(flags & O_QUIET)) {
-			std::print("What's your handle? ");
-			std::fflush(stdout);
-		}
-		std::string buff;
-		if (!ngets(buff, st_glob.inp)) /* st_glob.inp */
-			return;
-		if (buff[0] == '%') {
-			const char *f, *str;
-			str = buff.c_str() + 1;
-			f = get_sep(&str);
-			buff = f;
-		}
-		if (!buff.empty())
-			pseudo = buff;
-		else {
-			wputs(std::format("Resonse aborted!  Returning to current {}.\n", topic()));
-			return;
-		}
-	} else
-		pseudo = fullname_in_conference(&st_glob);
+    /* Get pseudo */
+    std::string pseudo;
+    if (ps) {
+        if (!(flags & O_QUIET)) {
+            std::print("What's your handle? ");
+            std::fflush(stdout);
+        }
+        std::string buff;
+        if (!ngets(buff, st_glob.inp)) /* st_glob.inp */
+            return;
+        if (buff[0] == '%') {
+            const char *f, *str;
+            str = buff.c_str() + 1;
+            f = get_sep(&str);
+            buff = f;
+        }
+        if (!buff.empty())
+            pseudo = buff;
+        else {
+            wputs(std::format(
+                "Resonse aborted!  Returning to current {}.\n", topic()));
+            return;
+        }
+    } else
+        pseudo = fullname_in_conference(&st_glob);
 
-	if (nr >= MAX_RESPONSES) {
-		wputs(std::format("Too many resposnes on this {}!\n", topic()));
-		return;
-	}
+    if (nr >= MAX_RESPONSES) {
+        wputs(std::format("Too many resposnes on this {}!\n", topic()));
+        return;
+    }
 #ifdef NEWS
-	if (st_glob.c_security & CT_NEWS) {
-		if (!resp)
-			resp = nr;
+    if (st_glob.c_security & CT_NEWS) {
+        if (!resp)
+            resp = nr;
 
-		if (resp > 0) {
-			const auto config = get_config(confidx);
-			if (config.size() <= CF_NEWSGROUP)
-				return;
-			const auto path = std::format("{}/{}/{}",
-			    get_conf_param("newsdir", NEWSDIR),
-			    dot2slash(config[CF_NEWSGROUP]),
-			    st_glob.i_current);
-			fp = mopen(path, O_R);
-			if (fp == NULL)
-				return;
-			get_resp(fp, &(re[resp - 1]), GR_ALL, resp - 1);
-			mclose(fp);
-		}
-		make_rnhead(re, resp);
-		if (resp > 0)
-			re[resp - 1].text.clear();
-		const auto rnh = str::concat({home, "/.rnhead"});
-		unix_cmd(std::format("Pnews -h {}", rnh));
-		rm(rnh, SL_USER);
-		return;
-	}
+        if (resp > 0) {
+            const auto config = get_config(confidx);
+            if (config.size() <= CF_NEWSGROUP)
+                return;
+            const auto path =
+                std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+                    dot2slash(config[CF_NEWSGROUP]), st_glob.i_current);
+            fp = mopen(path, O_R);
+            if (fp == NULL)
+                return;
+            get_resp(fp, &(re[resp - 1]), GR_ALL, resp - 1);
+            mclose(fp);
+        }
+        make_rnhead(re, resp);
+        if (resp > 0)
+            re[resp - 1].text.clear();
+        const auto rnh = str::concat({home, "/.rnhead"});
+        unix_cmd(std::format("Pnews -h {}", rnh));
+        rm(rnh, SL_USER);
+        return;
+    }
 #endif
 
-	if (st_glob.c_security & CT_EMAIL) {
-		/* Load parent for inclusion */
-		if (resp > 0) {
-			const auto path = std::format("{}/_{}",
-			    conflist[confidx].location,
-			    st_glob.i_current);
-			if ((fp = mopen(path, O_R)) == NULL)
-				return;
-			get_resp(fp, &(re[resp - 1]), GR_ALL, resp - 1);
-			mclose(fp);
-		}
-		make_emhead(re, resp);
-		if (resp > 0)
-			re[resp - 1].text.clear();
-	}
+    if (st_glob.c_security & CT_EMAIL) {
+        /* Load parent for inclusion */
+        if (resp > 0) {
+            const auto path = std::format(
+                "{}/_{}", conflist[confidx].location, st_glob.i_current);
+            if ((fp = mopen(path, O_R)) == NULL)
+                return;
+            get_resp(fp, &(re[resp - 1]), GR_ALL, resp - 1);
+            mclose(fp);
+        }
+        make_emhead(re, resp);
+        if (resp > 0)
+            re[resp - 1].text.clear();
+    }
 
-	/* Delete old if not EMAIL */
-	if (text_loop(!(st_glob.c_security & CT_EMAIL), "response") &&
-	    get_yes("Ok to enter this response? ", false)) { /* success */
-		omode = mode;
-		mode = M_OK;
+    /* Delete old if not EMAIL */
+    if (text_loop(!(st_glob.c_security & CT_EMAIL), "response") &&
+        get_yes("Ok to enter this response? ", false)) { /* success */
+        omode = mode;
+        mode = M_OK;
 
-		std::vector<std::string> file;
-		if (st_glob.c_security & CT_EMAIL) {
-			make_emtail();
-			const auto cmd = std::format("{} -t < {}/cf.buffer",
-			    get_conf_param("sendmail", SENDMAIL), work);
-			unix_cmd(cmd);
+        std::vector<std::string> file;
+        if (st_glob.c_security & CT_EMAIL) {
+            make_emtail();
+            const auto cmd = std::format("{} -t < {}/cf.buffer",
+                get_conf_param("sendmail", SENDMAIL), work);
+            unix_cmd(cmd);
 
-		} else if ((file = grab_file(work, "cf.buffer", 0)), file.empty())
-			wputs("The file cf.buffer doesn't seem to exist.\n");
-		else {
-			if (file.empty()) {
-				wputs("No text in buffer!\n");
-			} else {
-				add_response(&(sum[st_glob.i_current - 1]),
-				    file, confidx, sum,
-				    part, &st_glob, 0, "",
-				    uid, login, pseudo, resp);
-				custom_log("respond", M_RFP);
-			}
-		}
+        } else if ((file = grab_file(work, "cf.buffer", 0)), file.empty())
+            wputs("The file cf.buffer doesn't seem to exist.\n");
+        else {
+            if (file.empty()) {
+                wputs("No text in buffer!\n");
+            } else {
+                add_response(&(sum[st_glob.i_current - 1]), file, confidx, sum,
+                    part, &st_glob, 0, "", uid, login, pseudo, resp);
+                custom_log("respond", M_RFP);
+            }
+        }
 
-		if (flags & O_STAY)
-			mode = omode;
-	} else {
-		wputs(std::format("Response aborted!  Returning to current {}.\n", topic()));
-	}
+        if (flags & O_STAY)
+            mode = omode;
+    } else {
+        wputs(std::format(
+            "Response aborted!  Returning to current {}.\n", topic()));
+    }
 
-	/* Delete text buffer */
-	const auto cfbuffer = str::concat({work, "/cf.buffer"});
-	rm(cfbuffer, SL_USER);
+    /* Delete text buffer */
+    const auto cfbuffer = str::concat({work, "/cf.buffer"});
+    rm(cfbuffer, SL_USER);
 }
 /******************************************************************************/
 /* ADD A RESPONSE TO THE CURRENT ITEM                                         */
@@ -502,38 +492,37 @@ respond(        /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	char act[MAX_ITEMS];
-	short j, fl;
+    char act[MAX_ITEMS];
+    short j, fl;
 
-	if (!check_acl(RESPOND_RIGHT, confidx)) {
-		std::println("You only have read access.");
-		return 1;
-	}
-	rangeinit(&st_glob, act);
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	st_glob.r_first = -1;
+    if (!check_acl(RESPOND_RIGHT, confidx)) {
+        std::println("You only have read access.");
+        return 1;
+    }
+    rangeinit(&st_glob, act);
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    st_glob.r_first = -1;
 
-	fl = 0;
-	if (argc < 2) {
-		std::println("Error, no {} specified! (try HELP RANGE)", topic(false));
-	} else { /* Process args */
-		range(argc, argv, &fl, act, sum, &st_glob, 0);
-	}
+    fl = 0;
+    if (argc < 2) {
+        std::println("Error, no {} specified! (try HELP RANGE)", topic(false));
+    } else { /* Process args */
+        range(argc, argv, &fl, act, sum, &st_glob, 0);
+    }
 
-	/* Process items */
-	for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT);
-	     j++) {
-		if (!act[j - 1] || !sum[j - 1].flags)
-			continue;
-		st_glob.i_current = j;
-		if (!(flags & O_QUIET))
-			show_header();
-		if (status & S_PAGER)
-			spclose(st_glob.outp);
-		do_respond(argc > 0 && match(argv[0], "ps_eudonym"),
-		    st_glob.r_first + 1);
-	}
-	return 1;
+    /* Process items */
+    for (j = st_glob.i_first; j <= st_glob.i_last && !(status & S_INT); j++) {
+        if (!act[j - 1] || !sum[j - 1].flags)
+            continue;
+        st_glob.i_current = j;
+        if (!(flags & O_QUIET))
+            show_header();
+        if (status & S_PAGER)
+            spclose(st_glob.outp);
+        do_respond(
+            argc > 0 && match(argv[0], "ps_eudonym"), st_glob.r_first + 1);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* ENTER A RESPONSE IN THE CURRENT ITEM                                       */
@@ -544,32 +533,30 @@ rfp_respond(    /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	int a = -1;
-	if (argc > 2 ||
-	    (argc > 1 && (sscanf(argv[1], "%d", &a) < 1 || a < 0))) {
-		std::println("Bad parameters near \"{}\"", argv[(argc > 2) ? 2 : 1]);
-		return 2;
-	} else
-		do_respond(
-		    argc > 0 && match(argv[0], "ps_eudonym"), (int)a + 1);
+    int a = -1;
+    if (argc > 2 || (argc > 1 && (sscanf(argv[1], "%d", &a) < 1 || a < 0))) {
+        std::println("Bad parameters near \"{}\"", argv[(argc > 2) ? 2 : 1]);
+        return 2;
+    } else
+        do_respond(argc > 0 && match(argv[0], "ps_eudonym"), (int)a + 1);
 
-	return 1;
+    return 1;
 }
 
 void
 dump_reply(const char *sep)
 {
-	sepinit(IS_START);
-	itemsep(expand(sep, DM_VAR), 0);
-	for (st_glob.l_current = 0;
-	     static_cast<size_t>(st_glob.l_current) < re[st_glob.r_current].text.size() &&
-	     !(status & S_INT);
-	     st_glob.l_current++) {
-		sepinit(IS_ITEM);
-		itemsep(expand(sep, DM_VAR), 0);
-	}
-	sepinit(IS_CFIDX);
-	itemsep(expand(sep, DM_VAR), 0);
+    sepinit(IS_START);
+    itemsep(expand(sep, DM_VAR), 0);
+    for (st_glob.l_current = 0; static_cast<size_t>(st_glob.l_current) <
+                                    re[st_glob.r_current].text.size() &&
+                                !(status & S_INT);
+        st_glob.l_current++) {
+        sepinit(IS_ITEM);
+        itemsep(expand(sep, DM_VAR), 0);
+    }
+    sepinit(IS_CFIDX);
+    itemsep(expand(sep, DM_VAR), 0);
 }
 /******************************************************************************/
 /* MAIL A REPLY TO THE AUTHOR OF A RESPONSE                                   */
@@ -580,102 +567,98 @@ reply(          /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	int i;
-	flag_t ss;
-	int cpid, wpid;
-	int statusp;
+    int i;
+    flag_t ss;
+    int cpid, wpid;
+    int statusp;
 
-	/* Validate arguments */
-	if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
-		std::println("You must specify a comment number.");
-		return 1;
-	} else if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
-	if (re[i].flags & RF_CENSORED) {
-		wputs("Cannot reply to censored response!\n");
-		return 1;
-	}
-	if (re[i].offset < 0) {
-		std::println("Offset error."); /* should never happen */
-		return 1;
-	}
+    /* Validate arguments */
+    if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
+        std::println("You must specify a comment number.");
+        return 1;
+    } else if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
+    if (re[i].flags & RF_CENSORED) {
+        wputs("Cannot reply to censored response!\n");
+        return 1;
+    }
+    if (re[i].offset < 0) {
+        std::println("Offset error."); /* should never happen */
+        return 1;
+    }
 
-	/* Get complete text */
-	std::string path;
+    /* Get complete text */
+    std::string path;
 #ifdef NEWS
-	if (st_glob.c_security & CT_NEWS) {
-		const auto config = get_config(confidx);
-		if (config.size() <= CF_NEWSGROUP)
-			return 1;
-		path = std::format("{}/{}/{}",
-		    get_conf_param("newsdir", NEWSDIR),
-		    dot2slash(config[CF_NEWSGROUP]),
-		    st_glob.i_current);
-	} else
+    if (st_glob.c_security & CT_NEWS) {
+        const auto config = get_config(confidx);
+        if (config.size() <= CF_NEWSGROUP)
+            return 1;
+        path = std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+            dot2slash(config[CF_NEWSGROUP]), st_glob.i_current);
+    } else
 #endif
-		path = std::format("{}/_{}",
-		    conflist[confidx].location,
-		    st_glob.i_current);
-	FILE *fp = mopen(path, O_R);
-	if (fp == NULL)
-		return 1;
-	get_resp(fp, &(re[i]), GR_ALL, i);
-	mclose(fp);
+        path = std::format(
+            "{}/_{}", conflist[confidx].location, st_glob.i_current);
+    FILE *fp = mopen(path, O_R);
+    if (fp == NULL)
+        return 1;
+    get_resp(fp, &(re[i]), GR_ALL, i);
+    mclose(fp);
 
-	/* Fork & setuid down when creating cf.buffer */
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    /* Fork & setuid down when creating cf.buffer */
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		while ((wpid = wait(&statusp)) != cpid && wpid != -1)
-			;
-		/* post = !statusp; */
-	} else { /* child */
-		if (setuid(getuid()))
-			error("setuid", "");
-		setgid(getgid());
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return -1; /* error: couldn't fork */
+        while ((wpid = wait(&statusp)) != cpid && wpid != -1);
+        /* post = !statusp; */
+    } else { /* child */
+        if (setuid(getuid()))
+            error("setuid", "");
+        setgid(getgid());
 
-		/* Save to cf.buffer */
-		const auto path = str::concat({work, "/cf.buffer"});
-		FILE *fp = mopen(path, O_W);
-		if (fp == NULL) {
-			re[i].text.clear();
-			return 1;
-		}
-		FILE *pp = st_glob.outp;
-		ss = status;
-		st_glob.r_current = i;
-		st_glob.outp = fp;
-		status |= S_PAGER;
+        /* Save to cf.buffer */
+        const auto path = str::concat({work, "/cf.buffer"});
+        FILE *fp = mopen(path, O_W);
+        if (fp == NULL) {
+            re[i].text.clear();
+            return 1;
+        }
+        FILE *pp = st_glob.outp;
+        ss = status;
+        st_glob.r_current = i;
+        st_glob.outp = fp;
+        status |= S_PAGER;
 
-		dump_reply("replysep");
+        dump_reply("replysep");
 
-		st_glob.outp = pp;
-		status = ss;
+        st_glob.outp = pp;
+        status = ss;
 
-		dump_reply("replysep");
+        dump_reply("replysep");
 
-		mclose(fp);
-		exit(0);
-	}
+        mclose(fp);
+        exit(0);
+    }
 
-	/* Invoke mailer */
-	const auto cmd = std::format("mail {}", re[i].login);
-	command(cmd.c_str(), 0);
-	re[i].text.clear();
-	mode = M_RFP;
-	return 1;
+    /* Invoke mailer */
+    const auto cmd = std::format("mail {}", re[i].login);
+    command(cmd.c_str(), 0);
+    re[i].text.clear();
+    mode = M_RFP;
+    return 1;
 }
 /******************************************************************************/
 /* CENSOR A RESPONSE IN THE CURRENT ITEM                                      */
@@ -685,132 +668,125 @@ reply(          /* ARGUMENTS:                  */
 /* Number of arguments */
 /* Argument list       */
 int
-censor(
-    int argc,
-    char **argv
-)
+censor(int argc, char **argv)
 {
-	int i, typ, j, k;
-	FILE *fp;
-	int len;
-	int frozen = 0; /* 1 if we need to unfreeze,censor,freeze */
-	struct stat stt;
-	typ = (match(argv[0], "scr_ibble")) ? RF_CENSORED | RF_SCRIBBLED
-	                                    : RF_CENSORED;
+    int i, typ, j, k;
+    FILE *fp;
+    int len;
+    int frozen = 0; /* 1 if we need to unfreeze,censor,freeze */
+    struct stat stt;
+    typ = (match(argv[0], "scr_ibble")) ? RF_CENSORED | RF_SCRIBBLED
+                                        : RF_CENSORED;
 
-	/* Validate arguments */
-	if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
-		std::println("You must specify a comment number.");
-		return 1;
-	} else if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
+    /* Validate arguments */
+    if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
+        std::println("You must specify a comment number.");
+        return 1;
+    } else if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
 
-	/* Check for permission to censor */
-	if (!re[i].date)
-		get_resp(ext_fp, &(re[i]), GR_HEADER, i);
-	if (!(st_glob.c_status & CS_FW) &&
-	    (uid != re[i].uid ||
-	        (uid == get_nobody_uid() && !str::eq(login, re[i].login)))) {
-		std::println("You don't have permission to affect response {}.", i);
-		return 1;
-	}
-	if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
-		if (!match(get_conf_param("censorfrozen", CENSOR_FROZEN), "true")) {
-			wputs(std::format("Cannot censor frozen {}s!\n", topic()));
-			return 1;
-		} else
-			frozen = 1;
-	}
-	if ((re[i].flags & typ) == typ)
-		return 1; /* already done */
-	if (re[i].offset < 0) {
-		std::println("Offset error."); /* should never happen */
-		return 1;
-	}
-	if (typ & RF_SCRIBBLED &&
-	    !get_yes(expand("scribok", DM_VAR), false))
-		return 1;
+    /* Check for permission to censor */
+    if (!re[i].date)
+        get_resp(ext_fp, &(re[i]), GR_HEADER, i);
+    if (!(st_glob.c_status & CS_FW) &&
+        (uid != re[i].uid ||
+            (uid == get_nobody_uid() && !str::eq(login, re[i].login)))) {
+        std::println("You don't have permission to affect response {}.", i);
+        return 1;
+    }
+    if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
+        if (!match(get_conf_param("censorfrozen", CENSOR_FROZEN), "true")) {
+            wputs(std::format("Cannot censor frozen {}s!\n", topic()));
+            return 1;
+        } else
+            frozen = 1;
+    }
+    if ((re[i].flags & typ) == typ)
+        return 1; /* already done */
+    if (re[i].offset < 0) {
+        std::println("Offset error."); /* should never happen */
+        return 1;
+    }
+    if (typ & RF_SCRIBBLED && !get_yes(expand("scribok", DM_VAR), false))
+        return 1;
 
-	const auto path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	if (frozen) {
-		stat(path.c_str(), &stt);
-		chmod(path.c_str(), stt.st_mode | S_IWUSR);
-	}
-	if ((fp = mopen(path, O_RPLUS)) != NULL) {
-		if (frozen)
-			chmod(path.c_str(), stt.st_mode & ~S_IWUSR);
-		if (fseek(fp, re[i].offset, 0))
-			error("fseeking in ", path);
-		std::println(fp, ",R{:04}", typ);
+    const auto path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    if (frozen) {
+        stat(path.c_str(), &stt);
+        chmod(path.c_str(), stt.st_mode | S_IWUSR);
+    }
+    if ((fp = mopen(path, O_RPLUS)) != NULL) {
+        if (frozen)
+            chmod(path.c_str(), stt.st_mode & ~S_IWUSR);
+        if (fseek(fp, re[i].offset, 0))
+            error("fseeking in ", path);
+        std::println(fp, ",R{:04}", typ);
 
-		/* log it and overwrite it, unless it's a news article */
+        /* log it and overwrite it, unless it's a news article */
 #ifdef NEWS
-		if (!re[i].article) {
+        if (!re[i].article) {
 #endif
-			get_resp(fp, &(re[i]), GR_ALL, i);
-			fseek(fp, re[i].textoff, 0);
-			if (typ & RF_SCRIBBLED) {
-				const auto over = std::format("{} {} {} ",
-				    login,
-				    get_date(time((time_t *)0), 0),
-				    fullname_in_conference(&st_glob));
-				len = over.size();
-				/* was j=re[i].numchars below */
-				for (j = (re[i].endoff - 3) - re[i].textoff;
-				     j > 76; j -= 76) {
-					for (k = 0; k < 75; k++)
-						std::print(fp, "{:c}", over[k % len]);
-					std::println(fp, "");
-				}
-				for (k = 0; k < j - 1; k++)
-					fputc(over[k % len], fp);
-				std::println(fp, "");
-				std::println(fp, ",E");
-			}
+            get_resp(fp, &(re[i]), GR_ALL, i);
+            fseek(fp, re[i].textoff, 0);
+            if (typ & RF_SCRIBBLED) {
+                const auto over = std::format("{} {} {} ", login,
+                    get_date(time((time_t *)0), 0),
+                    fullname_in_conference(&st_glob));
+                len = over.size();
+                /* was j=re[i].numchars below */
+                for (j = (re[i].endoff - 3) - re[i].textoff; j > 76; j -= 76) {
+                    for (k = 0; k < 75; k++)
+                        std::print(fp, "{:c}", over[k % len]);
+                    std::println(fp, "");
+                }
+                for (k = 0; k < j - 1; k++) fputc(over[k % len], fp);
+                std::println(fp, "");
+                std::println(fp, ",E");
+            }
 #ifdef NEWS
-		}
+        }
 #endif
-		mclose(fp);
+        mclose(fp);
 
-		/* Added 4/18, since sum file wasn't being updated, causing
-		 * set sensitive to fail. */
-		sum[st_glob.i_current - 1].last = time((time_t *)0);
-		save_sum(sum, (int)(st_glob.i_current - 1), confidx, &st_glob);
-		dirty_sum(st_glob.i_current - 1);
-	} else if (frozen)
-		chmod(path.c_str(), stt.st_mode & ~S_IWUSR);
+        /* Added 4/18, since sum file wasn't being updated, causing
+         * set sensitive to fail. */
+        sum[st_glob.i_current - 1].last = time((time_t *)0);
+        save_sum(sum, (int)(st_glob.i_current - 1), confidx, &st_glob);
+        dirty_sum(st_glob.i_current - 1);
+    } else if (frozen)
+        chmod(path.c_str(), stt.st_mode & ~S_IWUSR);
 
-	/* free_sum(sum); unneeded, always SF_FAST */
+    /* free_sum(sum); unneeded, always SF_FAST */
 
-	/* Write to censorlog */
-	const auto censored = str::concat({bbsdir, "/censored"});
-	if ((fp = mopen(censored, O_A | O_PRIVATE)) != NULL) {
-		std::println(fp, ",C {} {} {} resp {} rflg {} {},{} {} date {}",
-		    conflist[confidx].location, topic(), st_glob.i_current, i,
-		    typ, login, uid, get_date(time((time_t *)0), 0),
-		    fullname_in_conference(&st_glob));
-		std::println(fp, ",R{:04X}", re[i].flags);
-		std::println(fp, ",U{},{}", re[i].uid, re[i].login);
-		std::println(fp, ",A{}", re[i].fullname);
-		std::println(fp, ",D{:08X}", re[i].date);
-		std::println(fp, ",T");
-		for (const auto &line: re[i].text)
-			std::println(fp, "{}", line);
-		std::println(fp, ",E");
-		mclose(fp);
-	}
-	re[i].text.clear();
-	re[i].flags = typ;
+    /* Write to censorlog */
+    const auto censored = str::concat({bbsdir, "/censored"});
+    if ((fp = mopen(censored, O_A | O_PRIVATE)) != NULL) {
+        std::println(fp, ",C {} {} {} resp {} rflg {} {},{} {} date {}",
+            conflist[confidx].location, topic(), st_glob.i_current, i, typ,
+            login, uid, get_date(time((time_t *)0), 0),
+            fullname_in_conference(&st_glob));
+        std::println(fp, ",R{:04X}", re[i].flags);
+        std::println(fp, ",U{},{}", re[i].uid, re[i].login);
+        std::println(fp, ",A{}", re[i].fullname);
+        std::println(fp, ",D{:08X}", re[i].date);
+        std::println(fp, ",T");
+        for (const auto &line : re[i].text) std::println(fp, "{}", line);
+        std::println(fp, ",E");
+        mclose(fp);
+    }
+    re[i].text.clear();
+    re[i].flags = typ;
 
-	custom_log((typ == RF_CENSORED) ? "censor" : "scribble", M_RFP);
-	return 1;
+    custom_log((typ == RF_CENSORED) ? "censor" : "scribble", M_RFP);
+    return 1;
 }
 /******************************************************************************/
 /* UN-CENSOR A RESPONSE IN THE CURRENT ITEM                                   */
@@ -821,61 +797,62 @@ uncensor(       /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	int i;
-	FILE *fp;
+    int i;
+    FILE *fp;
 
-	/* Validate arguments */
-	if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
-		std::println("You must specify a comment number.");
-		return 1;
-	} else if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
+    /* Validate arguments */
+    if (argc < 2 || sscanf(argv[1], "%d", &i) < 1) {
+        std::println("You must specify a comment number.");
+        return 1;
+    } else if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
 
-	/* Check for permission to uncensor */
-	if (!re[i].date)
-		get_resp(ext_fp, &(re[i]), GR_HEADER, i);
-	if (!(st_glob.c_status & CS_FW) &&
-	    (uid != re[i].uid ||
-	        (uid == get_nobody_uid() && !str::eq(login, re[i].login)))) {
-		std::println("You don't have permission to affect response {}.", i);
-		return 1;
-	}
-	if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
-		wputs(std::format("Cannot uncensor frozen {}s!\n", topic()));
-		return 1;
-	}
-	if (!(re[i].flags & (RF_CENSORED | RF_SCRIBBLED)))
-		return 1; /* already done */
-	if (re[i].offset < 0) {
-		std::println("Offset error."); /* should never happen */
-		return 1;
-	}
-	const auto path = std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
-	if ((fp = mopen(path, O_RPLUS)) != NULL) {
-		if (fseek(fp, re[i].offset, 0))
-			error("fseeking in ", path);
-		std::println(fp, ",R{:04}", RF_NORMAL);
+    /* Check for permission to uncensor */
+    if (!re[i].date)
+        get_resp(ext_fp, &(re[i]), GR_HEADER, i);
+    if (!(st_glob.c_status & CS_FW) &&
+        (uid != re[i].uid ||
+            (uid == get_nobody_uid() && !str::eq(login, re[i].login)))) {
+        std::println("You don't have permission to affect response {}.", i);
+        return 1;
+    }
+    if (sum[st_glob.i_current - 1].flags & IF_FROZEN) {
+        wputs(std::format("Cannot uncensor frozen {}s!\n", topic()));
+        return 1;
+    }
+    if (!(re[i].flags & (RF_CENSORED | RF_SCRIBBLED)))
+        return 1; /* already done */
+    if (re[i].offset < 0) {
+        std::println("Offset error."); /* should never happen */
+        return 1;
+    }
+    const auto path =
+        std::format("{}/_{}", conflist[confidx].location, st_glob.i_current);
+    if ((fp = mopen(path, O_RPLUS)) != NULL) {
+        if (fseek(fp, re[i].offset, 0))
+            error("fseeking in ", path);
+        std::println(fp, ",R{:04}", RF_NORMAL);
 
-		mclose(fp);
+        mclose(fp);
 
-		/* Added 4/18, since sum file wasn't being updated, causing
-		 * set sensitive to fail. */
-		sum[st_glob.i_current - 1].last = time((time_t *)0);
-		save_sum(sum, st_glob.i_current - 1, confidx, &st_glob);
-		dirty_sum(st_glob.i_current - 1);
-	}
-	re[i].flags = RF_NORMAL;
+        /* Added 4/18, since sum file wasn't being updated, causing
+         * set sensitive to fail. */
+        sum[st_glob.i_current - 1].last = time((time_t *)0);
+        save_sum(sum, st_glob.i_current - 1, confidx, &st_glob);
+        dirty_sum(st_glob.i_current - 1);
+    }
+    re[i].flags = RF_NORMAL;
 
-	/* free_sum(sum); unneeded, always SF_FAST */
+    /* free_sum(sum); unneeded, always SF_FAST */
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* PRESERVE RESPONSES IN THE CURRENT ITEM                                     */
@@ -886,60 +863,60 @@ preserve(       /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	int i;
-	int i_i;
+    int i;
+    int i_i;
 
-	if (match(argv[0], "pr_eserve") || match(argv[0], "po_stpone") ||
-	    match(argv[0], "n_ew") || match(argv[0], "wait")) {
-		if (!(flags & O_QUIET)) {
-			wputs(std::format("This {} will still be new.\n", topic()));
-		}
-		st_glob.r_last = -2;
-	} else
-		st_glob.r_last = -1; /* re-read nothing */
+    if (match(argv[0], "pr_eserve") || match(argv[0], "po_stpone") ||
+        match(argv[0], "n_ew") || match(argv[0], "wait")) {
+        if (!(flags & O_QUIET)) {
+            wputs(std::format("This {} will still be new.\n", topic()));
+        }
+        st_glob.r_last = -2;
+    } else
+        st_glob.r_last = -1; /* re-read nothing */
 
-	/* Lots of ways to stop, so check inverse */
-	i_i = st_glob.i_current - 1;
-	if (!match(argv[0], "pr_eserve") && !match(argv[0], "po_stpone") &&
-	    !match(argv[0], "p_ass") && !match(argv[0], "hide")) {
-		if (st_glob.opt_flags & OF_REVERSE)
-			st_glob.i_current = st_glob.i_first;
-		else
-			st_glob.i_current = st_glob.i_last;
-		if (!(flags & O_QUIET))
-			wputs("Stopping.\n");
-		status |= S_STOP;
-	}
-	if (argc < 2) {
-		mode = M_OK;
-		return 1;
-	}
+    /* Lots of ways to stop, so check inverse */
+    i_i = st_glob.i_current - 1;
+    if (!match(argv[0], "pr_eserve") && !match(argv[0], "po_stpone") &&
+        !match(argv[0], "p_ass") && !match(argv[0], "hide")) {
+        if (st_glob.opt_flags & OF_REVERSE)
+            st_glob.i_current = st_glob.i_first;
+        else
+            st_glob.i_current = st_glob.i_last;
+        if (!(flags & O_QUIET))
+            wputs("Stopping.\n");
+        status |= S_STOP;
+    }
+    if (argc < 2) {
+        mode = M_OK;
+        return 1;
+    }
 
-	/* Validate arguments */
-	if (sscanf(argv[1], "%d", &i) < 1) {
-		std::println("You must specify a comment number.");
-		return 1;
-	} else if (argc > 2) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[i_i].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
+    /* Validate arguments */
+    if (sscanf(argv[1], "%d", &i) < 1) {
+        std::println("You must specify a comment number.");
+        return 1;
+    } else if (argc > 2) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[i_i].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
 
-	/* Do it */
-	part[i_i].nr = st_glob.r_lastseen = i;
-	if (st_glob.r_last == -2) { /* preserve/new */
-		st_glob.r_last = -1;
-		part[i_i].last = sum[i_i].last - 1;
-	} else
-		time(&(part[i_i].last));
-	dirty_part(i_i);
-	mode = M_OK;
+    /* Do it */
+    part[i_i].nr = st_glob.r_lastseen = i;
+    if (st_glob.r_last == -2) { /* preserve/new */
+        st_glob.r_last = -1;
+        part[i_i].last = sum[i_i].last - 1;
+    } else
+        time(&(part[i_i].last));
+    dirty_part(i_i);
+    mode = M_OK;
 
-	return 1;
+    return 1;
 }
 
 #ifdef INCLUDE_EXTRA_COMMANDS
@@ -947,36 +924,36 @@ int stack[MAX_RESPONSES], top = 0;
 void
 traverse(int i)
 {
-	int c, l, s;
-	std::print("{}{:3d}", (top) ? "-" : " ", i);
-	stack[top++] = i;
-	c = child(i);
-	if (c < 0)
-		std::println("");
-	else
-		traverse(c);
+    int c, l, s;
+    std::print("{}{:3d}", (top) ? "-" : " ", i);
+    stack[top++] = i;
+    c = child(i);
+    if (c < 0)
+        std::println("");
+    else
+        traverse(c);
 
-	top--;
-	if (!top)
-		return;
+    top--;
+    if (!top)
+        return;
 
-	c = sibling(i);
-	if (c >= 0) {
-		for (l = 1; l <= top; l++) {
-			std::print("   ");
-			/* std::print("({})", stack[l]); */
-			s = sibling(stack[l]);
-			if (s < 0)
-				std::print(" ");
-			else if (l < top)
-				std::print("|");
-			else if (sibling(s) < 0)
-				std::print("\\");
-			else
-				std::print("+");
-		}
-		traverse(c);
-	}
+    c = sibling(i);
+    if (c >= 0) {
+        for (l = 1; l <= top; l++) {
+            std::print("   ");
+            /* std::print("({})", stack[l]); */
+            s = sibling(stack[l]);
+            if (s < 0)
+                std::print(" ");
+            else if (l < top)
+                std::print("|");
+            else if (sibling(s) < 0)
+                std::print("\\");
+            else
+                std::print("+");
+        }
+        traverse(c);
+    }
 }
 /******************************************************************************/
 /* DISPLAY RESPONSE TREE                                                      */
@@ -987,65 +964,65 @@ tree(           /* ARGUMENTS:                  */
     char **argv /* Argument list            */
 )
 {
-	int i = 0;
-	/* Validate arguments */
-	if (argc > 2 || (argc > 1 && sscanf(argv[1], "%d", &i) < 1)) {
-		std::println("Bad parameters near \"{}\"", argv[2]);
-		return 2;
-	}
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
-		wputs("Can't go that far! near \"<newline>\"\n");
-		return 1;
-	}
-	traverse(i);
-	return 1;
+    int i = 0;
+    /* Validate arguments */
+    if (argc > 2 || (argc > 1 && sscanf(argv[1], "%d", &i) < 1)) {
+        std::println("Bad parameters near \"{}\"", argv[2]);
+        return 2;
+    }
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (i < 0 || i >= sum[st_glob.i_current - 1].nr) {
+        wputs("Can't go that far! near \"<newline>\"\n");
+        return 1;
+    }
+    traverse(i);
+    return 1;
 }
 
 int
 sibling(int r)
 {
-	int a, p;
-	/* Find next sibling */
-	p = parent(r);
-	a = r + 1;
-	if (!re[a].date)
-		get_resp(ext_fp, &(re[a]), GR_HEADER, a);
-	while (a <= st_glob.r_max && parent(a) != p) {
-		a++;
-		if (!re[a].date)
-			get_resp(ext_fp, &(re[a]), GR_HEADER, a);
-	}
-	if (a > st_glob.r_max)
-		return -1;
-	else
-		return a;
+    int a, p;
+    /* Find next sibling */
+    p = parent(r);
+    a = r + 1;
+    if (!re[a].date)
+        get_resp(ext_fp, &(re[a]), GR_HEADER, a);
+    while (a <= st_glob.r_max && parent(a) != p) {
+        a++;
+        if (!re[a].date)
+            get_resp(ext_fp, &(re[a]), GR_HEADER, a);
+    }
+    if (a > st_glob.r_max)
+        return -1;
+    else
+        return a;
 }
 
 int
 parent(int r)
 {
-	return (re[r].parent < 1) ? r - 1 : re[r].parent - 1;
+    return (re[r].parent < 1) ? r - 1 : re[r].parent - 1;
 }
 
 int
 child(int r)
 {
-	int a, p;
-	/* Find 1st child */
-	a = p = r + 1;
-	if (!re[a].date)
-		get_resp(ext_fp, &(re[a]), GR_HEADER, a);
-	if (re[a].parent && re[a].parent != p) {
-		a++;
-		if (!re[a].date)
-			get_resp(ext_fp, &(re[a]), GR_HEADER, a);
-		while (a <= st_glob.r_max && re[a].parent != p) {
-			a++;
-			if (!re[a].date)
-				get_resp(ext_fp, &(re[a]), GR_HEADER, a);
-		}
-	}
-	return (a > st_glob.r_max) ? -1 : a;
+    int a, p;
+    /* Find 1st child */
+    a = p = r + 1;
+    if (!re[a].date)
+        get_resp(ext_fp, &(re[a]), GR_HEADER, a);
+    if (re[a].parent && re[a].parent != p) {
+        a++;
+        if (!re[a].date)
+            get_resp(ext_fp, &(re[a]), GR_HEADER, a);
+        while (a <= st_glob.r_max && re[a].parent != p) {
+            a++;
+            if (!re[a].date)
+                get_resp(ext_fp, &(re[a]), GR_HEADER, a);
+        }
+    }
+    return (a > st_glob.r_max) ? -1 : a;
 }
 #endif

--- a/security.cc
+++ b/security.cc
@@ -31,67 +31,67 @@ static const std::string rightstr{"rwca"};
 void
 reinit_acl(void)
 {
-	acl_idx = -1;
+    acl_idx = -1;
 }
 
 void
 load_acl(int idx)
 {
-	if (idx == acl_idx)
-		return;
-	for (auto it = std::begin(acl_list); it != std::end(acl_list); ++it)
-		it->clear();
-	auto lines = grab_file(conflist[idx].location, "acl", GF_IGNCMT | GF_SILENT);
-	for (auto &acl: lines) {
-		char *ptr{};
-		for (ptr = acl.data(); isspace(*ptr); ptr++)
-			;
-		const char *q = strchr(ptr, ' ');
-		while (ptr < q) {
-			const auto pos = rightstr.find(*ptr++);
-			if (pos != std::string::npos)
-				acl_list[pos] = std::string(q + 1);
-		}
-	}
+    if (idx == acl_idx)
+        return;
+    for (auto it = std::begin(acl_list); it != std::end(acl_list); ++it)
+        it->clear();
+    auto lines =
+        grab_file(conflist[idx].location, "acl", GF_IGNCMT | GF_SILENT);
+    for (auto &acl : lines) {
+        char *ptr{};
+        for (ptr = acl.data(); isspace(*ptr); ptr++);
+        const char *q = strchr(ptr, ' ');
+        while (ptr < q) {
+            const auto pos = rightstr.find(*ptr++);
+            if (pos != std::string::npos)
+                acl_list[pos] = std::string(q + 1);
+        }
+    }
 
-	const auto no_join_acl =    acl_list[JOIN_RIGHT].empty();
-	const auto no_respond_acl = acl_list[RESPOND_RIGHT].empty();
-	const auto no_enter_acl =   acl_list[ENTER_RIGHT].empty();
+    const auto no_join_acl = acl_list[JOIN_RIGHT].empty();
+    const auto no_respond_acl = acl_list[RESPOND_RIGHT].empty();
+    const auto no_enter_acl = acl_list[ENTER_RIGHT].empty();
 
-	// If we hit eof without finding any relevant lines, revert to
-	// conference security type default
-	if (no_join_acl || no_respond_acl || no_enter_acl) {
-		auto sec = security_type(get_config(idx), idx);
-		auto basic_sec = (sec & CT_BASIC);
+    // If we hit eof without finding any relevant lines, revert to
+    // conference security type default
+    if (no_join_acl || no_respond_acl || no_enter_acl) {
+        auto sec = security_type(get_config(idx), idx);
+        auto basic_sec = (sec & CT_BASIC);
 
-		std::string base{"+registered"};
-		if (basic_sec == CT_PRESELECT || basic_sec == CT_PARANOID)
-			base.append(" +f:ulist");
-		if ((sec & CT_ORIGINLIST) != 0)
-			base.append(" +originlist");
+        std::string base{"+registered"};
+        if (basic_sec == CT_PRESELECT || basic_sec == CT_PARANOID)
+            base.append(" +f:ulist");
+        if ((sec & CT_ORIGINLIST) != 0)
+            base.append(" +originlist");
 
-		if (no_respond_acl)
-			acl_list[RESPOND_RIGHT] = str::concat({base, " -f:observers"});
+        if (no_respond_acl)
+            acl_list[RESPOND_RIGHT] = str::concat({base, " -f:observers"});
 
-		if (no_join_acl) {
-			if ((sec & CT_READONLY) != 0)
-				acl_list[JOIN_RIGHT] = "+all";
-			else
-				acl_list[JOIN_RIGHT] = base;
+        if (no_join_acl) {
+            if ((sec & CT_READONLY) != 0)
+                acl_list[JOIN_RIGHT] = "+all";
+            else
+                acl_list[JOIN_RIGHT] = base;
 
-			if (basic_sec == CT_PASSWORD || basic_sec == CT_PARANOID)
-				acl_list[JOIN_RIGHT].append(" +password");
-		}
-		if (no_enter_acl) {
-			acl_list[ENTER_RIGHT] = acl_list[RESPOND_RIGHT];
-			if ((sec & CT_NOENTER) != 0)
-				acl_list[ENTER_RIGHT].append(" +fwlist");
-		}
-	}
-	if (acl_list[CHACL_RIGHT].empty())
-		acl_list[CHACL_RIGHT] = "+sysop";
+            if (basic_sec == CT_PASSWORD || basic_sec == CT_PARANOID)
+                acl_list[JOIN_RIGHT].append(" +password");
+        }
+        if (no_enter_acl) {
+            acl_list[ENTER_RIGHT] = acl_list[RESPOND_RIGHT];
+            if ((sec & CT_NOENTER) != 0)
+                acl_list[ENTER_RIGHT].append(" +fwlist");
+        }
+    }
+    if (acl_list[CHACL_RIGHT].empty())
+        acl_list[CHACL_RIGHT] = "+sysop";
 
-	acl_idx = idx;
+    acl_idx = idx;
 }
 
 /* ARGUMENTS:                           */
@@ -100,37 +100,37 @@ load_acl(int idx)
 static bool
 check_field(std::string_view field, int idx)
 {
-	bool no = false;
-	bool ok = false;
+    bool no = false;
+    bool ok = false;
 
-	const auto uidstr = std::to_string(uid);
-	if (field[0] == '-') {
-		no = true;
-		field.remove_prefix(1);
-	} else if (field[0] == '+') {
-		field.remove_prefix(1);
-	}
-	if (tolower(field[0]) == 'f' && field[1] == ':') {
-		field.remove_prefix(2);
-		const std::string file(field);
-		ok = is_inlistfile(idx, file.c_str());
-	} else if (field == "fwlist")
-		ok = is_fairwitness(idx);
-	else if (field == "all")
-		ok = 1;
-	else if (field == "registered")
-		ok = (status & S_NOAUTH) == 0;
-	else if (field == "password")
-		ok = check_password(idx);
-	else if (field == "originlist")
-		ok = is_validorigin(idx);
-	else if (field == "sysop")
-		ok = is_sysop(1);
+    const auto uidstr = std::to_string(uid);
+    if (field[0] == '-') {
+        no = true;
+        field.remove_prefix(1);
+    } else if (field[0] == '+') {
+        field.remove_prefix(1);
+    }
+    if (tolower(field[0]) == 'f' && field[1] == ':') {
+        field.remove_prefix(2);
+        const std::string file(field);
+        ok = is_inlistfile(idx, file.c_str());
+    } else if (field == "fwlist")
+        ok = is_fairwitness(idx);
+    else if (field == "all")
+        ok = 1;
+    else if (field == "registered")
+        ok = (status & S_NOAUTH) == 0;
+    else if (field == "password")
+        ok = check_password(idx);
+    else if (field == "originlist")
+        ok = is_validorigin(idx);
+    else if (field == "sysop")
+        ok = is_sysop(1);
 
-	if (no)
-		ok = !ok;
+    if (no)
+        ok = !ok;
 
-	return ok;
+    return ok;
 }
 
 /* ARGUMENTS:                     */
@@ -139,14 +139,14 @@ check_field(std::string_view field, int idx)
 bool
 check_acl(int right, int idx)
 {
-	load_acl(idx);
-	const auto fields = str::split(acl_list[right], " ");
+    load_acl(idx);
+    const auto fields = str::split(acl_list[right], " ");
 
-	/* Ok iff user fits every field.  */
-	for (const auto &field : fields)
-		if (!check_field(field, idx))
-			return false;
-	return true;
+    /* Ok iff user fits every field.  */
+    for (const auto &field : fields)
+        if (!check_field(field, idx))
+            return false;
+    return true;
 }
 /******************************************************************************/
 /* TEST TO SEE IF ULIST SHOULD BE UPDATED WITH NEW JOINERS                    */
@@ -156,10 +156,10 @@ is_auto_ulist(/* ARGUMENTS:             */
     int idx   /* IN: conference index */
 )
 {
-	load_acl(idx);
-	// True if and only if the ulist file is not mentioned in any acls
-	for (auto acl = std::begin(acl_list); acl != std::end(acl_list); ++acl)
-		if (acl->find("ulist") != std::string::npos)
-			return false;
-	return true;
+    load_acl(idx);
+    // True if and only if the ulist file is not mentioned in any acls
+    for (auto acl = std::begin(acl_list); acl != std::end(acl_list); ++acl)
+        if (acl->find("ulist") != std::string::npos)
+            return false;
+    return true;
 }

--- a/sep.cc
+++ b/sep.cc
@@ -53,32 +53,33 @@ extern char *cfiles[];
 void
 init_show(void)
 {
-	show[0] = 1; /* was: show[depth]=1; */
+    show[0] = 1; /* was: show[depth]=1; */
 }
 
 /******************************************************************************/
 /* OUTPUT A STRING TO THE DESIRED FORMAT                                      */
 /******************************************************************************/
 static void
-putstring(      /* ARGUMENTS:                   */
+putstring(                     /* ARGUMENTS:                   */
     const std::string_view &b, /* String to output          */
-    FILE *fp /* File pointer to output to */
+    FILE *fp                   /* File pointer to output to */
 )
 {
-	/* LOCAL VARIABLES:             */
-	char buf[MAX_LINE_LENGTH]; /* Formatted output          */
+    /* LOCAL VARIABLES:             */
+    char buf[MAX_LINE_LENGTH]; /* Formatted output          */
 
-	if (!show[depth])
-		return;
-	auto len = std::min(b.size(), sizeof(buf) - 1);
-	if (0 < num && num < len)
-		len = num;
-	memcpy(buf, b.data(), len);
-	buf[len] = '\0';
-	wfputs(buf, fp);
+    if (!show[depth])
+        return;
+    auto len = std::min(b.size(), sizeof(buf) - 1);
+    if (0 < num && num < len)
+        len = num;
+    memcpy(buf, b.data(), len);
+    buf[len] = '\0';
+    wfputs(buf, fp);
 }
 
-namespace y {
+namespace y
+{
 
 constexpr auto WHITESPACE = " \t\v\f\r\n";
 
@@ -86,10 +87,10 @@ constexpr auto WHITESPACE = " \t\v\f\r\n";
 std::size_t
 wrapcolumn(void)
 {
-	const auto wrapstr = expand("wrap", DM_VAR);
-	if (wrapstr.empty())
-		return 0;
-	return str::toi(wrapstr);
+    const auto wrapstr = expand("wrap", DM_VAR);
+    if (wrapstr.empty())
+        return 0;
+    return str::toi(wrapstr);
 }
 
 // Returns a new view over the given string, with trailing
@@ -97,10 +98,10 @@ wrapcolumn(void)
 std::string_view
 rtrim(std::string_view s)
 {
-	const auto lpos = s.find_last_not_of(WHITESPACE);
-	if (lpos != std::string_view::npos)
-		s.remove_suffix(s.size() - lpos - 1);
-	return s;
+    const auto lpos = s.find_last_not_of(WHITESPACE);
+    if (lpos != std::string_view::npos)
+        s.remove_suffix(s.size() - lpos - 1);
+    return s;
 }
 
 // Writes the given string to the given output,
@@ -111,40 +112,40 @@ rtrim(std::string_view s)
 void
 wrapout(std::ostream &out, std::string_view str)
 {
-	const auto wrapcol = wrapcolumn();
-	if (wrapcol == 0) {
-		std::print(out, "{}", str);
-		return;
-	}
-	while (!str.empty()) {
-		if (str.size() < wrapcol) {
-			std::println(out, "{}", str);
-			break;
-		}
-		auto len = wrapcol;
-		auto prefix = str.substr(0, len);
-		auto pos = prefix.find_first_of("\r\n");
-		if (pos != std::string_view::npos) {
-			auto line = prefix.substr(0, pos);
-			std::println(out, "{}", rtrim(line));
-			auto c = prefix[pos];
-			str.remove_prefix(pos + 1);
-			if ((c == '\r' && str.starts_with("\n")) ||
-			    (c == '\n' && str.starts_with("\r")))
-				str.remove_prefix(1);
-			continue;
-		}
-		pos = prefix.find_last_of(WHITESPACE);
-		if (pos != std::string_view::npos) {
-			prefix.remove_suffix(prefix.size() - pos - 1);
-			prefix = rtrim(prefix);
-			len = pos + 1;
-		}
-		std::println(out, "{}", prefix);
-		str.remove_prefix(len);
-	}
+    const auto wrapcol = wrapcolumn();
+    if (wrapcol == 0) {
+        std::print(out, "{}", str);
+        return;
+    }
+    while (!str.empty()) {
+        if (str.size() < wrapcol) {
+            std::println(out, "{}", str);
+            break;
+        }
+        auto len = wrapcol;
+        auto prefix = str.substr(0, len);
+        auto pos = prefix.find_first_of("\r\n");
+        if (pos != std::string_view::npos) {
+            auto line = prefix.substr(0, pos);
+            std::println(out, "{}", rtrim(line));
+            auto c = prefix[pos];
+            str.remove_prefix(pos + 1);
+            if ((c == '\r' && str.starts_with("\n")) ||
+                (c == '\n' && str.starts_with("\r")))
+                str.remove_prefix(1);
+            continue;
+        }
+        pos = prefix.find_last_of(WHITESPACE);
+        if (pos != std::string_view::npos) {
+            prefix.remove_suffix(prefix.size() - pos - 1);
+            prefix = rtrim(prefix);
+            len = pos + 1;
+        }
+        std::println(out, "{}", prefix);
+        str.remove_prefix(len);
+    }
 }
-}  // anonymous namespace
+} // namespace y
 
 /*
  * This routine does:   std::println(fp, "{}", str);
@@ -153,71 +154,68 @@ wrapout(std::ostream &out, std::string_view str)
 static void
 wrapout(FILE *fp, const char *str)
 {
-	int wrapcol;
-	char *line, *ptr;
+    int wrapcol;
+    char *line, *ptr;
 
-	if (!show[depth])
-		return;
+    if (!show[depth])
+        return;
 
-	const auto wrap = expand("wrap", DM_VAR);
-	if (wrap.empty() || (wrapcol = str::toi(wrap)) < 1) {
-		putstring(str, fp);
-		return;
-	}
-	ptr = line = (char *)emalloc(wrapcol + 2);
+    const auto wrap = expand("wrap", DM_VAR);
+    if (wrap.empty() || (wrapcol = str::toi(wrap)) < 1) {
+        putstring(str, fp);
+        return;
+    }
+    ptr = line = (char *)emalloc(wrapcol + 2);
 
-	const char *p;
-	for (p = str; *p; p++) {
-		if (*p == '\n' || *p == '\r') {
-			(*ptr) = '\0';
-			if (ptr > line)
-				wfputs(line, fp);
-			ptr = line;
-			wfputc(*p, fp);
-			continue;
-		}
-		if (ptr - line == wrapcol) {
-			if (*p == ' ') {
-				(*ptr) = '\0';
-				wfputs(line, fp);
-				ptr = line;
+    const char *p;
+    for (p = str; *p; p++) {
+        if (*p == '\n' || *p == '\r') {
+            (*ptr) = '\0';
+            if (ptr > line)
+                wfputs(line, fp);
+            ptr = line;
+            wfputc(*p, fp);
+            continue;
+        }
+        if (ptr - line == wrapcol) {
+            if (*p == ' ') {
+                (*ptr) = '\0';
+                wfputs(line, fp);
+                ptr = line;
 
-				wfputc('\n', fp);
-				continue;
-			} else {
-				/* Find previous space */
-				char *s;
-				for (s = ptr - 1; s >= line && !isspace(*s);
-				     s--)
-					;
-				if (s < line) {
-					(*ptr) = '\0';
-					wfputs(line, fp);
-					while (*p && !isspace(*p))
-						wfputc(*p++, fp);
-					wfputc('\n', fp);
-					ptr = line;
-					if (!*p)
-						p--;
-					continue;
-				} else {
-					(*s++) = (*ptr) = '\0';
-					wfputs(line, fp);
-					wfputc('\n', fp);
-					strcpy(line, s);
-					ptr -= s - line;
-				}
-			}
-		}
-		*ptr++ = *p;
-	}
+                wfputc('\n', fp);
+                continue;
+            } else {
+                /* Find previous space */
+                char *s;
+                for (s = ptr - 1; s >= line && !isspace(*s); s--);
+                if (s < line) {
+                    (*ptr) = '\0';
+                    wfputs(line, fp);
+                    while (*p && !isspace(*p)) wfputc(*p++, fp);
+                    wfputc('\n', fp);
+                    ptr = line;
+                    if (!*p)
+                        p--;
+                    continue;
+                } else {
+                    (*s++) = (*ptr) = '\0';
+                    wfputs(line, fp);
+                    wfputc('\n', fp);
+                    strcpy(line, s);
+                    ptr -= s - line;
+                }
+            }
+        }
+        *ptr++ = *p;
+    }
 
-	/* Once we hit end of line, dump the rest but don't append a newline */
-	if (ptr > line) {
-		(*ptr) = '\0';
-		wfputs(line, fp);
-	}
-	free(line);
+    /* Once we hit end of line, dump the rest but don't append a newline */
+    if (ptr > line) {
+        (*ptr) = '\0';
+        wfputs(line, fp);
+    }
+    free(line);
 }
 /******************************************************************************/
 /* OUTPUT A NUMBER TO THE DESIRED FORMAT                                      */
@@ -228,66 +226,66 @@ number(      /* ARGUMENTS:           */
     FILE *fp /* Stream to send to */
 )
 {
-	if (!show[depth])
-		return;
-	if (b == 0 && zero)
-		wfputs(std::format("{:c}o", "nN"[zero - 1]), fp);
-	else if (num != 0)
-		wfputs(std::format("{:{}d}", b, num), fp);
-	else
-		wfputs(std::format("{}", b), fp);
-	lastnum = b;
+    if (!show[depth])
+        return;
+    if (b == 0 && zero)
+        wfputs(std::format("{:c}o", "nN"[zero - 1]), fp);
+    else if (num != 0)
+        wfputs(std::format("{:{}d}", b, num), fp);
+    else
+        wfputs(std::format("{}", b), fp);
+    lastnum = b;
 }
 
 entity_t *
 get_entity(const char **spp)
 {
-	static entity_t ent;
-	char buff[80];
-	const char *sp;
-	char *sub;
+    static entity_t ent;
+    char buff[80];
+    const char *sp;
+    char *sub;
 
-	sp = *spp;
+    sp = *spp;
 
-	if (*sp == '"') { /* Get string */
-		sp++;     /* skip start quote */
-		for (sub = buff; *sp && *sp != '"'; sp++, sub++) *sub = *sp;
-		(*sub) = '\0';
-		if (*sp == '"') /* skip ending quote */
-			sp++;
-		ent.type = ET_STRING;
-		ent.val.s = estrdup(buff);
+    if (*sp == '"') { /* Get string */
+        sp++;         /* skip start quote */
+        for (sub = buff; *sp && *sp != '"'; sp++, sub++) *sub = *sp;
+        (*sub) = '\0';
+        if (*sp == '"') /* skip ending quote */
+            sp++;
+        ent.type = ET_STRING;
+        ent.val.s = estrdup(buff);
 
-	} else if (isdigit(*sp) || *sp == '-') { /* Get int    */
-		sub = buff;
-		if (*sp == '-')
-			*sub++ = *sp++;
-		while (*sp && isdigit(*sp)) *sub++ = *sp++;
-		*sub = '\0';
-		ent.type = ET_INTEGER;
-		ent.val.i = atoi(buff);
-	} else { /* Get macro */
-		for (sub = buff; *sp && isalnum(*sp); sp++, sub++) *sub = *sp;
-		(*sub) = '\0';
-		auto str = expand(buff, DM_VAR);
-		if (!str.empty() && (isdigit(str[0]) || str[0] == '-')) {
-			ent.type = ET_INTEGER;
-			ent.val.i = str::toi(str);
-		} else {
-			ent.type = ET_STRING;
-			ent.val.s = estrdup(str.c_str());
-		}
-	}
+    } else if (isdigit(*sp) || *sp == '-') { /* Get int    */
+        sub = buff;
+        if (*sp == '-')
+            *sub++ = *sp++;
+        while (*sp && isdigit(*sp)) *sub++ = *sp++;
+        *sub = '\0';
+        ent.type = ET_INTEGER;
+        ent.val.i = atoi(buff);
+    } else { /* Get macro */
+        for (sub = buff; *sp && isalnum(*sp); sp++, sub++) *sub = *sp;
+        (*sub) = '\0';
+        auto str = expand(buff, DM_VAR);
+        if (!str.empty() && (isdigit(str[0]) || str[0] == '-')) {
+            ent.type = ET_INTEGER;
+            ent.val.i = str::toi(str);
+        } else {
+            ent.type = ET_STRING;
+            ent.val.s = estrdup(str.c_str());
+        }
+    }
 
-	*spp = sp;
-	return &ent;
+    *spp = sp;
+    return &ent;
 }
 
 void
 dest_entity(entity_t *ent)
 {
-	if (ent->type == ET_STRING)
-		free(ent->val.s);
+    if (ent->type == ET_STRING)
+        free(ent->val.s);
 }
 /*
  * Convert an operator string to integer format, which some OR'ed combination
@@ -303,38 +301,38 @@ opstr2int(    /* ARGUMENTS: */
     char *str /* Operator string, e.g. "<=", "==", etc */
 )
 {
-	char *p;
-	int no_t = 0;
-	int ret = 0;
-	for (p = str; *p; p++) {
-		switch (*p) {
-		case '~':
-			ret |= OP_IN;
-			break;
-		case '=':
-			ret |= OP_EQ;
-			break;
-		case '>':
-			ret |= OP_GT;
-			break;
-		case '<':
-			ret |= OP_LT;
-			break;
-		case '!':
-			no_t = 1 - no_t;
-			break;
-		default:
-			return 0;
-		}
-	}
+    char *p;
+    int no_t = 0;
+    int ret = 0;
+    for (p = str; *p; p++) {
+        switch (*p) {
+        case '~':
+            ret |= OP_IN;
+            break;
+        case '=':
+            ret |= OP_EQ;
+            break;
+        case '>':
+            ret |= OP_GT;
+            break;
+        case '<':
+            ret |= OP_LT;
+            break;
+        case '!':
+            no_t = 1 - no_t;
+            break;
+        default:
+            return 0;
+        }
+    }
 
-	if (no_t) {
-		if (!(ret & OP_IN))
-			ret = 0x111 - ret;
-		else
-			ret |= OP_NOT;
-	}
-	return ret;
+    if (no_t) {
+        if (!(ret & OP_IN))
+            ret = 0x111 - ret;
+        else
+            ret |= OP_NOT;
+    }
+    return ret;
 }
 
 int
@@ -344,143 +342,143 @@ opcompare(          /* ARGUMENTS: */
     entity_t *right /* right operand */
 )
 {
-	const char *lstr = nullptr, *rstr = nullptr;
-	int lint = 0, rint = 0, typ;
-	std::string buff, buff2;
-	/* Promote int to string if needed */
-	if ((op && op != 0x111) && left->type == ET_STRING &&
-	    right->type == ET_INTEGER) {
-		lstr = left->val.s;
-		buff = std::format("{}", right->val.i);
-		rstr = buff.c_str();
-		typ = ET_STRING;
-	} else if ((op && op != 0x111) && left->type == ET_INTEGER &&
-	           right->type == ET_STRING) {
-		rstr = right->val.s;
-		buff = std::format("{}", left->val.i);
-		lstr = buff.c_str();
-		typ = ET_STRING;
-	} else if (left->type == ET_STRING) { /* both strings */
-		typ = ET_STRING;
-		lstr = left->val.s;
-		rstr = right->val.s;
-	} else {                  /* both int's */
-		if (op & OP_IN) { /* must promote both to
-			           * strings */
-			typ = ET_STRING;
-			buff = std::format("{}", left->val.i);
-			lstr = buff.c_str();
-			buff2 = std::format("{}", right->val.i);
-			rstr = buff2.c_str();
-		} else {
-			typ = ET_INTEGER;
-			lint = left->val.i;
-			rint = right->val.i;
-		}
-	}
+    const char *lstr = nullptr, *rstr = nullptr;
+    int lint = 0, rint = 0, typ;
+    std::string buff, buff2;
+    /* Promote int to string if needed */
+    if ((op && op != 0x111) && left->type == ET_STRING &&
+        right->type == ET_INTEGER) {
+        lstr = left->val.s;
+        buff = std::format("{}", right->val.i);
+        rstr = buff.c_str();
+        typ = ET_STRING;
+    } else if ((op && op != 0x111) && left->type == ET_INTEGER &&
+               right->type == ET_STRING) {
+        rstr = right->val.s;
+        buff = std::format("{}", left->val.i);
+        lstr = buff.c_str();
+        typ = ET_STRING;
+    } else if (left->type == ET_STRING) { /* both strings */
+        typ = ET_STRING;
+        lstr = left->val.s;
+        rstr = right->val.s;
+    } else {              /* both int's */
+        if (op & OP_IN) { /* must promote both to
+                           * strings */
+            typ = ET_STRING;
+            buff = std::format("{}", left->val.i);
+            lstr = buff.c_str();
+            buff2 = std::format("{}", right->val.i);
+            rstr = buff2.c_str();
+        } else {
+            typ = ET_INTEGER;
+            lint = left->val.i;
+            rint = right->val.i;
+        }
+    }
 
-	if (typ == ET_INTEGER) {
-		if (op == 0x000) /* single operand */
-			return lint;
-		if (op == 0x111) /* single operand */
-			return !lint;
+    if (typ == ET_INTEGER) {
+        if (op == 0x000) /* single operand */
+            return lint;
+        if (op == 0x111) /* single operand */
+            return !lint;
 
-		/* Two operands */
-		return ((lint > rint && (op & OP_GT)) ||
-		        (lint == rint && (op & OP_EQ)) ||
-		        (lint < rint && (op & OP_LT)));
-	} else {                 /* ET_STRING */
-		if (op == 0x000) /* single operand */
-			return (lstr != NULL);
-		if (op == 0x111) /* single operand */
-			return (lstr == NULL);
+        /* Two operands */
+        return ((lint > rint && (op & OP_GT)) ||
+                (lint == rint && (op & OP_EQ)) ||
+                (lint < rint && (op & OP_LT)));
+    } else {             /* ET_STRING */
+        if (op == 0x000) /* single operand */
+            return (lstr != NULL);
+        if (op == 0x111) /* single operand */
+            return (lstr == NULL);
 
-		/* Check for containment in list... */
-		if (op & OP_IN) {
-			const auto little = std::format(" {} ", rstr);
-			const auto big = std::format(" {} ", lstr);
-			const auto p = big.find(little) != std::string::npos;
-			return (op & OP_NOT) ? !p : p;
-		}
+        /* Check for containment in list... */
+        if (op & OP_IN) {
+            const auto little = std::format(" {} ", rstr);
+            const auto big = std::format(" {} ", lstr);
+            const auto p = big.find(little) != std::string::npos;
+            return (op & OP_NOT) ? !p : p;
+        }
 
-		/* Two operands */
-		return ((strcmp(lstr, rstr) > 0 && (op & OP_GT)) ||
-		        (strcmp(lstr, rstr) == 0 && (op & OP_EQ)) ||
-		        (strcmp(lstr, rstr) < 0 && (op & OP_LT)));
-	}
+        /* Two operands */
+        return ((strcmp(lstr, rstr) > 0 && (op & OP_GT)) ||
+                (strcmp(lstr, rstr) == 0 && (op & OP_EQ)) ||
+                (strcmp(lstr, rstr) < 0 && (op & OP_LT)));
+    }
 }
 /******************************************************************************/
 /* PROCESS CONDITIONS FOR BOTH ITEM/CONF SEPS                                 */
 /******************************************************************************/
 static char
-misccond(      /* ARGUMENTS: */
+misccond(            /* ARGUMENTS: */
     const char **spp /* Separator string */
 )
 {
-	const char *sp = *spp;
-	char ret = 0, no_t = 0;
+    const char *sp = *spp;
+    char ret = 0, no_t = 0;
 
-	if (*sp == '!' || *sp == '~') {
-		no_t = !no_t;
-		sp++;
-	}
-	switch (*(sp++)) {
-	case 'P':
-		ret = (lastnum != 1);
-		break;
-	case 'S':
-		ret = (st_glob.c_status & CS_FW);
-		break;
-	case 'l':
-		ret = (st_glob.c_status & CS_NORESPONSE);
-		break;
-	case '(': {
-		char *buff;
-		entity_t left, right;
-		int op;
-		/* Skip whitespace */
-		while (isspace(*sp)) sp++;
+    if (*sp == '!' || *sp == '~') {
+        no_t = !no_t;
+        sp++;
+    }
+    switch (*(sp++)) {
+    case 'P':
+        ret = (lastnum != 1);
+        break;
+    case 'S':
+        ret = (st_glob.c_status & CS_FW);
+        break;
+    case 'l':
+        ret = (st_glob.c_status & CS_NORESPONSE);
+        break;
+    case '(': {
+        char *buff;
+        entity_t left, right;
+        int op;
+        /* Skip whitespace */
+        while (isspace(*sp)) sp++;
 
-		/* Get left operand */
-		memcpy(&left, get_entity(&sp), sizeof(left));
+        /* Get left operand */
+        memcpy(&left, get_entity(&sp), sizeof(left));
 
-		/* Skip whitespace */
-		while (isspace(*sp)) sp++;
+        /* Skip whitespace */
+        while (isspace(*sp)) sp++;
 
-		/* Get operator */
-		size_t oplen = strspn(sp, "<>=!~");
-		buff = estrndup(sp, oplen);
-		sp += oplen;
-		op = opstr2int(buff);
-		free(buff);
+        /* Get operator */
+        size_t oplen = strspn(sp, "<>=!~");
+        buff = estrndup(sp, oplen);
+        sp += oplen;
+        op = opstr2int(buff);
+        free(buff);
 
-		/* Skip whitespace */
-		while (isspace(*sp)) sp++;
+        /* Skip whitespace */
+        while (isspace(*sp)) sp++;
 
-		/* Get right operand */
-		memcpy(&right, get_entity(&sp), sizeof(right));
+        /* Get right operand */
+        memcpy(&right, get_entity(&sp), sizeof(right));
 
-		/* Skip whitespace */
-		while (isspace(*sp)) sp++;
+        /* Skip whitespace */
+        while (isspace(*sp)) sp++;
 
-		/* Get right paren */
-		if (*sp == ')')
-			sp++;
+        /* Get right paren */
+        if (*sp == ')')
+            sp++;
 
-		ret = opcompare(&left, op, &right);
-		dest_entity(&left);
-		dest_entity(&right);
-		break;
-	}
-	default:
-		ret = 0;
-		break; /* don't show */
-	}
+        ret = opcompare(&left, op, &right);
+        dest_entity(&left);
+        dest_entity(&right);
+        break;
+    }
+    default:
+        ret = 0;
+        break; /* don't show */
+    }
 
-	*spp = sp;
-	if (!show[depth])
-		return 0;
-	return (ret != 0) ^ no_t;
+    *spp = sp;
+    if (!show[depth])
+        return 0;
+    return (ret != 0) ^ no_t;
 }
 
 static sumentry_t oldsum[MAX_ITEMS];
@@ -490,30 +488,28 @@ void
 announce_new_responses(FILE *fp /* IN: Stream to send to */
 )
 {
-	int newr = 0, i;
-	refresh_sum(0, confidx, sum, part, &st_glob);
-	if (confidx == oldconfidx) {
-		for (i = st_glob.i_first; i < st_glob.i_last; i++) {
-			if (sum[i].nr > oldsum[i].nr &&
-			    sum[i].last > part[i].last) {
-				if (!newr) {
-					putstring(
-					    "New responses were just posted to "
-					    "item(s):\n",
-					    fp);
-					newr = 1;
-				}
-				putstring(" ", fp);
-				number(i + 1, fp);
-				oldsum[i].nr = sum[i].nr;
-			}
-		}
-		if (newr)
-			putstring("\n", fp);
-	} else {
-		oldconfidx = confidx;
-		memcpy(oldsum, sum, MAX_ITEMS * sizeof(sumentry_t));
-	}
+    int newr = 0, i;
+    refresh_sum(0, confidx, sum, part, &st_glob);
+    if (confidx == oldconfidx) {
+        for (i = st_glob.i_first; i < st_glob.i_last; i++) {
+            if (sum[i].nr > oldsum[i].nr && sum[i].last > part[i].last) {
+                if (!newr) {
+                    putstring("New responses were just posted to "
+                              "item(s):\n",
+                        fp);
+                    newr = 1;
+                }
+                putstring(" ", fp);
+                number(i + 1, fp);
+                oldsum[i].nr = sum[i].nr;
+            }
+        }
+        if (newr)
+            putstring("\n", fp);
+    } else {
+        oldconfidx = confidx;
+        memcpy(oldsum, sum, MAX_ITEMS * sizeof(sumentry_t));
+    }
 }
 /* Mark given response as not new, so our own responses don't trigger
  * the message above
@@ -524,205 +520,203 @@ skip_new_response(int c, /* IN: conference index */
     int nr               /* IN: response count */
 )
 {
-	if (c == oldconfidx) {
-		oldsum[i].nr = nr;
-	} else {
-		oldconfidx = c;
-		refresh_sum(0, c, sum, part, &st_glob);
-		memcpy(oldsum, sum, MAX_ITEMS * sizeof(sumentry_t));
-	}
+    if (c == oldconfidx) {
+        oldsum[i].nr = nr;
+    } else {
+        oldconfidx = c;
+        refresh_sum(0, c, sum, part, &st_glob);
+        memcpy(oldsum, sum, MAX_ITEMS * sizeof(sumentry_t));
+    }
 }
 /******************************************************************************/
 /* PROCESS SEPS FOR BOTH ITEM/CONF SEPS                                       */
 /******************************************************************************/
 void
-miscsep(        /* ARGUMENTS: */
+miscsep(              /* ARGUMENTS: */
     const char **spp, /* Separator string */
-    FILE *fp    /* Stream to send to */
+    FILE *fp          /* Stream to send to */
 )
 {
-	const char *sp;
-	short i;
-	char *sub;
+    const char *sp;
+    short i;
+    char *sub;
 
-	sp = *spp;
-	switch (*(sp++)) {
+    sp = *spp;
+    switch (*(sp++)) {
 
-		/* Customization separators */
-	case '%':
-		putstring("%", fp);
-		break;
-	case 'E':
-		if (!depth || show[depth - 1])
-			show[depth] = !show[depth];
-		break;
-	case 'c':
-		newline = 0;
-		break;
-		/* case 'R': refresh_sum(0,confidx,sum,part,&st_glob);
-		 * break; */
-	case 'R':
-		announce_new_responses(fp);
-		break;
-	case 'S':
-		if (lastnum != 1)
-			putstring("s", fp);
-		break;
-	case 'T':
-		tabs = num;
-		break;
-	case 'X':
-		for (i = 0; i < tabs; i++)
-			if (show[depth])
-				wfputc(' ', fp);
-		break;
-	case ')':
-		/*
-		for (i=0; i<depth; i++) std::print("   ");
-		std::println("---");
-		*/
-		depth--;
-		break;
-	case 'D':
-		if (show[depth])
-			wfputs(get_date(time((time_t *)0), num), fp);
-		break;
-	case '`': /* Execute a command */
-	{
-		int tmp = once; /* save once */
-		int lvl = stdin_stack_top;
-		const char *tick = strchr(sp, '`');
-		if (tick == NULL)
-			tick = sp + strlen(sp);
-		size_t len = tick - sp;
-		sub = estrndup(sp, len);
-		sp += len;
-		if (*sp == '`')
-			sp++;
-		once = 0;
-		command(sub, 1);
-		once = tmp;
-		free(sub);
-		while (stdin_stack_top > lvl)
-			pop_stdin();
-	} break;
+        /* Customization separators */
+    case '%':
+        putstring("%", fp);
+        break;
+    case 'E':
+        if (!depth || show[depth - 1])
+            show[depth] = !show[depth];
+        break;
+    case 'c':
+        newline = 0;
+        break;
+        /* case 'R': refresh_sum(0,confidx,sum,part,&st_glob);
+         * break; */
+    case 'R':
+        announce_new_responses(fp);
+        break;
+    case 'S':
+        if (lastnum != 1)
+            putstring("s", fp);
+        break;
+    case 'T':
+        tabs = num;
+        break;
+    case 'X':
+        for (i = 0; i < tabs; i++)
+            if (show[depth])
+                wfputc(' ', fp);
+        break;
+    case ')':
+        /*
+        for (i=0; i<depth; i++) std::print("   ");
+        std::println("---");
+        */
+        depth--;
+        break;
+    case 'D':
+        if (show[depth])
+            wfputs(get_date(time((time_t *)0), num), fp);
+        break;
+    case '`': /* Execute a command */
+    {
+        int tmp = once; /* save once */
+        int lvl = stdin_stack_top;
+        const char *tick = strchr(sp, '`');
+        if (tick == NULL)
+            tick = sp + strlen(sp);
+        size_t len = tick - sp;
+        sub = estrndup(sp, len);
+        sp += len;
+        if (*sp == '`')
+            sp++;
+        once = 0;
+        command(sub, 1);
+        once = tmp;
+        free(sub);
+        while (stdin_stack_top > lvl) pop_stdin();
+    } break;
 
-	default:
-		break; /* do nothing */
-	}
+    default:
+        break; /* do nothing */
+    }
 
-	*spp = sp;
+    *spp = sp;
 }
 /******************************************************************************/
 /* PROCESS CONDITIONS FOR ITEM SEPS ONLY                                      */
 /******************************************************************************/
 char
-itemcond(       /* ARGUMENTS:               */
+itemcond(             /* ARGUMENTS:               */
     const char **spp, /* Separator string      */
-    long fl     /* Sep flags             */
+    long fl           /* Sep flags             */
 )
 {
-	const char *sp;
-	char ret = 0, no_t = 0;
-	response_t *cre;
-	sp = *spp;
-	cre = &(re[st_glob.r_current]);
+    const char *sp;
+    char ret = 0, no_t = 0;
+    response_t *cre;
+    sp = *spp;
+    cre = &(re[st_glob.r_current]);
 
-	if (*sp == '!' || *sp == '~') {
-		no_t = !no_t;
-		sp++;
-	}
-	for (num = 0; isdigit(*sp); sp++) num = num * 10 + (*sp - '0');
+    if (*sp == '!' || *sp == '~') {
+        no_t = !no_t;
+        sp++;
+    }
+    for (num = 0; isdigit(*sp); sp++) num = num * 10 + (*sp - '0');
 
-	switch (*(sp++)) {
-	case 'B':
-		ret = ((once & IS_START) > 0);
-		once &= ~IS_START;
-		break;
-	case 'D':
-		ret = ((once & IS_DATE) > 0);
-		break;
+    switch (*(sp++)) {
+    case 'B':
+        ret = ((once & IS_START) > 0);
+        once &= ~IS_START;
+        break;
+    case 'D':
+        ret = ((once & IS_DATE) > 0);
+        break;
 #ifdef NEWS
-	case 'E':
-		ret = ((cre->flags & RF_EXPIRED) > 0);
-		break;
+    case 'E':
+        ret = ((cre->flags & RF_EXPIRED) > 0);
+        break;
 #endif
-	case 'F':
-		ret = ((fl & OF_NUMBERED) || (flags & O_NUMBERED));
-		break;
-		/* case 'I': (see 'O') */
-	case 'L':
-		ret = (st_glob.l_current >= 0 &&
-		       st_glob.l_current < cre->text.size() &&
-		       !cre->text[st_glob.l_current].empty());
-		break;
-	case 'N':
-		ret = (st_glob.r_current > 0);
-		/*           ret= (!(!part[st_glob.i_current-1].nr &&
-		   sum[st_glob.i_current-1].nr)
-		                  && (part[st_glob.i_current-1].nr  <
-		   sum[st_glob.i_current-1].nr));
-		*/
-		break;
-	case 'I': /* ret=(!part[st_glob.i_current-1].nr &&
-	           * sum[st_glob.i_current-1].nr); break; fall
-	           * through into O */
-	case 'O':
-		ret = ((once & IS_ITEM) > 0);
-		once &= ~IS_ITEM;
-		break;
-	case 'p':
-		ret = (cre->parent > 0);
-		once &= ~IS_PARENT;
-		break;
-	case 'r':
-		ret = (st_glob.r_current >= 0);
-		break;
-	case 'R':
-		ret = ((once & (IS_ITEM | IS_RESP)) > 0);
-		once &= ~(IS_ITEM | IS_RESP);
-		/*
-		             ret= ((!part[st_glob.i_current-1].nr &&
-		   sum[st_glob.i_current-1].nr)
-		                 || (part[st_glob.i_current-1].nr  <
-		   sum[st_glob.i_current-1].nr));
-		*/
-		break;
-	case 'T':
-		ret = ((fl & OF_FORMFEED) > 0);
-		break;
-	case 'U':
-		ret = ((once & IS_UID) > 0);
-		break;
-	case 'V':
-		ret = ((cre->flags & RF_CENSORED) > 0);
-		break;
-	case 'W':
-		ret = ((cre->flags & RF_SCRIBBLED) > 0);
-		break;
-	case 'X':
-		ret = ((sum[st_glob.i_current - 1].flags & IF_RETIRED) > 0);
-		once &= ~IS_RETIRED;
-		break;
-	case 'x':
-		ret = (once & num); /* once &= ~num; */
-		break;
-	case 'Y':
-		ret = ((sum[st_glob.i_current - 1].flags & IF_FORGOTTEN) > 0);
-		once &= ~IS_FORGOTTEN;
-		break;
-	case 'Z':
-		ret = ((sum[st_glob.i_current - 1].flags & IF_FROZEN) > 0);
-		once &= ~IS_FROZEN;
-		break;
-	default:
-		return misccond(spp);
-	}
+    case 'F':
+        ret = ((fl & OF_NUMBERED) || (flags & O_NUMBERED));
+        break;
+        /* case 'I': (see 'O') */
+    case 'L':
+        ret = (st_glob.l_current >= 0 && st_glob.l_current < cre->text.size() &&
+               !cre->text[st_glob.l_current].empty());
+        break;
+    case 'N':
+        ret = (st_glob.r_current > 0);
+        /*           ret= (!(!part[st_glob.i_current-1].nr &&
+           sum[st_glob.i_current-1].nr)
+                          && (part[st_glob.i_current-1].nr  <
+           sum[st_glob.i_current-1].nr));
+        */
+        break;
+    case 'I': /* ret=(!part[st_glob.i_current-1].nr &&
+               * sum[st_glob.i_current-1].nr); break; fall
+               * through into O */
+    case 'O':
+        ret = ((once & IS_ITEM) > 0);
+        once &= ~IS_ITEM;
+        break;
+    case 'p':
+        ret = (cre->parent > 0);
+        once &= ~IS_PARENT;
+        break;
+    case 'r':
+        ret = (st_glob.r_current >= 0);
+        break;
+    case 'R':
+        ret = ((once & (IS_ITEM | IS_RESP)) > 0);
+        once &= ~(IS_ITEM | IS_RESP);
+        /*
+                     ret= ((!part[st_glob.i_current-1].nr &&
+           sum[st_glob.i_current-1].nr)
+                         || (part[st_glob.i_current-1].nr  <
+           sum[st_glob.i_current-1].nr));
+        */
+        break;
+    case 'T':
+        ret = ((fl & OF_FORMFEED) > 0);
+        break;
+    case 'U':
+        ret = ((once & IS_UID) > 0);
+        break;
+    case 'V':
+        ret = ((cre->flags & RF_CENSORED) > 0);
+        break;
+    case 'W':
+        ret = ((cre->flags & RF_SCRIBBLED) > 0);
+        break;
+    case 'X':
+        ret = ((sum[st_glob.i_current - 1].flags & IF_RETIRED) > 0);
+        once &= ~IS_RETIRED;
+        break;
+    case 'x':
+        ret = (once & num); /* once &= ~num; */
+        break;
+    case 'Y':
+        ret = ((sum[st_glob.i_current - 1].flags & IF_FORGOTTEN) > 0);
+        once &= ~IS_FORGOTTEN;
+        break;
+    case 'Z':
+        ret = ((sum[st_glob.i_current - 1].flags & IF_FROZEN) > 0);
+        once &= ~IS_FROZEN;
+        break;
+    default:
+        return misccond(spp);
+    }
 
-	*spp = sp;
-	if (!show[depth])
-		return 0;
-	return (ret != 0) ^ no_t;
+    *spp = sp;
+    if (!show[depth])
+        return 0;
+    return (ret != 0) ^ no_t;
 }
 /******************************************************************************/
 /* PROCESS SEPS FOR ITEM SEPS ONLY                                            */
@@ -736,287 +730,286 @@ itemcond(       /* ARGUMENTS:               */
 void
 itemsep2(const char **spp, short *fl, FILE *fp)
 {
-	const char *sp;
-	char *sub, neg = 0;
-	response_t *cre;
-	int cap = 0;
-	cre = &(re[st_glob.r_current]);
-	sp = *spp;
-	num = 0;
+    const char *sp;
+    char *sub, neg = 0;
+    response_t *cre;
+    int cap = 0;
+    cre = &(re[st_glob.r_current]);
+    sp = *spp;
+    num = 0;
 
-	/* Get number */
-	zero = 0;
-	if (*sp == '^') {
-		cap = 1;
-		sp++;
-	}
-	if (*sp == 'z') {
-		zero = 1;
-		sp++;
-	} else if (*sp == 'Z') {
-		zero = 2;
-		sp++;
-	}
-	if (*sp == '-') {
-		neg = 1;
-		sp++;
-	}
-	while (isdigit(*sp)) {
-		num = num * 10 + (*sp - '0');
-		sp++;
-	}
-	if (neg)
-		num = -num;
+    /* Get number */
+    zero = 0;
+    if (*sp == '^') {
+        cap = 1;
+        sp++;
+    }
+    if (*sp == 'z') {
+        zero = 1;
+        sp++;
+    } else if (*sp == 'Z') {
+        zero = 2;
+        sp++;
+    }
+    if (*sp == '-') {
+        neg = 1;
+        sp++;
+    }
+    while (isdigit(*sp)) {
+        num = num * 10 + (*sp - '0');
+        sp++;
+    }
+    if (neg)
+        num = -num;
 
-	switch (*(sp++)) {
+    switch (*(sp++)) {
 
-		/* Item Function Codes */
-	case 'a':
-		if (!cre->fullname.empty())
-			putstring(cre->fullname, fp);
-		break;
-	case 'C':
-		if (confidx >= 0)
-			putstring(compress(conflist[confidx].name), fp);
-		break;
-	case 'h':
-		putstring(get_subj(confidx, st_glob.i_current - 1, sum), fp);
-		break;
-	case 'i':
-		number(st_glob.i_current, fp);
-		break;
-	case 'l':
-		if (!cre->login.empty())
-			putstring(cre->login, fp);
-		break;
-	case 'e': {
-		uid_t tuid = 0;
-		std::string tlogin;
-		std::string temail;
-		std::string tfullname;
-		std::string thome;
-		if (!cre->login.empty()) {
-			tlogin = cre->login;
-			const auto at = tlogin.find('@');
-			if (at != std::string::npos &&
-			    str::eq(std::string_view(tlogin).substr(at + 1), hostname))
-				tlogin.erase(at);
-			tuid = cre->uid;
-			if (get_user(&tuid, tlogin, tfullname, thome, temail))
-				putstring(temail, fp);
-			else
-				putstring(cre->login, fp);
-		} else
-			temail = email;
-		break;
-	}
-	case 'L':
-		wrapout(fp, cre->text[st_glob.l_current].c_str());
-		break;
+        /* Item Function Codes */
+    case 'a':
+        if (!cre->fullname.empty())
+            putstring(cre->fullname, fp);
+        break;
+    case 'C':
+        if (confidx >= 0)
+            putstring(compress(conflist[confidx].name), fp);
+        break;
+    case 'h':
+        putstring(get_subj(confidx, st_glob.i_current - 1, sum), fp);
+        break;
+    case 'i':
+        number(st_glob.i_current, fp);
+        break;
+    case 'l':
+        if (!cre->login.empty())
+            putstring(cre->login, fp);
+        break;
+    case 'e': {
+        uid_t tuid = 0;
+        std::string tlogin;
+        std::string temail;
+        std::string tfullname;
+        std::string thome;
+        if (!cre->login.empty()) {
+            tlogin = cre->login;
+            const auto at = tlogin.find('@');
+            if (at != std::string::npos &&
+                str::eq(std::string_view(tlogin).substr(at + 1), hostname))
+                tlogin.erase(at);
+            tuid = cre->uid;
+            if (get_user(&tuid, tlogin, tfullname, thome, temail))
+                putstring(temail, fp);
+            else
+                putstring(cre->login, fp);
+        } else
+            temail = email;
+        break;
+    }
+    case 'L':
+        wrapout(fp, cre->text[st_glob.l_current].c_str());
+        break;
 #ifdef NEWS
-	case 'm':
-		putstring(message_id(compress(conflist[confidx].name),
-		           st_glob.i_current, st_glob.r_current, re),
-		    fp);
-		break;
+    case 'm':
+        putstring(message_id(compress(conflist[confidx].name),
+                      st_glob.i_current, st_glob.r_current, re),
+            fp);
+        break;
 #endif
-	case 'n':
-		number(sum[st_glob.i_current - 1].nr - 1, fp);
-		break;
-	case 'N':
-		number(st_glob.l_current + 1, fp);
-		break;
-	case 'r':
-		number(st_glob.r_current, fp);
-		break;
-	case 's':
-		number((cre->flags & (RF_SCRIBBLED | RF_EXPIRED))
-		           ? 0
-		           : cre->text.size(),
-		    fp);
-		break;
-	case 'k':
-		number((cre->numchars + 1023) / 1024, fp);
-		break;
-	case 'q':
-		number(cre->numchars, fp);
-		break;
-	case 'K': /* KKK */
-		break;
-	case 'Q': /* KKK */
-		break;
-	case 'u':
-		number((short)cre->uid, fp);
-		/* *fl &= ~OF_UID; */
-		once &= ~IS_UID;
-		break;
-	case 'd':
-		if (show[depth])
-			wfputs(get_date(cre->date, num ? num : 1), fp);
-		/* *fl &= ~OF_DATE; */
-		once &= ~IS_DATE;
-		break;
-	case 't':
-		if (show[depth])
-			wfputs(get_date(cre->date, num), fp);
-		/* *fl &= ~OF_DATE; */
-		once &= ~IS_DATE;
-		break;
-	case 'p':
-		number((short)cre->parent - 1, fp);
-		once &= ~IS_PARENT;
-		break;
-	case '<': {
-		int tmp = once; /* save once */
-		const char *angle = strchr(sp, '>');
-		if (angle == NULL)
-			angle = sp + strlen(sp);
-		size_t len = angle - sp;
-		sub = estrndup(sp, len);
-		sp += len;
-		if (*sp == '>')
-			sp++;
-		once = 0;
-		fitemsep(fp, capexpand(sub, DM_VAR, cap), 1);
-		free(sub);
-		once = tmp;
-	} break;
-	case '{': {
-		int tmp = once; /* save once */
-		const char *brace = strchr(sp, '}');
-		if (brace == NULL)
-			brace = sp + strlen(sp);
-		size_t len = brace - sp;
-		sub = estrndup(sp, len);
-		sp += len;
-		if (*sp == '}')
-			sp++;
-		once = 0;
-		/* itemsep(capexpand(sub,DM_VAR,cap),1); */
-		fitemsep(fp, capexpand(sub, DM_VAR, cap), 1);
-		free(sub);
-		once = tmp;
-	} break;
-	case '(':
-		show[depth + 1] = itemcond(&sp, *fl);
-		depth++;
-		break; /* ) */
+    case 'n':
+        number(sum[st_glob.i_current - 1].nr - 1, fp);
+        break;
+    case 'N':
+        number(st_glob.l_current + 1, fp);
+        break;
+    case 'r':
+        number(st_glob.r_current, fp);
+        break;
+    case 's':
+        number(
+            (cre->flags & (RF_SCRIBBLED | RF_EXPIRED)) ? 0 : cre->text.size(),
+            fp);
+        break;
+    case 'k':
+        number((cre->numchars + 1023) / 1024, fp);
+        break;
+    case 'q':
+        number(cre->numchars, fp);
+        break;
+    case 'K': /* KKK */
+        break;
+    case 'Q': /* KKK */
+        break;
+    case 'u':
+        number((short)cre->uid, fp);
+        /* *fl &= ~OF_UID; */
+        once &= ~IS_UID;
+        break;
+    case 'd':
+        if (show[depth])
+            wfputs(get_date(cre->date, num ? num : 1), fp);
+        /* *fl &= ~OF_DATE; */
+        once &= ~IS_DATE;
+        break;
+    case 't':
+        if (show[depth])
+            wfputs(get_date(cre->date, num), fp);
+        /* *fl &= ~OF_DATE; */
+        once &= ~IS_DATE;
+        break;
+    case 'p':
+        number((short)cre->parent - 1, fp);
+        once &= ~IS_PARENT;
+        break;
+    case '<': {
+        int tmp = once; /* save once */
+        const char *angle = strchr(sp, '>');
+        if (angle == NULL)
+            angle = sp + strlen(sp);
+        size_t len = angle - sp;
+        sub = estrndup(sp, len);
+        sp += len;
+        if (*sp == '>')
+            sp++;
+        once = 0;
+        fitemsep(fp, capexpand(sub, DM_VAR, cap), 1);
+        free(sub);
+        once = tmp;
+    } break;
+    case '{': {
+        int tmp = once; /* save once */
+        const char *brace = strchr(sp, '}');
+        if (brace == NULL)
+            brace = sp + strlen(sp);
+        size_t len = brace - sp;
+        sub = estrndup(sp, len);
+        sp += len;
+        if (*sp == '}')
+            sp++;
+        once = 0;
+        /* itemsep(capexpand(sub,DM_VAR,cap),1); */
+        fitemsep(fp, capexpand(sub, DM_VAR, cap), 1);
+        free(sub);
+        once = tmp;
+    } break;
+    case '(':
+        show[depth + 1] = itemcond(&sp, *fl);
+        depth++;
+        break; /* ) */
 
-	default:
-		*spp = sp - 1;
-		miscsep(spp, fp);
-		return;
-	}
+    default:
+        *spp = sp - 1;
+        miscsep(spp, fp);
+        return;
+    }
 
-	*spp = sp;
+    *spp = sp;
 }
 /******************************************************************************/
 /* PROCESS CONDITIONS FOR CONF SEPS ONLY                                      */
 /******************************************************************************/
 char
-confcond(       /* ARGUMENTS:          */
+confcond(             /* ARGUMENTS:          */
     const char **spp, /* Separator string */
-    int idx,    /* Conference index */
+    int idx,          /* Conference index */
     status_t *st)
 {
-	struct stat stt;
-	const char *sp;
-	char ret = 0, no_t = 0;
+    struct stat stt;
+    const char *sp;
+    char ret = 0, no_t = 0;
 
-	sp = *spp;
-	if (*sp == '!' || *sp == '~') {
-		no_t = !no_t;
-		sp++;
-	}
-	for (num = 0; isdigit(*sp); sp++) num = num * 10 + (*sp - '0');
-	/*
-	for (int i = 0; i < depth; i++) {
-		std::print("   ");
-		std::print("{:1d}: {:c} ", i, *sp);
-	}
-	*/
-	switch (*(sp++)) {
-	case 'y':
-		lastnum = st->i_unseen;
-		ret = lastnum;
-		break;
-	case 'n':
-		lastnum = st->i_brandnew + st->i_newresp;
-		ret = lastnum;
-		break;
-	case 'b':
-		lastnum = st->i_brandnew;
-		ret = lastnum;
-		break;
-	case 'r':
-		lastnum = st->i_newresp;
-		ret = lastnum;
-		break;
-	case 'm':
-		ret = (status & S_MAIL);
-		break;
-	case 'x':
-		ret = (once & num); /* once &= ~num; */
-		break;
-	case 'N':
-		if (num >= 0 && num < CF_PUBLIC && idx >= 0) {
-			const auto path =
-			    str::join("/", {conflist[idx].location, compress(cfiles[num])});
-			if (stat(path.c_str(), &stt) || stt.st_size <= 0)
-				ret = 0;
-			else if (st->c_status & CS_JUSTJOINED)
-				ret = 1;
-			else
-				ret = (stt.st_mtime > st->parttime);
-		}
-		break;
-	case 'F':
-		if (num >= 0 && num < CF_PUBLIC && idx >= 0) {
-			const auto path =
-			    str::join("/", {conflist[idx].location, compress(cfiles[num])});
-			ret = !stat(path.c_str(), &stt);
-		}
-		break;
-	case 'O':
-		ret = (st->c_status & CS_OTHERCONF) ? 1 : 0;
-		break;
-	case 'C':
-		ret = (idx >= 0);
-		break;
-	case 'i':
-		ret = (st->i_first <= st->i_last);
-		break;
-	case 's':
-		ret = (st->c_status & CS_FW);
-		break;
-	case 'f':
-		if (num >= 0 && idx >= 0) {
-			const auto path = str::concat({conflist[idx].location, "/sum"});
-			ret = !stat(path.c_str(), &stt);
-		}
-		break;
-	case 'j':
-		ret = (st->c_status & CS_JUSTJOINED) ? 1 : 0;
-		break;
-		/* case 'l': ret= (st->c_status & CS_NORESPONSE); break;
-		 */
-	case 'B':
-		ret = (idx == confidx);
-		break;
-	case 'k':
-		ret = (once & IS_CFIDX); /* once &= ~IS_CFIDX; */
-		break;
+    sp = *spp;
+    if (*sp == '!' || *sp == '~') {
+        no_t = !no_t;
+        sp++;
+    }
+    for (num = 0; isdigit(*sp); sp++) num = num * 10 + (*sp - '0');
+    /*
+    for (int i = 0; i < depth; i++) {
+        std::print("   ");
+        std::print("{:1d}: {:c} ", i, *sp);
+    }
+    */
+    switch (*(sp++)) {
+    case 'y':
+        lastnum = st->i_unseen;
+        ret = lastnum;
+        break;
+    case 'n':
+        lastnum = st->i_brandnew + st->i_newresp;
+        ret = lastnum;
+        break;
+    case 'b':
+        lastnum = st->i_brandnew;
+        ret = lastnum;
+        break;
+    case 'r':
+        lastnum = st->i_newresp;
+        ret = lastnum;
+        break;
+    case 'm':
+        ret = (status & S_MAIL);
+        break;
+    case 'x':
+        ret = (once & num); /* once &= ~num; */
+        break;
+    case 'N':
+        if (num >= 0 && num < CF_PUBLIC && idx >= 0) {
+            const auto path =
+                str::join("/", {conflist[idx].location, compress(cfiles[num])});
+            if (stat(path.c_str(), &stt) || stt.st_size <= 0)
+                ret = 0;
+            else if (st->c_status & CS_JUSTJOINED)
+                ret = 1;
+            else
+                ret = (stt.st_mtime > st->parttime);
+        }
+        break;
+    case 'F':
+        if (num >= 0 && num < CF_PUBLIC && idx >= 0) {
+            const auto path =
+                str::join("/", {conflist[idx].location, compress(cfiles[num])});
+            ret = !stat(path.c_str(), &stt);
+        }
+        break;
+    case 'O':
+        ret = (st->c_status & CS_OTHERCONF) ? 1 : 0;
+        break;
+    case 'C':
+        ret = (idx >= 0);
+        break;
+    case 'i':
+        ret = (st->i_first <= st->i_last);
+        break;
+    case 's':
+        ret = (st->c_status & CS_FW);
+        break;
+    case 'f':
+        if (num >= 0 && idx >= 0) {
+            const auto path = str::concat({conflist[idx].location, "/sum"});
+            ret = !stat(path.c_str(), &stt);
+        }
+        break;
+    case 'j':
+        ret = (st->c_status & CS_JUSTJOINED) ? 1 : 0;
+        break;
+        /* case 'l': ret= (st->c_status & CS_NORESPONSE); break;
+         */
+    case 'B':
+        ret = (idx == confidx);
+        break;
+    case 'k':
+        ret = (once & IS_CFIDX); /* once &= ~IS_CFIDX; */
+        break;
 
-	default:
-		return misccond(spp);
-	}
-	/*
-	std::println("{}", ret);
-	*/
-	*spp = sp;
-	if (!show[depth])
-		return 0;
-	return (ret != 0) ^ no_t;
+    default:
+        return misccond(spp);
+    }
+    /*
+    std::println("{}", ret);
+    */
+    *spp = sp;
+    if (!show[depth])
+        return 0;
+    return (ret != 0) ^ no_t;
 }
 
 /******************************************************************************/
@@ -1030,188 +1023,186 @@ confsep2(                            /* ARGUMENTS: */
     FILE *fp                         /* Stream to output to */
 )
 {
-	char *sub, neg = 0;
-	const char *sp;
-	time_t t;
-	int cap = 0;
-	sp = *spp;
-	num = 0;
+    char *sub, neg = 0;
+    const char *sp;
+    time_t t;
+    int cap = 0;
+    sp = *spp;
+    num = 0;
 
-	/* Get number */
-	zero = 0;
-	if (*sp == '^') {
-		cap = 1;
-		sp++;
-	}
-	if (*sp == 'z') {
-		zero = 1;
-		sp++;
-	} else if (*sp == 'Z') {
-		zero = 2;
-		sp++;
-	}
-	if (*sp == '-') {
-		neg = 1;
-		sp++;
-	}
-	while (isdigit(*sp)) {
-		num = num * 10 + (*sp - '0');
-		sp++;
-	}
-	if (neg)
-		num = -num;
+    /* Get number */
+    zero = 0;
+    if (*sp == '^') {
+        cap = 1;
+        sp++;
+    }
+    if (*sp == 'z') {
+        zero = 1;
+        sp++;
+    } else if (*sp == 'Z') {
+        zero = 2;
+        sp++;
+    }
+    if (*sp == '-') {
+        neg = 1;
+        sp++;
+    }
+    while (isdigit(*sp)) {
+        num = num * 10 + (*sp - '0');
+        sp++;
+    }
+    if (neg)
+        num = -num;
 
-	switch (*(sp++)) {
+    switch (*(sp++)) {
 
-		/* Conference separators */
+        /* Conference separators */
 #ifdef NEWS
-	case 'A':
-		number(st->c_article, fp);
-		break;
+    case 'A':
+        number(st->c_article, fp);
+        break;
 #endif
-	case 'y':
-		number(st->i_unseen, fp);
-		break;
-	case 'n':
-		number(st->i_brandnew + st->i_newresp, fp);
-		break;
-	case 'b':
-		number(st->i_brandnew, fp);
-		break;
-	case 'C':
-		putstring(st->string, fp);
-		break;
-	case 'r':
-		number(st->i_newresp, fp);
-		break;
-	case 'N':
-		number(st->r_totalnewresp, fp);
-		break;
-	case 'k':
-		number(st->count, fp);
-		break;
-	case 'u':
-		putstring(fullname_in_conference(st), fp);
-		break;
-	case 'v':
-		putstring(login, fp);
-		break;
-	case 'w':
-		putstring(work, fp);
-		break;
-	case 'f':
-		number(st->i_first, fp);
-		break;
-	case 'L':
-		if (idx >= 0)
-			putstring(get_desc(compress(conflist[idx].name)), fp);
-		break;
-	case 'l':
-		number(st->i_last, fp);
-		break;
-	case 'Q':
-		if (idx < 0) {
-			putstring("Not in a conference!", fp);
-			qfail = 1;
-		}
-		break;
-	case 'i':
-		number(st->i_numitems, fp);
-		break;
-	case 't':
-		number((short)st->c_security & CT_VISIBLE, fp);
-		break;
-	case 's':
-		if (idx >= 0)
-			putstring(compress(conflist[idx].name), fp);
-		break;
-	case 'p': {
-		const auto config = get_config(idx);
-		if (config.size() > CF_PARTFILE)
-			putstring(config[CF_PARTFILE], fp);
-		break;
-	}
-	case 'd':
-		if (idx >= 0)
-			putstring(conflist[idx].location, fp);
-		break;
-	case 'q':
-		if (idx >= 0) {
-			const char *sh = conflist[idx].location.c_str();
-			const char *sh2;
-			for (sh2 = sh + strlen(sh) - 1;
-			     sh2 >= sh && *sh2 != '/'; sh2--)
-				;
-			putstring(sh2 + 1, fp);
-		}
-		break;
-	case 'o':
-		if (show[depth])
-			wfputs(get_date(st->parttime, num), fp);
-		break;
-	case 'm': /* NEW: lastmod of sum file, if any */
-		/*
-		if (idx < 0)
-			t = 0;
-		else {
-			const auto path = str::concat({conflist[idx].location, "/sum"});
-			t = 0;
-			if (stat(path.c_str(), &stt) == 0)
-				t = stt.st_mtime;
-		}
-		*/
-		t = st->sumtime;
-		if (show[depth])
-			wfputs(get_date(t, num), fp);
-		break;
-	case 'g':
-		if (num >= 0 && num < CF_PUBLIC && show[depth] && idx >= 0)
-			more(conflist[idx].location, compress(cfiles[num]));
-		break;
-	case '<': {
-		int tmp = once; /* save once */
-		const char *angle = strchr(sp, '>');
-		if (angle == NULL)
-			angle = sp + strlen(sp);
-		size_t len = angle - sp;
-		sub = estrndup(sp, len);
-		sp += len;
-		if (*sp == '>')
-			sp++;
-		once = 0;
-		confsep(capexpand(sub, DM_VAR, cap), idx, st, part, 1);
-		free(sub);
-		once = tmp;
-	} break;
-	case '{': {
-		int tmp = once; /* save once */
-		const char *brace = strchr(sp, '}');
-		if (brace == NULL)
-			brace = sp + strlen(sp);
-		size_t len = brace - sp;
-		sub = estrndup(sp, len);
-		sp += len;
-		if (*sp == '}')
-			sp++;
-		once = 0;
-		confsep(capexpand(sub, DM_VAR, cap), idx, st, part, 1);
-		free(sub);
-		once = tmp;
-	} break;
-	case '(': /* Get number */
-		/* for (num=0; isdigit(*sp); sp++) num=
-		 * num*10+(*sp-'0'); */
-		show[depth + 1] = confcond(&sp, idx, st); /* for ultrix */
-		depth++;
-		break; /* ) */
+    case 'y':
+        number(st->i_unseen, fp);
+        break;
+    case 'n':
+        number(st->i_brandnew + st->i_newresp, fp);
+        break;
+    case 'b':
+        number(st->i_brandnew, fp);
+        break;
+    case 'C':
+        putstring(st->string, fp);
+        break;
+    case 'r':
+        number(st->i_newresp, fp);
+        break;
+    case 'N':
+        number(st->r_totalnewresp, fp);
+        break;
+    case 'k':
+        number(st->count, fp);
+        break;
+    case 'u':
+        putstring(fullname_in_conference(st), fp);
+        break;
+    case 'v':
+        putstring(login, fp);
+        break;
+    case 'w':
+        putstring(work, fp);
+        break;
+    case 'f':
+        number(st->i_first, fp);
+        break;
+    case 'L':
+        if (idx >= 0)
+            putstring(get_desc(compress(conflist[idx].name)), fp);
+        break;
+    case 'l':
+        number(st->i_last, fp);
+        break;
+    case 'Q':
+        if (idx < 0) {
+            putstring("Not in a conference!", fp);
+            qfail = 1;
+        }
+        break;
+    case 'i':
+        number(st->i_numitems, fp);
+        break;
+    case 't':
+        number((short)st->c_security & CT_VISIBLE, fp);
+        break;
+    case 's':
+        if (idx >= 0)
+            putstring(compress(conflist[idx].name), fp);
+        break;
+    case 'p': {
+        const auto config = get_config(idx);
+        if (config.size() > CF_PARTFILE)
+            putstring(config[CF_PARTFILE], fp);
+        break;
+    }
+    case 'd':
+        if (idx >= 0)
+            putstring(conflist[idx].location, fp);
+        break;
+    case 'q':
+        if (idx >= 0) {
+            const char *sh = conflist[idx].location.c_str();
+            const char *sh2;
+            for (sh2 = sh + strlen(sh) - 1; sh2 >= sh && *sh2 != '/'; sh2--);
+            putstring(sh2 + 1, fp);
+        }
+        break;
+    case 'o':
+        if (show[depth])
+            wfputs(get_date(st->parttime, num), fp);
+        break;
+    case 'm': /* NEW: lastmod of sum file, if any */
+        /*
+        if (idx < 0)
+            t = 0;
+        else {
+            const auto path = str::concat({conflist[idx].location, "/sum"});
+            t = 0;
+            if (stat(path.c_str(), &stt) == 0)
+                t = stt.st_mtime;
+        }
+        */
+        t = st->sumtime;
+        if (show[depth])
+            wfputs(get_date(t, num), fp);
+        break;
+    case 'g':
+        if (num >= 0 && num < CF_PUBLIC && show[depth] && idx >= 0)
+            more(conflist[idx].location, compress(cfiles[num]));
+        break;
+    case '<': {
+        int tmp = once; /* save once */
+        const char *angle = strchr(sp, '>');
+        if (angle == NULL)
+            angle = sp + strlen(sp);
+        size_t len = angle - sp;
+        sub = estrndup(sp, len);
+        sp += len;
+        if (*sp == '>')
+            sp++;
+        once = 0;
+        confsep(capexpand(sub, DM_VAR, cap), idx, st, part, 1);
+        free(sub);
+        once = tmp;
+    } break;
+    case '{': {
+        int tmp = once; /* save once */
+        const char *brace = strchr(sp, '}');
+        if (brace == NULL)
+            brace = sp + strlen(sp);
+        size_t len = brace - sp;
+        sub = estrndup(sp, len);
+        sp += len;
+        if (*sp == '}')
+            sp++;
+        once = 0;
+        confsep(capexpand(sub, DM_VAR, cap), idx, st, part, 1);
+        free(sub);
+        once = tmp;
+    } break;
+    case '(': /* Get number */
+        /* for (num=0; isdigit(*sp); sp++) num=
+         * num*10+(*sp-'0'); */
+        show[depth + 1] = confcond(&sp, idx, st); /* for ultrix */
+        depth++;
+        break; /* ) */
 
-	default:
-		*spp = sp - 1;
-		miscsep(spp, fp);
-		return;
-	}
+    default:
+        *spp = sp - 1;
+        miscsep(spp, fp);
+        return;
+    }
 
-	*spp = sp;
+    *spp = sp;
 }
 /******************************************************************************/
 /* SET "ONCE-ONLY" FLAGS VALUE                                                */
@@ -1221,7 +1212,7 @@ sepinit(  /* ARGUMENTS:         */
     int x /* Flags to set    */
 )
 {
-	once |= x;
+    once |= x;
 }
 
 /* sep: Separator variable */
@@ -1229,158 +1220,160 @@ sepinit(  /* ARGUMENTS:         */
 void
 fitemsep(FILE *fp, const std::string_view &sep, int fl)
 {
-	const char *sp, *tp;
-	response_t *cre;
-	int start_depth = depth, start_show = show[depth];
-	int start_newline = newline;
-	char str[1024];
+    const char *sp, *tp;
+    response_t *cre;
+    int start_depth = depth, start_show = show[depth];
+    int start_newline = newline;
+    char str[1024];
 
-	if (sep.empty())
-		return;
+    if (sep.empty())
+        return;
 
-	const auto len = std::min(sizeof(str) - 1, sep.size());
-	memcpy(str, sep.data(), len);
-	str[len] = 0;
+    const auto len = std::min(sizeof(str) - 1, sep.size());
+    memcpy(str, sep.data(), len);
+    str[len] = 0;
 
-	/* Force %c */
-	if (fl)
-		strlcat(str, "%c", sizeof(str));
+    /* Force %c */
+    if (fl)
+        strlcat(str, "%c", sizeof(str));
 
-	/* get status without trashing subj's in memory */
-	cre = &(re[st_glob.r_current]);
+    /* get status without trashing subj's in memory */
+    cre = &(re[st_glob.r_current]);
 
-	init_show();
-	newline = 1;
-	sp = str;
+    init_show();
+    newline = 1;
+    sp = str;
 
-	for (;;) {
-		switch (*sp) {
-		case '$': {
-			int cap = 0;
-			if (sp[1] == '^') {
-				cap = 1;
-				sp++;
-			}
-			if (sp[1] != '{') {
-				if (show[depth])
-					wfputc(*sp++, fp);
-				else
-					sp++;
-			} else {
-				sp += 2;
-				const char *brace = strchr(sp, '}');
-				if (brace == NULL)
-					brace = sp + strlen(brace);
-				size_t len = brace - sp;
-				char *sub = estrndup(sp, len);
-				sp += len;
-				if (*sp == '}')
-					sp++;
-				if (show[depth])
-					wfputs(capexpand(sub, DM_VAR, cap), fp);
-				free(sub);
-			}
-			break;
-		}
-		case '%':
-			sp++;
-			itemsep2(&sp, &st_glob.opt_flags, fp);
-			break;
-		case '\0':
-			if ((once & IS_UID) &&
-			    ((st_glob.opt_flags & OF_UID) || (flags & O_UID)))
-				std::print(fp, " uid {}", cre->uid);
-			if ((once & IS_DATE) &&
-			    ((st_glob.opt_flags & OF_DATE) || (flags & O_DATE)))
-				std::print(fp, " on {:.24}", get_date(cre->date, 0));
-			if ((once & IS_RETIRED) &&
-			    (sum[st_glob.i_current - 1].flags & IF_RETIRED))
-				std::print(fp, "\n   <{} is retired>", topic());
-			if ((once & IS_FORGOTTEN) &&
-			    (sum[st_glob.i_current - 1].flags & IF_FORGOTTEN))
-				std::print(fp, "\n   <{} is forgotten>", topic());
-			if ((once & IS_FROZEN) &&
-			    (sum[st_glob.i_current - 1].flags & IF_FROZEN))
-				std::print(fp, "\n   <{} is frozen>", topic());
-			if ((once & IS_LINKED) &&
-			    (sum[st_glob.i_current - 1].flags & IF_LINKED))
-				std::print(fp, "\n   <linked {}>", topic());
-			if ((once & IS_PARENT) && (cre->parent > 0))
-				std::print(fp, "   <response to #{}>", cre->parent - 1);
+    for (;;) {
+        switch (*sp) {
+        case '$': {
+            int cap = 0;
+            if (sp[1] == '^') {
+                cap = 1;
+                sp++;
+            }
+            if (sp[1] != '{') {
+                if (show[depth])
+                    wfputc(*sp++, fp);
+                else
+                    sp++;
+            } else {
+                sp += 2;
+                const char *brace = strchr(sp, '}');
+                if (brace == NULL)
+                    brace = sp + strlen(brace);
+                size_t len = brace - sp;
+                char *sub = estrndup(sp, len);
+                sp += len;
+                if (*sp == '}')
+                    sp++;
+                if (show[depth])
+                    wfputs(capexpand(sub, DM_VAR, cap), fp);
+                free(sub);
+            }
+            break;
+        }
+        case '%':
+            sp++;
+            itemsep2(&sp, &st_glob.opt_flags, fp);
+            break;
+        case '\0':
+            if ((once & IS_UID) &&
+                ((st_glob.opt_flags & OF_UID) || (flags & O_UID)))
+                std::print(fp, " uid {}", cre->uid);
+            if ((once & IS_DATE) &&
+                ((st_glob.opt_flags & OF_DATE) || (flags & O_DATE)))
+                std::print(fp, " on {:.24}", get_date(cre->date, 0));
+            if ((once & IS_RETIRED) &&
+                (sum[st_glob.i_current - 1].flags & IF_RETIRED))
+                std::print(fp, "\n   <{} is retired>", topic());
+            if ((once & IS_FORGOTTEN) &&
+                (sum[st_glob.i_current - 1].flags & IF_FORGOTTEN))
+                std::print(fp, "\n   <{} is forgotten>", topic());
+            if ((once & IS_FROZEN) &&
+                (sum[st_glob.i_current - 1].flags & IF_FROZEN))
+                std::print(fp, "\n   <{} is frozen>", topic());
+            if ((once & IS_LINKED) &&
+                (sum[st_glob.i_current - 1].flags & IF_LINKED))
+                std::print(fp, "\n   <linked {}>", topic());
+            if ((once & IS_PARENT) && (cre->parent > 0))
+                std::print(fp, "   <response to #{}>", cre->parent - 1);
 
-			if (once & IS_CENSORED) {
-				if (cre->flags & RF_EXPIRED)
-					wfputs("   <expired>", fp);
-				else if (cre->flags & RF_SCRIBBLED) {
-					if (cre->numchars > 8 && !cre->text.empty() && (flags & O_SCRIBBLER)) {
-						char buff[9];
-						int i;
-						for (i = 0; i < 8 && cre->text[0][i] != ' '; i++)
-							buff[i] = cre->text[0][i];
-						buff[i] = '\0';
-						std::println(fp, "   <censored & scribbled by {}>", buff);
-					} else {
-						int tmp = once; /* save once */
-						once = 0;
-						itemsep(expand("scribbled", DM_VAR), 1);
-						once = tmp;
-						/* wfputs(expand("scribbled", DM_VAR),fp); */
-					}
-				} else if (cre->flags & RF_CENSORED) {
-					int tmp = once; /* save once */
-					once = 0;
-					itemsep(expand("censored", DM_VAR), 1);
-					once = tmp;
-					/* wfputs(expand("censored", DM_VAR),fp); */
-				}
-			}
-			if (newline)
-				wfputc('\n', fp);
-			once = 0;
-			if (fp)
-				fflush(fp);  /* flush when done with
-				              * wfput stuff */
-			depth = start_depth; /* restore original depth */
-			show[depth] = start_show;
-			newline = start_newline;
-			return;
-		case '\\': /* Translate lchar into rchar */
-			sp++;
-			tp = strchr(lchars, *sp);
-			if (tp) { /* if *sp is 0 byte, will insert a 0
-				   * byte */
-				if (show[depth])
-					wfputc(rchars[tp - lchars], fp);
-				sp++;
-				break;
-			} /* else fall through into default */
-		default:
-			if (show[depth])
-				wfputc(*sp++, fp);
-			else
-				sp++;
-		}
-	}
+            if (once & IS_CENSORED) {
+                if (cre->flags & RF_EXPIRED)
+                    wfputs("   <expired>", fp);
+                else if (cre->flags & RF_SCRIBBLED) {
+                    if (cre->numchars > 8 && !cre->text.empty() &&
+                        (flags & O_SCRIBBLER)) {
+                        char buff[9];
+                        int i;
+                        for (i = 0; i < 8 && cre->text[0][i] != ' '; i++)
+                            buff[i] = cre->text[0][i];
+                        buff[i] = '\0';
+                        std::println(
+                            fp, "   <censored & scribbled by {}>", buff);
+                    } else {
+                        int tmp = once; /* save once */
+                        once = 0;
+                        itemsep(expand("scribbled", DM_VAR), 1);
+                        once = tmp;
+                        /* wfputs(expand("scribbled", DM_VAR),fp); */
+                    }
+                } else if (cre->flags & RF_CENSORED) {
+                    int tmp = once; /* save once */
+                    once = 0;
+                    itemsep(expand("censored", DM_VAR), 1);
+                    once = tmp;
+                    /* wfputs(expand("censored", DM_VAR),fp); */
+                }
+            }
+            if (newline)
+                wfputc('\n', fp);
+            once = 0;
+            if (fp)
+                fflush(fp);      /* flush when done with
+                                  * wfput stuff */
+            depth = start_depth; /* restore original depth */
+            show[depth] = start_show;
+            newline = start_newline;
+            return;
+        case '\\': /* Translate lchar into rchar */
+            sp++;
+            tp = strchr(lchars, *sp);
+            if (tp) { /* if *sp is 0 byte, will insert a 0
+                       * byte */
+                if (show[depth])
+                    wfputc(rchars[tp - lchars], fp);
+                sp++;
+                break;
+            } /* else fall through into default */
+        default:
+            if (show[depth])
+                wfputc(*sp++, fp);
+            else
+                sp++;
+        }
+    }
 }
 /******************************************************************************/
 /* PROCESS ITEMSEP STRING                                                     */
 /* Output to pipe, if one is open, else to stdout                             */
 /******************************************************************************/
 void
-itemsep(       /* ARGUMENTS: */
+itemsep(                         /* ARGUMENTS: */
     const std::string_view &sep, /* Separator variable */
-    int fl     /* Force %c? */
+    int fl                       /* Force %c? */
 )
 {
-	FILE *fp;
+    FILE *fp;
 
-	if (status & S_EXECUTE)
-		fp = 0;
-	else if (status & S_PAGER)
-		fp = st_glob.outp;
-	else
-		fp = stdout;
-	fitemsep(fp, sep, fl);
+    if (status & S_EXECUTE)
+        fp = 0;
+    else if (status & S_PAGER)
+        fp = st_glob.outp;
+    else
+        fp = stdout;
+    fitemsep(fp, sep, fl);
 }
 /******************************************************************************/
 /* PROCESS CONFSEP STRING                                                     */
@@ -1393,143 +1386,143 @@ confsep(                             /* ARGUMENTS:                         */
     int fl                           /* Force %c? */
 )
 {
-	const char *sp, *tp;
-	FILE *fp;
-	char str[1024];
-	int start_depth = depth; /* save original depth */
-	int start_show = show[depth];
-	int start_newline = newline;
+    const char *sp, *tp;
+    FILE *fp;
+    char str[1024];
+    int start_depth = depth; /* save original depth */
+    int start_show = show[depth];
+    int start_newline = newline;
 
-	/*
-	  str = expand(sep,DM_VAR);
-	  if (!str) str=sep;
-	*/
-	if (sep.empty())
-		return;
+    /*
+      str = expand(sep,DM_VAR);
+      if (!str) str=sep;
+    */
+    if (sep.empty())
+        return;
 
-	auto len = std::min(sizeof(str) - 1, sep.size());
-	memcpy(str, sep.data(), len);
-	str[len] = 0;
+    auto len = std::min(sizeof(str) - 1, sep.size());
+    memcpy(str, sep.data(), len);
+    str[len] = 0;
 
-	/* Compatibility: force "...prompt" to end in \c */
-	if (fl)
-		strlcat(str, "%c", sizeof(str));
+    /* Compatibility: force "...prompt" to end in \c */
+    if (fl)
+        strlcat(str, "%c", sizeof(str));
 
-	if (status & S_EXECUTE)
-		fp = 0;
-	else if (status & S_PAGER)
-		fp = st_glob.outp;
-	else
-		fp = stdout;
+    if (status & S_EXECUTE)
+        fp = 0;
+    else if (status & S_PAGER)
+        fp = st_glob.outp;
+    else
+        fp = stdout;
 
-	init_show();
-	newline = 1;
-	qfail = 0;
-	sp = str;
+    init_show();
+    newline = 1;
+    qfail = 0;
+    sp = str;
 
-	while (!qfail) {
-		switch (*sp) {
-		case '$': {
-			char *sub;
-			int cap = 0;
-			if (sp[1] == '^') {
-				cap = 1;
-				sp++;
-			}
-			if (sp[1] != '{') {
-				if (show[depth])
-					wfputc(*sp++, fp);
-				else
-					sp++;
-			} else {
-				sp += 2;
-				const char *brace = strchr(sp, '}');
-				if (brace == NULL)
-					brace = brace + strlen(sp);
-				size_t len = brace - sp;
-				sub = estrndup(sp, len);
-				sp += len;
-				if (*sp == '}')
-					sp++;
-				if (show[depth])
-					wfputs(capexpand(sub, DM_VAR, cap), fp);
-				free(sub);
-			}
-			break;
-		}
-		case '%':
-			sp++;
-			confsep2(&sp, idx, st, part, fp);
-			break;
-		case '\0':
-			if (newline)
-				wfputc('\n', fp);
-			once = 0;
-			if (fp)
-				fflush(fp);  /* flush when done with
-				              * wfput stuff */
-			depth = start_depth; /* restore original depth */
-			show[depth] = start_show;
-			newline = start_newline;
-			return;
-		case '\\': /* Translate lchar into rchar */
-			sp++;
-			tp = strchr(lchars, *sp);
-			if (tp) { /* if *sp is 0 byte, will insert a 0
-				   * byte */
-				if (show[depth])
-					wfputc(rchars[tp - lchars], fp);
-				sp++;
-				break;
-			} /* else fall through into default */
-		default:
-			if (show[depth])
-				wfputc(*sp++, fp);
-			else
-				sp++;
-			break;
-		}
-	}
-	if (newline)
-		wfputc('\n', fp);
-	if (fp)
-		fflush(fp);
-	depth = start_depth; /* restore original depth */
-	show[depth] = start_show;
-	newline = start_newline;
+    while (!qfail) {
+        switch (*sp) {
+        case '$': {
+            char *sub;
+            int cap = 0;
+            if (sp[1] == '^') {
+                cap = 1;
+                sp++;
+            }
+            if (sp[1] != '{') {
+                if (show[depth])
+                    wfputc(*sp++, fp);
+                else
+                    sp++;
+            } else {
+                sp += 2;
+                const char *brace = strchr(sp, '}');
+                if (brace == NULL)
+                    brace = brace + strlen(sp);
+                size_t len = brace - sp;
+                sub = estrndup(sp, len);
+                sp += len;
+                if (*sp == '}')
+                    sp++;
+                if (show[depth])
+                    wfputs(capexpand(sub, DM_VAR, cap), fp);
+                free(sub);
+            }
+            break;
+        }
+        case '%':
+            sp++;
+            confsep2(&sp, idx, st, part, fp);
+            break;
+        case '\0':
+            if (newline)
+                wfputc('\n', fp);
+            once = 0;
+            if (fp)
+                fflush(fp);      /* flush when done with
+                                  * wfput stuff */
+            depth = start_depth; /* restore original depth */
+            show[depth] = start_show;
+            newline = start_newline;
+            return;
+        case '\\': /* Translate lchar into rchar */
+            sp++;
+            tp = strchr(lchars, *sp);
+            if (tp) { /* if *sp is 0 byte, will insert a 0
+                       * byte */
+                if (show[depth])
+                    wfputc(rchars[tp - lchars], fp);
+                sp++;
+                break;
+            } /* else fall through into default */
+        default:
+            if (show[depth])
+                wfputc(*sp++, fp);
+            else
+                sp++;
+            break;
+        }
+    }
+    if (newline)
+        wfputc('\n', fp);
+    if (fp)
+        fflush(fp);
+    depth = start_depth; /* restore original depth */
+    show[depth] = start_show;
+    newline = start_newline;
 }
 
 char *
 get_sep(const char **pEptr)
 {
-	static char buff[MAX_LINE_LENGTH];
-	char oldeval[MAX_LINE_LENGTH];
+    static char buff[MAX_LINE_LENGTH];
+    char oldeval[MAX_LINE_LENGTH];
 
-	int tmp_status;
-	tmp_status = status;
-	strcpy(oldeval, evalbuf);
-	switch (mode) {
-	case M_RFP:
-	case M_TEXT:
-	case M_EDB:
-		evalbuf[0] = '\0';
-		status |= S_EXECUTE;
-		itemsep2(pEptr, &st_glob.opt_flags, NULL);
-		status &= ~S_EXECUTE;
-		break;
+    int tmp_status;
+    tmp_status = status;
+    strcpy(oldeval, evalbuf);
+    switch (mode) {
+    case M_RFP:
+    case M_TEXT:
+    case M_EDB:
+        evalbuf[0] = '\0';
+        status |= S_EXECUTE;
+        itemsep2(pEptr, &st_glob.opt_flags, NULL);
+        status &= ~S_EXECUTE;
+        break;
 
-	case M_OK:
-	case M_JOQ:
-	default:
-		evalbuf[0] = '\0';
-		status |= S_EXECUTE;
-		confsep2(pEptr, confidx, &st_glob, part, NULL);
-		status &= ~S_EXECUTE;
-		break;
-	}
-	strcpy(buff, evalbuf);
-	strcpy(evalbuf, oldeval);
-	status = tmp_status;
+    case M_OK:
+    case M_JOQ:
+    default:
+        evalbuf[0] = '\0';
+        status |= S_EXECUTE;
+        confsep2(pEptr, confidx, &st_glob, part, NULL);
+        status &= ~S_EXECUTE;
+        break;
+    }
+    strcpy(buff, evalbuf);
+    strcpy(evalbuf, oldeval);
+    status = tmp_status;
 
-	return buff;
+    return buff;
 }

--- a/str.cc
+++ b/str.cc
@@ -13,200 +13,201 @@
 #include <string_view>
 #include <vector>
 
-namespace str {
+namespace str
+{
 
 std::intmax_t
 toi(const std::string_view &str)
 {
-	const auto *b = str.data();
-	const auto *e = b + str.size();
-	std::intmax_t i = 0;
-	std::from_chars(b, e, i);
-	return i;
+    const auto *b = str.data();
+    const auto *e = b + str.size();
+    std::intmax_t i = 0;
+    std::from_chars(b, e, i);
+    return i;
 }
 
 std::string
 join(const std::string_view &sep, const std::vector<std::string_view> &strs)
 {
-	std::string out;
-	std::string_view p;
-	for (const auto &s : strs) {
-		out.append(p);
-		out.append(s);
-		p = sep;
-	}
-	return out;
+    std::string out;
+    std::string_view p;
+    for (const auto &s : strs) {
+        out.append(p);
+        out.append(s);
+        p = sep;
+    }
+    return out;
 }
 
 std::string
 concat(const std::vector<std::string_view> &strs)
 {
-	return join("", strs);
+    return join("", strs);
 }
-
 
 std::string_view
 ltrim(std::string_view s, const std::string_view ws)
 {
-	auto f = s.find_first_not_of(ws);
-	if (f == s.npos)
-		return {};
-	s.remove_prefix(f);
-	return s;
+    auto f = s.find_first_not_of(ws);
+    if (f == s.npos)
+        return {};
+    s.remove_prefix(f);
+    return s;
 }
 
 std::string_view
 rtrim(std::string_view s, const std::string_view ws)
 {
-	auto l = s.find_last_not_of(ws);
-	if (l == s.npos)
-		return {};
-	s.remove_suffix(s.length() - l - 1);
-	return s;
+    auto l = s.find_last_not_of(ws);
+    if (l == s.npos)
+        return {};
+    s.remove_suffix(s.length() - l - 1);
+    return s;
 }
 
 std::string_view
 trim(std::string_view s, const std::string_view ws)
 {
-	return rtrim(ltrim(s, ws));
+    return rtrim(ltrim(s, ws));
 }
 
 bool
 eq(const std::string_view &a, const std::string_view &b)
 {
-	return a == b;
+    return a == b;
 }
 
 bool
 eqcase(const std::string_view &a, const std::string_view &b)
 {
-	if (a.length() != b.length())
-		return false;
-	for (const auto [ac, bc]: std::views::zip(a, b))
-		if (tolower(ac) != tolower(bc))
-			return false;
-	return true;
+    if (a.length() != b.length())
+        return false;
+    for (const auto [ac, bc] : std::views::zip(a, b))
+        if (tolower(ac) != tolower(bc))
+            return false;
+    return true;
 }
 
 bool
 starteqcase(const std::string_view &s, const std::string_view &prefix)
 {
-	const auto start = s.substr(0, prefix.length());
-	return eqcase(start, prefix);
+    const auto start = s.substr(0, prefix.length());
+    return eqcase(start, prefix);
 }
 
 // Returns true IFF s matches m.
 bool
 match(const std::string_view &s, const std::string_view &m)
 {
-	auto seplen = 1;
-	auto pos = m.find('_');
-	if (pos == m.npos) {
-		pos = m.length();
-		seplen = 0;
-	}
-	if (pos == 0)
-		return s.empty();
-	if (s.length() < pos || m.length() - seplen < s.length())
-		return false;
-	const auto sp = s.begin() + pos;
-	const std::string_view sbefore(s.begin(), sp);
-	const std::string_view safter(sp, s.end());
-	const auto mp = m.begin() + pos;
-	const std::string_view mbefore(m.begin(), mp);
-	const std::string_view mafter(mp + seplen, mp + seplen + safter.length());
-	return eqcase(sbefore, mbefore) && eqcase(safter, mafter);
+    auto seplen = 1;
+    auto pos = m.find('_');
+    if (pos == m.npos) {
+        pos = m.length();
+        seplen = 0;
+    }
+    if (pos == 0)
+        return s.empty();
+    if (s.length() < pos || m.length() - seplen < s.length())
+        return false;
+    const auto sp = s.begin() + pos;
+    const std::string_view sbefore(s.begin(), sp);
+    const std::string_view safter(sp, s.end());
+    const auto mp = m.begin() + pos;
+    const std::string_view mbefore(m.begin(), mp);
+    const std::string_view mafter(mp + seplen, mp + seplen + safter.length());
+    return eqcase(sbefore, mbefore) && eqcase(safter, mafter);
 }
 
 bool
 contains(const std::vector<std::string> &v, const std::string_view &key)
 {
-	const auto end = v.end();
-	const auto it = std::find(v.begin(), end, key);
-	return it != end;
+    const auto end = v.end();
+    const auto it = std::find(v.begin(), end, key);
+    return it != end;
 }
 
 bool
 contains(const std::vector<std::string_view> &v, const std::string_view &key)
 {
-	const auto end = v.end();
-	const auto it = std::find(v.begin(), end, key);
-	return it != end;
+    const auto end = v.end();
+    const auto it = std::find(v.begin(), end, key);
+    return it != end;
 }
 
-
 std::vector<std::string_view>
-split(const std::string_view &str, const std::string_view &sep, bool discard_empty)
+split(const std::string_view &str, const std::string_view &sep,
+    bool discard_empty)
 {
-	if (str.empty())
-		return {};
-	if (sep.empty())
-		return {str};
-	std::vector<std::string_view> v;
-	std::size_t pos{}, ppos{};
-	do {
-		pos = str.find(sep, ppos);
-		const auto end = pos == str.npos ? str.length() : pos;
-		const auto len = end - ppos;
-		const auto token = str.substr(ppos, len);
-		if (!discard_empty || !token.empty())
-			v.push_back(trim(token));
-		ppos = pos + 1;
-	} while (pos != str.npos);
-	return v;
+    if (str.empty())
+        return {};
+    if (sep.empty())
+        return {str};
+    std::vector<std::string_view> v;
+    std::size_t pos{}, ppos{};
+    do {
+        pos = str.find(sep, ppos);
+        const auto end = pos == str.npos ? str.length() : pos;
+        const auto len = end - ppos;
+        const auto token = str.substr(ppos, len);
+        if (!discard_empty || !token.empty())
+            v.push_back(trim(token));
+        ppos = pos + 1;
+    } while (pos != str.npos);
+    return v;
 }
 
 std::vector<std::string>
-splits(const std::string_view &str, const std::string_view &sep, bool discard_empty)
+splits(const std::string_view &str, const std::string_view &sep,
+    bool discard_empty)
 {
-	const auto v =  str::split(str, sep, discard_empty);
-	std::vector<std::string> sv;
-	std::transform(v.begin(), v.end(), std::back_inserter(sv), [](auto v) { return std::string(v); });
-	return sv;
+    const auto v = str::split(str, sep, discard_empty);
+    std::vector<std::string> sv;
+    std::transform(v.begin(), v.end(), std::back_inserter(sv),
+        [](auto v) { return std::string(v); });
+    return sv;
 }
 
 // Removes surrounding quotes from a string.
 std::string
 unquote(const std::string_view &str)
 {
-	if (str.empty())
-		return "";
-	const auto q = str.front();
-	if (q != '"' && q != '\'')
-		return std::string(str);
-	std::string out;
-	for (auto it = str.cbegin() + 1; it != str.cend() && *it != q; ++it) {
-		const auto next = it + 1;
-		if (*it == '\\' && next != str.end() && *next == q)
-			it = next;
-		out.push_back(*it);
-	}
-	return out;
+    if (str.empty())
+        return "";
+    const auto q = str.front();
+    if (q != '"' && q != '\'')
+        return std::string(str);
+    std::string out;
+    for (auto it = str.cbegin() + 1; it != str.cend() && *it != q; ++it) {
+        const auto next = it + 1;
+        if (*it == '\\' && next != str.end() && *next == q)
+            it = next;
+        out.push_back(*it);
+    }
+    return out;
 }
 
 std::string &
 lowercase(std::string &str)
 {
-	for (auto &c: str)
-		c = tolower(c);
-	return str;
+    for (auto &c : str) c = tolower(c);
+    return str;
 }
 
 std::string
 lowercase(const std::string_view &str)
 {
-	std::string s(str);
-	lowercase(s);
-	return s;
+    std::string s(str);
+    lowercase(s);
+    return s;
 }
 
 // Returns a new string that is `s` with any of the given characters removed.
 std::string
 strip(const std::string_view &s, const std::string_view &chars)
 {
-	std::string out(s);
-	std::erase_if(out, [&](char c) { return chars.find(c) != chars.npos; });
-	return out;
+    std::string out(s);
+    std::erase_if(out, [&](char c) { return chars.find(c) != chars.npos; });
+    return out;
 }
 
-}  // namespace str
+} // namespace str

--- a/str_test.cc
+++ b/str_test.cc
@@ -9,197 +9,225 @@
 
 #include "str.h"
 
-TEST(StrTests, ToI) {
-	EXPECT_EQ(str::toi(""), 0);
-	EXPECT_EQ(str::toi("a"), 0);
-	EXPECT_EQ(str::toi("0"), 0);
-	EXPECT_EQ(str::toi("10"), 10);
-	EXPECT_EQ(str::toi("123abc"), 123);
-	EXPECT_EQ(str::toi("abc123"), 0);
+TEST(StrTests, ToI)
+{
+    EXPECT_EQ(str::toi(""), 0);
+    EXPECT_EQ(str::toi("a"), 0);
+    EXPECT_EQ(str::toi("0"), 0);
+    EXPECT_EQ(str::toi("10"), 10);
+    EXPECT_EQ(str::toi("123abc"), 123);
+    EXPECT_EQ(str::toi("abc123"), 0);
 }
 
-TEST(StrTests, ConcatEmpty) {
-	const std::vector<std::string_view> empty;
-	EXPECT_EQ(str::concat(empty), "");
+TEST(StrTests, ConcatEmpty)
+{
+    const std::vector<std::string_view> empty;
+    EXPECT_EQ(str::concat(empty), "");
 }
 
-TEST(StrTests, ConcatSingle) {
-	const std::vector<std::string_view> one{"hi"};
-	EXPECT_EQ(str::concat(one), "hi");
+TEST(StrTests, ConcatSingle)
+{
+    const std::vector<std::string_view> one{"hi"};
+    EXPECT_EQ(str::concat(one), "hi");
 }
 
-TEST(StrTests, ConcatMulti) {
-	const std::vector<std::string_view> two{"hi", "there"};
-	EXPECT_EQ(str::concat(two), "hithere");
+TEST(StrTests, ConcatMulti)
+{
+    const std::vector<std::string_view> two{"hi", "there"};
+    EXPECT_EQ(str::concat(two), "hithere");
 }
 
-TEST(StrTests, JoinEmpty) {
-	const std::vector<std::string_view> empty;
-	EXPECT_EQ(str::join(",", empty), "");
+TEST(StrTests, JoinEmpty)
+{
+    const std::vector<std::string_view> empty;
+    EXPECT_EQ(str::join(",", empty), "");
 }
 
-TEST(StrTests, JoinSingle) {
-	const std::vector<std::string_view> one{"single"};
-	EXPECT_EQ(str::join(",", one), "single");
+TEST(StrTests, JoinSingle)
+{
+    const std::vector<std::string_view> one{"single"};
+    EXPECT_EQ(str::join(",", one), "single");
 }
 
-TEST(StrTests, JoinMulti) {
-	const std::vector<std::string_view> two{"one", "two"};
-	EXPECT_EQ(str::join(",", two), "one,two");
+TEST(StrTests, JoinMulti)
+{
+    const std::vector<std::string_view> two{"one", "two"};
+    EXPECT_EQ(str::join(",", two), "one,two");
 }
 
-TEST(StrTests, JoinMany) {
-	const std::vector<std::string_view> many{"1", "2", "3"};
-	EXPECT_EQ(str::join(",", many), "1,2,3");
+TEST(StrTests, JoinMany)
+{
+    const std::vector<std::string_view> many{"1", "2", "3"};
+    EXPECT_EQ(str::join(",", many), "1,2,3");
 }
 
-TEST(StrTests, TrimEmpty) {
-	EXPECT_EQ(str::ltrim(""), "");
-	EXPECT_EQ(str::rtrim(""), "");
-	EXPECT_EQ(str::trim(""), "");
+TEST(StrTests, TrimEmpty)
+{
+    EXPECT_EQ(str::ltrim(""), "");
+    EXPECT_EQ(str::rtrim(""), "");
+    EXPECT_EQ(str::trim(""), "");
 }
 
-TEST(StrTests, LTrim) {
-	EXPECT_EQ(str::ltrim("hi"), "hi");
-	EXPECT_EQ(str::ltrim("hi "), "hi ");
-	EXPECT_EQ(str::ltrim("  \t\nhi"), "hi");
-	EXPECT_EQ(str::ltrim("  \t\nhi  "), "hi  ");
-	EXPECT_EQ(str::ltrim("  \t\nhi there "), "hi there ");
+TEST(StrTests, LTrim)
+{
+    EXPECT_EQ(str::ltrim("hi"), "hi");
+    EXPECT_EQ(str::ltrim("hi "), "hi ");
+    EXPECT_EQ(str::ltrim("  \t\nhi"), "hi");
+    EXPECT_EQ(str::ltrim("  \t\nhi  "), "hi  ");
+    EXPECT_EQ(str::ltrim("  \t\nhi there "), "hi there ");
 }
 
-TEST(StrTests, RTrim) {
-	EXPECT_EQ(str::rtrim("hi"), "hi");
-	EXPECT_EQ(str::rtrim(" hi"), " hi");
-	EXPECT_EQ(str::rtrim("hi \t\n \r \v \f"), "hi");
-	EXPECT_EQ(str::rtrim("  hi  "), "  hi");
-	EXPECT_EQ(str::rtrim(" hi there "), " hi there");
+TEST(StrTests, RTrim)
+{
+    EXPECT_EQ(str::rtrim("hi"), "hi");
+    EXPECT_EQ(str::rtrim(" hi"), " hi");
+    EXPECT_EQ(str::rtrim("hi \t\n \r \v \f"), "hi");
+    EXPECT_EQ(str::rtrim("  hi  "), "  hi");
+    EXPECT_EQ(str::rtrim(" hi there "), " hi there");
 }
 
-TEST(StrTests, Trim) {
-	EXPECT_EQ(str::trim(""), "");
-	EXPECT_EQ(str::trim("   "), "");
-	EXPECT_EQ(str::trim("hi"), "hi");
-	EXPECT_EQ(str::trim(" hi"), "hi");
-	EXPECT_EQ(str::trim("hi \t\n \r \v \f"), "hi");
-	EXPECT_EQ(str::trim("  \t\nhi"), "hi");
-	EXPECT_EQ(str::trim("  \t\nhi  "), "hi");
-	EXPECT_EQ(str::trim("  hi  "), "hi");
-	EXPECT_EQ(str::trim(" hi there "), "hi there");
+TEST(StrTests, Trim)
+{
+    EXPECT_EQ(str::trim(""), "");
+    EXPECT_EQ(str::trim("   "), "");
+    EXPECT_EQ(str::trim("hi"), "hi");
+    EXPECT_EQ(str::trim(" hi"), "hi");
+    EXPECT_EQ(str::trim("hi \t\n \r \v \f"), "hi");
+    EXPECT_EQ(str::trim("  \t\nhi"), "hi");
+    EXPECT_EQ(str::trim("  \t\nhi  "), "hi");
+    EXPECT_EQ(str::trim("  hi  "), "hi");
+    EXPECT_EQ(str::trim(" hi there "), "hi there");
 }
 
 TEST(StrTests, Eq)
 {
-	EXPECT_TRUE(str::eq("", ""));
-	EXPECT_TRUE(str::eq("a", "a"));
-	EXPECT_FALSE(str::eq("a", "b"));
-	EXPECT_FALSE(str::eq("aa", "a"));
+    EXPECT_TRUE(str::eq("", ""));
+    EXPECT_TRUE(str::eq("a", "a"));
+    EXPECT_FALSE(str::eq("a", "b"));
+    EXPECT_FALSE(str::eq("aa", "a"));
 }
 
 TEST(StrTests, EqCase)
 {
-	EXPECT_TRUE(str::eqcase("", ""));
-	EXPECT_TRUE(str::eqcase("a", "a"));
-	EXPECT_TRUE(str::eqcase("A", "a"));
-	EXPECT_FALSE(str::eqcase("Ab", "aBa"));
-	EXPECT_TRUE(str::eqcase("aBBcA", "AbBCa"));
+    EXPECT_TRUE(str::eqcase("", ""));
+    EXPECT_TRUE(str::eqcase("a", "a"));
+    EXPECT_TRUE(str::eqcase("A", "a"));
+    EXPECT_FALSE(str::eqcase("Ab", "aBa"));
+    EXPECT_TRUE(str::eqcase("aBBcA", "AbBCa"));
 }
 
 TEST(StrTests, StartEqCase)
 {
-	EXPECT_TRUE(str::starteqcase("Hi there", "hi"));
-	EXPECT_TRUE(str::starteqcase("Hi", "hi"));
-	EXPECT_TRUE(str::starteqcase("Hi", "HI"));
-	EXPECT_FALSE(str::starteqcase("Hello", "hi"));
-	EXPECT_FALSE(str::starteqcase("Hi", "HI THERE"));
+    EXPECT_TRUE(str::starteqcase("Hi there", "hi"));
+    EXPECT_TRUE(str::starteqcase("Hi", "hi"));
+    EXPECT_TRUE(str::starteqcase("Hi", "HI"));
+    EXPECT_FALSE(str::starteqcase("Hello", "hi"));
+    EXPECT_FALSE(str::starteqcase("Hi", "HI THERE"));
 }
 
 TEST(StrTests, Match)
 {
-	EXPECT_TRUE(str::match("", ""));
-	EXPECT_TRUE(str::match("", "_a"));
-	EXPECT_TRUE(str::match("a", "a"));
-	EXPECT_FALSE(str::match("ab", "a"));
-	EXPECT_FALSE(str::match("a", "ab_cde"));
-	EXPECT_TRUE(str::match("ab", "ab_cde"));
-	EXPECT_TRUE(str::match("abc", "ab_cde"));
-	EXPECT_TRUE(str::match("abcd", "ab_cde"));
-	EXPECT_TRUE(str::match("abcde", "ab_cde"));
-	EXPECT_FALSE(str::match("abcdef", "ab_cde"));
+    EXPECT_TRUE(str::match("", ""));
+    EXPECT_TRUE(str::match("", "_a"));
+    EXPECT_TRUE(str::match("a", "a"));
+    EXPECT_FALSE(str::match("ab", "a"));
+    EXPECT_FALSE(str::match("a", "ab_cde"));
+    EXPECT_TRUE(str::match("ab", "ab_cde"));
+    EXPECT_TRUE(str::match("abc", "ab_cde"));
+    EXPECT_TRUE(str::match("abcd", "ab_cde"));
+    EXPECT_TRUE(str::match("abcde", "ab_cde"));
+    EXPECT_FALSE(str::match("abcdef", "ab_cde"));
 }
 
 TEST(StrTests, Contains)
 {
-	EXPECT_FALSE(str::contains({}, ""));
-	EXPECT_TRUE(str::contains({""}, ""));
-	EXPECT_FALSE(str::contains({"a"}, ""));
-	EXPECT_FALSE(str::contains({""}, "a"));
-	EXPECT_TRUE(str::contains({"a", "b", "c"}, "b"));
+    EXPECT_FALSE(str::contains({}, ""));
+    EXPECT_TRUE(str::contains({""}, ""));
+    EXPECT_FALSE(str::contains({"a"}, ""));
+    EXPECT_FALSE(str::contains({""}, "a"));
+    EXPECT_TRUE(str::contains({"a", "b", "c"}, "b"));
 }
 
 TEST(StrTests, Split)
 {
-	const std::vector<std::string_view> empty;
-	EXPECT_EQ(str::split("", ""), empty);
-	EXPECT_EQ(str::split("", ","), empty);
-	EXPECT_EQ(str::split("a", ""), std::vector<std::string_view>{"a"});
-	EXPECT_EQ(str::split("a", "a"), empty);
-	EXPECT_EQ(str::split("a", ","), std::vector<std::string_view>{"a"});
-	EXPECT_EQ(str::split("a,b", ","), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split("a,,b", ","), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split(",a,,b,", ","), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split(",a, ,b,", ","), (std::vector<std::string_view>{"a", "", "b"}));
-	EXPECT_EQ(str::split(",a,b", ","), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split("a, b,", ","), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split("a,b,", ","), (std::vector<std::string_view>{"a", "b"}));
+    const std::vector<std::string_view> empty;
+    EXPECT_EQ(str::split("", ""), empty);
+    EXPECT_EQ(str::split("", ","), empty);
+    EXPECT_EQ(str::split("a", ""), std::vector<std::string_view>{"a"});
+    EXPECT_EQ(str::split("a", "a"), empty);
+    EXPECT_EQ(str::split("a", ","), std::vector<std::string_view>{"a"});
+    EXPECT_EQ(
+        str::split("a,b", ","), (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(
+        str::split("a,,b", ","), (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(
+        str::split(",a,,b,", ","), (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(str::split(",a, ,b,", ","),
+        (std::vector<std::string_view>{"a", "", "b"}));
+    EXPECT_EQ(
+        str::split(",a,b", ","), (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(
+        str::split("a, b,", ","), (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(
+        str::split("a,b,", ","), (std::vector<std::string_view>{"a", "b"}));
 }
 
 TEST(StrTests, SplitNoDiscardEmpty)
 {
-	const std::vector<std::string_view> empty;
-	EXPECT_EQ(str::split("", "", false), empty);
-	EXPECT_EQ(str::split("", ",", false), empty);
-	EXPECT_EQ(str::split("a", "", false), std::vector<std::string_view>{"a"});
-	EXPECT_EQ(str::split("a", "a", false), (std::vector<std::string_view>{"", ""}));
-	EXPECT_EQ(str::split("a", ",", false), std::vector<std::string_view>{"a"});
-	EXPECT_EQ(str::split("a,b", ",", false), (std::vector<std::string_view>{"a", "b"}));
-	EXPECT_EQ(str::split("a,,,b", ",", false), (std::vector<std::string_view>{"a", "", "", "b"}));
-	EXPECT_EQ(str::split("a,,b", ",", false), (std::vector<std::string_view>{"a", "", "b"}));
-	EXPECT_EQ(str::split(",a,,b,", ",", false), (std::vector<std::string_view>{"", "a", "", "b", ""}));
-	EXPECT_EQ(str::split(",a,b", ",", false), (std::vector<std::string_view>{"", "a", "b"}));
-	EXPECT_EQ(str::split("a, b,", ",", false), (std::vector<std::string_view>{"a", "b", ""}));
-	EXPECT_EQ(str::split("a,b,", ",", false), (std::vector<std::string_view>{"a", "b", ""}));
+    const std::vector<std::string_view> empty;
+    EXPECT_EQ(str::split("", "", false), empty);
+    EXPECT_EQ(str::split("", ",", false), empty);
+    EXPECT_EQ(str::split("a", "", false), std::vector<std::string_view>{"a"});
+    EXPECT_EQ(
+        str::split("a", "a", false), (std::vector<std::string_view>{"", ""}));
+    EXPECT_EQ(str::split("a", ",", false), std::vector<std::string_view>{"a"});
+    EXPECT_EQ(str::split("a,b", ",", false),
+        (std::vector<std::string_view>{"a", "b"}));
+    EXPECT_EQ(str::split("a,,,b", ",", false),
+        (std::vector<std::string_view>{"a", "", "", "b"}));
+    EXPECT_EQ(str::split("a,,b", ",", false),
+        (std::vector<std::string_view>{"a", "", "b"}));
+    EXPECT_EQ(str::split(",a,,b,", ",", false),
+        (std::vector<std::string_view>{"", "a", "", "b", ""}));
+    EXPECT_EQ(str::split(",a,b", ",", false),
+        (std::vector<std::string_view>{"", "a", "b"}));
+    EXPECT_EQ(str::split("a, b,", ",", false),
+        (std::vector<std::string_view>{"a", "b", ""}));
+    EXPECT_EQ(str::split("a,b,", ",", false),
+        (std::vector<std::string_view>{"a", "b", ""}));
 }
 
 TEST(StrTests, UnQuote)
 {
-	EXPECT_EQ(str::unquote(""), "");
-	EXPECT_EQ(str::unquote("'This is a test.'"), "This is a test.");
-	EXPECT_EQ(str::unquote("'Test \\' Embedded Quote'"), "Test ' Embedded Quote");
+    EXPECT_EQ(str::unquote(""), "");
+    EXPECT_EQ(str::unquote("'This is a test.'"), "This is a test.");
+    EXPECT_EQ(
+        str::unquote("'Test \\' Embedded Quote'"), "Test ' Embedded Quote");
 }
 
 TEST(StrTests, LowerCaseLiterals)
 {
-	EXPECT_EQ(str::lowercase(""), "");
-	EXPECT_EQ(str::lowercase("asdf"), "asdf");
-	EXPECT_EQ(str::lowercase("ASDF"), "asdf");
+    EXPECT_EQ(str::lowercase(""), "");
+    EXPECT_EQ(str::lowercase("asdf"), "asdf");
+    EXPECT_EQ(str::lowercase("ASDF"), "asdf");
 }
 
 TEST(StrTests, LowerCaseRef)
 {
-	std::string s;
-	str::lowercase(s);
-	EXPECT_EQ(s, "");
-	s = "asdf";
-	EXPECT_EQ(str::lowercase(s), "asdf");
-	s = "ASDF";
-	EXPECT_EQ(str::lowercase(s), "asdf");
-	EXPECT_EQ(s, "asdf");
+    std::string s;
+    str::lowercase(s);
+    EXPECT_EQ(s, "");
+    s = "asdf";
+    EXPECT_EQ(str::lowercase(s), "asdf");
+    s = "ASDF";
+    EXPECT_EQ(str::lowercase(s), "asdf");
+    EXPECT_EQ(s, "asdf");
 }
 
 TEST(StrTests, Strip)
 {
-	EXPECT_EQ(str::strip("", ""), "");
-	EXPECT_EQ(str::strip("", ","), "");
-	EXPECT_EQ(str::strip("hi, there,", ","), "hi there");
-	EXPECT_EQ(str::strip("r_ead, or, p_ass?", " ,_?"), "readorpass");
+    EXPECT_EQ(str::strip("", ""), "");
+    EXPECT_EQ(str::strip("", ","), "");
+    EXPECT_EQ(str::strip("hi, there,", ","), "hi there");
+    EXPECT_EQ(str::strip("r_ead, or, p_ass?", " ,_?"), "readorpass");
 }

--- a/sum.cc
+++ b/sum.cc
@@ -40,8 +40,8 @@
 #define OLD_YAPP 0x58585858L
 
 typedef struct {
-	uint32_t flags, nr;
-	time_t last, first;
+    uint32_t flags, nr;
+    time_t last, first;
 } longsumentry_t;
 
 static int part_is_dirty = 0;
@@ -51,52 +51,50 @@ static int sum_is_dirty = 0;
 uint32_t
 get_hash(const std::string_view &str) /* IN : participation filename */
 {
-	uint32_t ret = 0;
-	for (const auto *p = str.begin(); p != str.end(); ++p)
-		ret = (ret * 4) ^ *p;
-	return ret;
+    uint32_t ret = 0;
+    for (const auto *p = str.begin(); p != str.end(); ++p) ret = (ret * 4) ^ *p;
+    return ret;
 }
 
 uint32_t
 get_sumtype(const char *buff)
 {
-	uint32_t temp, sumtype;
-	/* constant used for byte swap check */
-	short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
-	/* Determine byte order & file type */
-	memcpy((char *)&temp, buff, sizeof(uint32_t));
-	switch (temp) {
-	case INT_MAGIC:
-		sumtype = ST_LONG;
-		break;
-	case INT_BACK:
-		sumtype = ST_LONG | ST_SWAP;
-		break;
-	case LONG_MAGIC:
-		sumtype = ST_LONG;
-		break;
-	case LONG_BACK:
-		sumtype = ST_SWAP;
-		break;
-	case OLD_YAPP:
-		swap = (*((char *)&swap));
-		sumtype = swap * ST_SWAP;
-		break;
-	default:
-		std::println("invalid sum type = {:08X}", temp);
-		swap = (*((char *)&swap)); /* check which byte contains
-		                            * the 1 */
-		sumtype = swap * ST_SWAP;
-		break;
-	}
+    uint32_t temp, sumtype;
+    /* constant used for byte swap check */
+    short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
+    /* Determine byte order & file type */
+    memcpy((char *)&temp, buff, sizeof(uint32_t));
+    switch (temp) {
+    case INT_MAGIC:
+        sumtype = ST_LONG;
+        break;
+    case INT_BACK:
+        sumtype = ST_LONG | ST_SWAP;
+        break;
+    case LONG_MAGIC:
+        sumtype = ST_LONG;
+        break;
+    case LONG_BACK:
+        sumtype = ST_SWAP;
+        break;
+    case OLD_YAPP:
+        swap = (*((char *)&swap));
+        sumtype = swap * ST_SWAP;
+        break;
+    default:
+        std::println("invalid sum type = {:08X}", temp);
+        swap = (*((char *)&swap)); /* check which byte contains
+                                    * the 1 */
+        sumtype = swap * ST_SWAP;
+        break;
+    }
 
 #ifdef SDEBUG
-	std::println("sum type = {:08X} ({})", temp, sumtype);
-	std::println("{} {}",
-	    (sumtype & ST_LONG) ? "long" : "short",
-	    (sumtype & ST_SWAP) ? "swap" : "normal");
+    std::println("sum type = {:08X} ({})", temp, sumtype);
+    std::println("{} {}", (sumtype & ST_LONG) ? "long" : "short",
+        (sumtype & ST_SWAP) ? "swap" : "normal");
 #endif
-	return sumtype;
+    return sumtype;
 }
 /******************************************************************************/
 /* SWAP BYTES IF LOW BIT IN HIGH BYTE (INTEL)                                 */
@@ -104,53 +102,53 @@ get_sumtype(const char *buff)
 /* processors can both use the same data files on the same filesystem         */
 /******************************************************************************/
 static void
-byteswap(       /* ARGUMENTS:                */
-    char *word, /* Byte string to reverse */
-    size_t length  /* Number of bytes        */
+byteswap(         /* ARGUMENTS:                */
+    char *word,   /* Byte string to reverse */
+    size_t length /* Number of bytes        */
 )
 {
-	if (length < 2)
-		return;
-	for (int i = 0; i <= (length - 2) / 2; i++) {
-		word[i] ^= word[length - i - 1];
-		word[length - i - 1] ^= word[i];
-		word[i] ^= word[length - i - 1];
-	}
+    if (length < 2)
+        return;
+    for (int i = 0; i <= (length - 2) / 2; i++) {
+        word[i] ^= word[length - i - 1];
+        word[length - i - 1] ^= word[i];
+        word[i] ^= word[length - i - 1];
+    }
 }
 
 #ifdef NEWS
 void
 save_article(long art, int idx)
 {
-	const auto path = str::concat({conflist[idx].location, "/article"});
+    const auto path = str::concat({conflist[idx].location, "/article"});
 
-	/* Create if doesn't exist, else update */
-	long mod;
-	struct stat st;
-	if (stat(path.c_str(), &st))
-		mod = O_W;
-	else
-		mod = O_RPLUS;
+    /* Create if doesn't exist, else update */
+    long mod;
+    struct stat st;
+    if (stat(path.c_str(), &st))
+        mod = O_W;
+    else
+        mod = O_RPLUS;
 
-	/* if (stt->c_security & CT_BASIC) mod |= O_PRIVATE; */
-	FILE *fp = mopen(path, mod);
-	if (fp == NULL)
-		return;
-	std::println(fp, "{}", art);
-	mclose(fp);
+    /* if (stt->c_security & CT_BASIC) mod |= O_PRIVATE; */
+    FILE *fp = mopen(path, mod);
+    if (fp == NULL)
+        return;
+    std::println(fp, "{}", art);
+    mclose(fp);
 }
 
 void
 load_article(long *art, int idx)
 {
-	const auto path = str::concat({conflist[idx].location, "/article"});
-	FILE *fp = mopen(path, O_R);
-	if (fp == NULL) {
-		*art = 0;
-		return;
-	}
-	fscanf(fp, "%ld\n", art);
-	mclose(fp);
+    const auto path = str::concat({conflist[idx].location, "/article"});
+    FILE *fp = mopen(path, O_R);
+    if (fp == NULL) {
+        *art = 0;
+        return;
+    }
+    fscanf(fp, "%ld\n", art);
+    mclose(fp);
 }
 #endif
 
@@ -164,103 +162,103 @@ save_sum(sumentry_t *newsum, /* IN/OUT: Modified record              */
     status_t *stt            /* */
 )
 {
-	FILE *fp;
-	short i = 1;
-	char buff[17];
-	sumentry_t entry;
-	longsumentry_t longentry;
-	/* constant used for * byte swap check */
-	short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
-	long mod;
-	struct stat st;
-	uint32_t temp, sumtype;
+    FILE *fp;
+    short i = 1;
+    char buff[17];
+    sumentry_t entry;
+    longsumentry_t longentry;
+    /* constant used for * byte swap check */
+    short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
+    long mod;
+    struct stat st;
+    uint32_t temp, sumtype;
 
-	if (debug & DB_SUM)
-		std::println("SAVE_SUM {:x} {}", (uintptr_t)newsum, where);
+    if (debug & DB_SUM)
+        std::println("SAVE_SUM {:x} {}", (uintptr_t)newsum, where);
 
-	swap = (*((char *)&swap)); /* check which byte contains the 1 */
+    swap = (*((char *)&swap)); /* check which byte contains the 1 */
 
-	const auto path = str::concat({conflist[idx].location, "/sum"});
+    const auto path = str::concat({conflist[idx].location, "/sum"});
 
-	/* Create if doesn't exist, else update */
-	if (stat(path.c_str(), &st) != 0)
-		mod = O_W;
-	else
-		mod = O_RPLUS;
+    /* Create if doesn't exist, else update */
+    if (stat(path.c_str(), &st) != 0)
+        mod = O_W;
+    else
+        mod = O_RPLUS;
 
-	if (stt->c_security & CT_BASIC)
-		mod |= O_PRIVATE;
-	if ((fp = mopen(path, mod)) == NULL)
-		return;
+    if (stt->c_security & CT_BASIC)
+        mod |= O_PRIVATE;
+    if ((fp = mopen(path, mod)) == NULL)
+        return;
 
-	/* Determine file type */
-	if (mod == O_W || (i = fread(buff, 20, 1, fp)) < 20) /* new file */
-		sumtype = ST_LONG;
-	else
-		sumtype = get_sumtype(buff + 12);
-	rewind(fp);
+    /* Determine file type */
+    if (mod == O_W || (i = fread(buff, 20, 1, fp)) < 20) /* new file */
+        sumtype = ST_LONG;
+    else
+        sumtype = get_sumtype(buff + 12);
+    rewind(fp);
 
-	const auto config = get_config(idx);
-	if (config.size() <= CF_PARTFILE)
-		return;
+    const auto config = get_config(idx);
+    if (config.size() <= CF_PARTFILE)
+        return;
 
-	/* Write header */
-	if (sumtype & ST_LONG) {
-		fwrite("!<sm02>\n", 8, 1, fp);
-		temp = get_hash(config[CF_PARTFILE]);
-		fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
-		temp = INT_MAGIC;
-		fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
-		temp = LONG_MAGIC;
-		fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
-	} else {
-		fwrite("!<pr03>\n", 8, 1, fp);
-		short tshort = get_hash(config[CF_PARTFILE]);
-		fwrite((char *)&tshort, sizeof(uint32_t), 1, fp);
-		temp = INT_MAGIC;
-		fwrite((char *)&tshort, sizeof(uint32_t), 1, fp);
-		temp = LONG_MAGIC;
-		fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
-	}
+    /* Write header */
+    if (sumtype & ST_LONG) {
+        fwrite("!<sm02>\n", 8, 1, fp);
+        temp = get_hash(config[CF_PARTFILE]);
+        fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
+        temp = INT_MAGIC;
+        fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
+        temp = LONG_MAGIC;
+        fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
+    } else {
+        fwrite("!<pr03>\n", 8, 1, fp);
+        short tshort = get_hash(config[CF_PARTFILE]);
+        fwrite((char *)&tshort, sizeof(uint32_t), 1, fp);
+        temp = INT_MAGIC;
+        fwrite((char *)&tshort, sizeof(uint32_t), 1, fp);
+        temp = LONG_MAGIC;
+        fwrite((char *)&temp, sizeof(uint32_t), 1, fp);
+    }
 
-	if (debug & DB_SUM)
-		std::println("Saving {} {}s\n", stt->c_confitems, topic());
-	if (where + 1 > stt->c_confitems)
-		stt->c_confitems = where + 1;
-	for (i = 1; i <= stt->c_confitems; i++) {
-		uint32_t t;
-		/* if (newsum[i-1].nr) std::println("{}: {}",i,newsum[i-1].nr); */
-		t = newsum[i - 1].flags;
-		newsum[i - 1].flags &= IF_SAVEMASK;
+    if (debug & DB_SUM)
+        std::println("Saving {} {}s\n", stt->c_confitems, topic());
+    if (where + 1 > stt->c_confitems)
+        stt->c_confitems = where + 1;
+    for (i = 1; i <= stt->c_confitems; i++) {
+        uint32_t t;
+        /* if (newsum[i-1].nr) std::println("{}: {}",i,newsum[i-1].nr); */
+        t = newsum[i - 1].flags;
+        newsum[i - 1].flags &= IF_SAVEMASK;
 
-		if (sumtype & ST_LONG) {
-			longentry.nr = newsum[i - 1].nr;
-			longentry.flags = newsum[i - 1].flags;
-			longentry.last = newsum[i - 1].last;
-			longentry.first = newsum[i - 1].first;
-			if (sumtype & ST_SWAP) {
-				byteswap((char *)&(longentry.nr), sizeof(uint32_t));
-				byteswap((char *)&(longentry.flags), sizeof(uint32_t));
-				byteswap((char *)&(longentry.first), sizeof(time_t));
-				byteswap((char *)&(longentry.last), sizeof(time_t));
-			}
-			fwrite((char *)&longentry, sizeof(longsumentry_t), 1, fp);
-		} else {
-			memcpy((char *)&entry, (char *)&(newsum[i - 1]),
-			    sizeof(sumentry_t));
-			if (sumtype & ST_SWAP) {
-				byteswap((char *)&(entry.nr), sizeof(uint32_t));
-				byteswap((char *)&(entry.flags), sizeof(uint32_t));
-				byteswap((char *)&(entry.first), sizeof(time_t));
-				byteswap((char *)&(entry.last), sizeof(time_t));
-			}
-			fwrite((char *)&entry, sizeof(sumentry_t), 1, fp);
-		}
+        if (sumtype & ST_LONG) {
+            longentry.nr = newsum[i - 1].nr;
+            longentry.flags = newsum[i - 1].flags;
+            longentry.last = newsum[i - 1].last;
+            longentry.first = newsum[i - 1].first;
+            if (sumtype & ST_SWAP) {
+                byteswap((char *)&(longentry.nr), sizeof(uint32_t));
+                byteswap((char *)&(longentry.flags), sizeof(uint32_t));
+                byteswap((char *)&(longentry.first), sizeof(time_t));
+                byteswap((char *)&(longentry.last), sizeof(time_t));
+            }
+            fwrite((char *)&longentry, sizeof(longsumentry_t), 1, fp);
+        } else {
+            memcpy(
+                (char *)&entry, (char *)&(newsum[i - 1]), sizeof(sumentry_t));
+            if (sumtype & ST_SWAP) {
+                byteswap((char *)&(entry.nr), sizeof(uint32_t));
+                byteswap((char *)&(entry.flags), sizeof(uint32_t));
+                byteswap((char *)&(entry.first), sizeof(time_t));
+                byteswap((char *)&(entry.last), sizeof(time_t));
+            }
+            fwrite((char *)&entry, sizeof(sumentry_t), 1, fp);
+        }
 
-		newsum[i - 1].flags = t;
-	}
+        newsum[i - 1].flags = t;
+    }
 
-	mclose(fp);
+    mclose(fp);
 }
 
 void
@@ -271,54 +269,52 @@ refresh_sum(int item,  /* IN:     Item index               */
     status_t *stt      /* IN/OUT: Status structure         */
 )
 {
-	struct stat st;
-	short last, first;
+    struct stat st;
+    short last, first;
 
-	if (idx < 0)
-		return;
+    if (idx < 0)
+        return;
 
 #ifdef NEWS
-	const auto config = get_config(idx);
-	if (config.size() > CF_NEWSGROUP && (stt->c_security & CT_NEWS) != 0) {
-		const auto path = str::join("/",
-		    {get_conf_param("newsdir", NEWSDIR),
-		    dot2slash(config[CF_NEWSGROUP])});
-		if (stat(path.c_str(), &st)) {
-			stt->sumtime = 0;
-			st.st_mtime = 1;
-		}
-		if (st.st_mtime != stt->sumtime) {
-			load_sum(sum, part, stt, idx);
-			stt->sumtime = st.st_mtime;
-		}
-		/* update stt */
-		refresh_stats(sum, part, stt);
-		return;
-	}
+    const auto config = get_config(idx);
+    if (config.size() > CF_NEWSGROUP && (stt->c_security & CT_NEWS) != 0) {
+        const auto path = str::join("/", {get_conf_param("newsdir", NEWSDIR),
+                                             dot2slash(config[CF_NEWSGROUP])});
+        if (stat(path.c_str(), &st)) {
+            stt->sumtime = 0;
+            st.st_mtime = 1;
+        }
+        if (st.st_mtime != stt->sumtime) {
+            load_sum(sum, part, stt, idx);
+            stt->sumtime = st.st_mtime;
+        }
+        /* update stt */
+        refresh_stats(sum, part, stt);
+        return;
+    }
 #endif
 
-	/* Is global information current? */
-	const auto path = str::concat({conflist[idx].location, "/sum"});
-	if (stat(path.c_str(), &st) != 0) {
-		stt->sumtime = 0;
-		st.st_mtime = 1;
-	}
-	if (st.st_mtime != stt->sumtime) {
-		/* Load global information */
-		load_sum(sum, part, stt, idx);
-		stt->sumtime = st.st_mtime;
-		refresh_stats(sum, part, stt);
-	}
+    /* Is global information current? */
+    const auto path = str::concat({conflist[idx].location, "/sum"});
+    if (stat(path.c_str(), &st) != 0) {
+        stt->sumtime = 0;
+        st.st_mtime = 1;
+    }
+    if (st.st_mtime != stt->sumtime) {
+        /* Load global information */
+        load_sum(sum, part, stt, idx);
+        stt->sumtime = st.st_mtime;
+        refresh_stats(sum, part, stt);
+    }
 
-	/* Are links current? */
-	last = (item > 0) ? item : MAX_ITEMS;
-	first = (item > 0) ? item : 1;
-	for (int i = first - 1; i < last; i++)
-		refresh_link(stt, sum, part, idx, i);
+    /* Are links current? */
+    last = (item > 0) ? item : MAX_ITEMS;
+    first = (item > 0) ? item : 1;
+    for (int i = first - 1; i < last; i++) refresh_link(stt, sum, part, idx, i);
 
-	/* Need to refresh stats anyway, in case part[] changed */
-	if (sum_is_dirty || part_is_dirty)
-		refresh_stats(sum, part, stt); /* update stt */
+    /* Need to refresh stats anyway, in case part[] changed */
+    if (sum_is_dirty || part_is_dirty)
+        refresh_stats(sum, part, stt); /* update stt */
 }
 
 int
@@ -328,81 +324,81 @@ item_sum(int i,        /* IN: Item number                   */
     int idx,           /* IN: Conference index              */
     status_t *stt)
 {
-	FILE *fp;
-	struct stat st;
-	std::string buff;
+    FILE *fp;
+    struct stat st;
+    std::string buff;
 
-	sum[i].flags = sum[i].nr = 0;
-	dirty_sum(i);
+    sum[i].flags = sum[i].nr = 0;
+    dirty_sum(i);
 
-	const auto config = get_config(idx);
-	if (config.empty())
-		return 0;
+    const auto config = get_config(idx);
+    if (config.empty())
+        return 0;
 
-	const auto path = std::format("{}/_{}", conflist[idx].location, i + 1);
-	if (stat(path.c_str(), &st))
-		return 0;
-	else
-		sum[i].flags |= IF_ACTIVE;
+    const auto path = std::format("{}/_{}", conflist[idx].location, i + 1);
+    if (stat(path.c_str(), &st))
+        return 0;
+    else
+        sum[i].flags |= IF_ACTIVE;
 
-	if (st.st_nlink > 1)
-		sum[i].flags |= IF_LINKED;
-	if (!(st.st_mode & S_IWUSR))
-		sum[i].flags |= IF_FROZEN;
-	if (part[i].nr < 0)
-		sum[i].flags |= IF_FORGOTTEN;
-	sum[i].last = st.st_mtime;
-	if (!(st.st_mode & S_IRUSR) || !(fp = mopen(path, O_R))) {
-		sum[i].flags |= IF_RETIRED;
-		sum[i].nr = 0;
-		sum[i].first = 0;
-	} else {
-		if (st.st_mode & S_IXUSR)
-			sum[i].flags |= IF_RETIRED;
-		sum[i].nr = 0; /* count them */
+    if (st.st_nlink > 1)
+        sum[i].flags |= IF_LINKED;
+    if (!(st.st_mode & S_IWUSR))
+        sum[i].flags |= IF_FROZEN;
+    if (part[i].nr < 0)
+        sum[i].flags |= IF_FORGOTTEN;
+    sum[i].last = st.st_mtime;
+    if (!(st.st_mode & S_IRUSR) || !(fp = mopen(path, O_R))) {
+        sum[i].flags |= IF_RETIRED;
+        sum[i].nr = 0;
+        sum[i].first = 0;
+    } else {
+        if (st.st_mode & S_IXUSR)
+            sum[i].flags |= IF_RETIRED;
+        sum[i].nr = 0; /* count them */
 
-		ngets(buff, fp); /* magic - ignore */
-		ngets(buff, fp); /* H - ignore if FAST */
-		store_subj(idx, i, buff.c_str() + 2);
-		ngets(buff, fp); /* R - ignore */
-		ngets(buff, fp); /* U - ignore */
-		auto p = strchr(buff.c_str() + 2, ',');
-		if (p != nullptr)
-			store_auth(idx, i, p + 1);
-		ngets(buff, fp); /* A - ignore */
-		ngets(buff, fp); /* date */
-		sscanf(buff.c_str() + 2, "%lx", &(sum[i].first));
-		while (ngets(buff, fp)) {
-			if (str::eq(buff, ",T"))
-				sum[i].nr++;
+        ngets(buff, fp); /* magic - ignore */
+        ngets(buff, fp); /* H - ignore if FAST */
+        store_subj(idx, i, buff.c_str() + 2);
+        ngets(buff, fp); /* R - ignore */
+        ngets(buff, fp); /* U - ignore */
+        auto p = strchr(buff.c_str() + 2, ',');
+        if (p != nullptr)
+            store_auth(idx, i, p + 1);
+        ngets(buff, fp); /* A - ignore */
+        ngets(buff, fp); /* date */
+        sscanf(buff.c_str() + 2, "%lx", &(sum[i].first));
+        while (ngets(buff, fp)) {
+            if (str::eq(buff, ",T"))
+                sum[i].nr++;
 
 #ifdef NEWS
-			if (buff.starts_with(",N")) {
-				long art = atoi(buff.c_str() + 2);
+            if (buff.starts_with(",N")) {
+                long art = atoi(buff.c_str() + 2);
 
-				/* Check to see if it has expired */
-				const auto buff = std::format("{}/{}/{}",
-				    get_conf_param("newsdir", NEWSDIR),
-				    dot2slash(config[CF_NEWSGROUP]), art);
-				std::print("Checking {} ", buff);
-				FILE *nfp = mopen(buff, O_R | O_SILENT);
-				if (nfp == nullptr) {
-					sum[i].flags |= IF_EXPIRED;
-					std::println("EXPIRED");
-				} else {
-					mclose(nfp);
-					std::println("OK");
-				}
+                /* Check to see if it has expired */
+                const auto buff =
+                    std::format("{}/{}/{}", get_conf_param("newsdir", NEWSDIR),
+                        dot2slash(config[CF_NEWSGROUP]), art);
+                std::print("Checking {} ", buff);
+                FILE *nfp = mopen(buff, O_R | O_SILENT);
+                if (nfp == nullptr) {
+                    sum[i].flags |= IF_EXPIRED;
+                    std::println("EXPIRED");
+                } else {
+                    mclose(nfp);
+                    std::println("OK");
+                }
 
-				if (art > stt->c_article)
-					stt->c_article = art;
-				/* std::println("Found article {}",art); */
-			}
+                if (art > stt->c_article)
+                    stt->c_article = art;
+                /* std::println("Found article {}",art); */
+            }
 #endif
-		}
-		mclose(fp);
-	}
-	return 1;
+        }
+        mclose(fp);
+    }
+    return 1;
 }
 /******************************************************************************/
 /* Load SUM data for arbitrary conference (requires part be done previously)  */
@@ -415,212 +411,211 @@ load_sum(              /* ARGUMENTS: */
     int idx            /* IN: Conference index */
 )
 {
-	FILE *fp;
-	short i = 1, j;
-	struct stat st;
-	char buff[MAX_LINE_LENGTH];
-	short confitems = 0;
-	/* constant used for * byte swap check */
-	short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
-	uint32_t sumtype = 0;
-	uint32_t temp;
-	short tshort;
+    FILE *fp;
+    short i = 1, j;
+    struct stat st;
+    char buff[MAX_LINE_LENGTH];
+    short confitems = 0;
+    /* constant used for * byte swap check */
+    short swap = str::toi(get_conf_param("byteswap", BYTESWAP));
+    uint32_t sumtype = 0;
+    uint32_t temp;
+    short tshort;
 
-	swap = (*((char *)&swap));
-	for (j = 0; j < MAX_ITEMS; j++) {
-		sum[j].nr = sum[j].flags = 0;
-		dirty_sum(j);
-	}
+    swap = (*((char *)&swap));
+    for (j = 0; j < MAX_ITEMS; j++) {
+        sum[j].nr = sum[j].flags = 0;
+        dirty_sum(j);
+    }
 
-	/* For NFS mounted cf, open is 27 secs with lock(failing) and 4
-	 * without the lock.  Why should we lock it anyway? */
-	const auto path = str::concat({conflist[idx].location, "/sum"});
-	fp = mopen(path, O_R | O_SILENT);
+    /* For NFS mounted cf, open is 27 secs with lock(failing) and 4
+     * without the lock.  Why should we lock it anyway? */
+    const auto path = str::concat({conflist[idx].location, "/sum"});
+    fp = mopen(path, O_R | O_SILENT);
 
-	/* If SUM doesn't exist */
-	if (fp == NULL) {
-		/* if ((fp=mopen(path,O_RPLUS|O_LOCK|O_SILENT))==NULL) */
-		DIR *fp = opendir(conflist[idx].location.c_str());
-		if (fp == NULL) {
-			error("opening ", path);
-			return;
-		}
+    /* If SUM doesn't exist */
+    if (fp == NULL) {
+        /* if ((fp=mopen(path,O_RPLUS|O_LOCK|O_SILENT))==NULL) */
+        DIR *fp = opendir(conflist[idx].location.c_str());
+        if (fp == NULL) {
+            error("opening ", path);
+            return;
+        }
 
-		/* Load in stats 1 piece at a time - the slow stuff */
-		struct dirent *dp;
-		for (dp = readdir(fp); dp != NULL; dp = readdir(fp)) {
-			long i2;
-			if (sscanf(dp->d_name, "_%ld", &i2) == 1) {
-				i = i2 - 1;
-				if (item_sum(i, sum, part, idx, stt)) {
-					confitems++;
-					if (i2 > stt->c_confitems)
-						stt->c_confitems = i2;
-				}
-			}
-		}
-		closedir(fp);
+        /* Load in stats 1 piece at a time - the slow stuff */
+        struct dirent *dp;
+        for (dp = readdir(fp); dp != NULL; dp = readdir(fp)) {
+            long i2;
+            if (sscanf(dp->d_name, "_%ld", &i2) == 1) {
+                i = i2 - 1;
+                if (item_sum(i, sum, part, idx, stt)) {
+                    confitems++;
+                    if (i2 > stt->c_confitems)
+                        stt->c_confitems = i2;
+                }
+            }
+        }
+        closedir(fp);
 
-		/* Load in stats 1 piece at a time - the slow stuff for (i=0;
-		 * i<MAX_ITEMS; i++) { confitems +=
-		 * item_sum(i,sum,part,idx,stt); } */
-
-#ifdef NEWS
-		/* Update ITEM files with new articles */
-		/* std::println("Article={}",stt->c_article); */
-		if (stt->c_security & CT_NEWS)
-			refresh_news(sum, part, stt, idx);
-#endif
-		refresh_stats(sum, part, stt);
-		save_sum(sum, (short)-1, idx, stt);
-		return;
-	}
-
-	/* Read in SUM file - the fast stuff */
-	if (stat(path.c_str(), &st) == 0)
-		stt->sumtime = st.st_mtime;
-
-	i = 0;
-	buff[0] = 0;
-	if (fp != nullptr)
-		i = fread(buff, 20, 1, fp);
-	if (i <= 0 ||
-	    (memcmp(buff, "!<sm02>\n", 8) != 0 && memcmp(buff, "!<pr03>\n", 8) != 0)) {
-		if (fp != nullptr)
-			mclose(fp);
-		errno = 0;
-		error(path, " failed magic check");
-		/* std::println("WARNING: {} failed magic check",path); */
-
-		/* Load in stats 1 piece at a time - the slow stuff */
-		for (i = 0; i < MAX_ITEMS; i++) {
-			if (item_sum(i, sum, part, idx, stt)) {
-				confitems++;
-				if (i + 1 > stt->c_confitems)
-					stt->c_confitems = i + 1;
-			}
-		}
-		refresh_stats(sum, part, stt);
-		save_sum(sum, (short)-1, idx, stt);
-		return;
-	}
-
-	/*
-	   fread((char *)&confitems, sizeof(confitems),1,fp); * skip first 16
-	   bytes * fread((char *)sum,sizeof(sumentry_t),1,fp); *fseek fails for
-	   some reason *
-	*/
-
-	/* Determine byte order & file type */
-	sumtype = get_sumtype(buff + 12);
-	const auto config = get_config(idx);
-	if (config.size() <= CF_PARTFILE)
-		return;
-
-	if (sumtype & ST_LONG) {
-		/* skip 4 more bytes */
-		//fread((char *)&temp, sizeof(uint32_t), 1, fp);
-		memcpy((char *)&temp, buff + 8, sizeof(uint32_t));
-		if (sumtype & ST_SWAP)
-			byteswap((char *)&temp, sizeof(uint32_t));
-		if (temp != get_hash(config[CF_PARTFILE])) {
-			errno = 0;
-			error("bad participation filename hash for ",
-			    config[CF_PARTFILE]);
-		}
-	} else {
-		memcpy((char *)&tshort, buff + 8, sizeof(short));
-		if (sumtype & ST_SWAP)
-			byteswap((char *)&temp, sizeof(short));
-		if (tshort != (short)get_hash(config[CF_PARTFILE])) {
-			errno = 0;
-			error("bad participation filename hash for ",
-			    config[CF_PARTFILE]);
-		}
-	}
+        /* Load in stats 1 piece at a time - the slow stuff for (i=0;
+         * i<MAX_ITEMS; i++) { confitems +=
+         * item_sum(i,sum,part,idx,stt); } */
 
 #ifdef NEWS
-	if (stt->c_security & CT_NEWS)
-		load_article(&stt->c_article, idx);
+        /* Update ITEM files with new articles */
+        /* std::println("Article={}",stt->c_article); */
+        if (stt->c_security & CT_NEWS)
+            refresh_news(sum, part, stt, idx);
 #endif
+        refresh_stats(sum, part, stt);
+        save_sum(sum, (short)-1, idx, stt);
+        return;
+    }
 
-	if (sumtype & ST_LONG) {
-		longsumentry_t longsum[MAX_ITEMS];
-		confitems = fread((char *)longsum, sizeof(longsumentry_t), MAX_ITEMS, fp);
+    /* Read in SUM file - the fast stuff */
+    if (stat(path.c_str(), &st) == 0)
+        stt->sumtime = st.st_mtime;
 
-		for (i = 0; i < confitems; i++) {
-			if (!longsum[i].nr)
-				continue; /* skip if deleted */
+    i = 0;
+    buff[0] = 0;
+    if (fp != nullptr)
+        i = fread(buff, 20, 1, fp);
+    if (i <= 0 || (memcmp(buff, "!<sm02>\n", 8) != 0 &&
+                      memcmp(buff, "!<pr03>\n", 8) != 0)) {
+        if (fp != nullptr)
+            mclose(fp);
+        errno = 0;
+        error(path, " failed magic check");
+        /* std::println("WARNING: {} failed magic check",path); */
 
-			if (sumtype & ST_SWAP) {
-				byteswap((char *)&(longsum[i].nr), sizeof(uint32_t));
-				byteswap((char *)&(longsum[i].flags), sizeof(uint32_t));
-				byteswap((char *)&(longsum[i].first), sizeof(time_t));
-				byteswap((char *)&(longsum[i].last), sizeof(time_t));
-			}
-			sum[i].nr = longsum[i].nr;
-			sum[i].flags = longsum[i].flags;
-			sum[i].first = longsum[i].first;
-			sum[i].last = longsum[i].last;
-		}
+        /* Load in stats 1 piece at a time - the slow stuff */
+        for (i = 0; i < MAX_ITEMS; i++) {
+            if (item_sum(i, sum, part, idx, stt)) {
+                confitems++;
+                if (i + 1 > stt->c_confitems)
+                    stt->c_confitems = i + 1;
+            }
+        }
+        refresh_stats(sum, part, stt);
+        save_sum(sum, (short)-1, idx, stt);
+        return;
+    }
 
-	} else {
-		confitems = fread((char *)sum, sizeof(sumentry_t), MAX_ITEMS, fp);
+    /*
+       fread((char *)&confitems, sizeof(confitems),1,fp); * skip first 16
+       bytes * fread((char *)sum,sizeof(sumentry_t),1,fp); *fseek fails for
+       some reason *
+    */
 
-		for (i = 0; i < confitems; i++) {
-			if (!sum[i].nr)
-				continue; /* skip if deleted */
+    /* Determine byte order & file type */
+    sumtype = get_sumtype(buff + 12);
+    const auto config = get_config(idx);
+    if (config.size() <= CF_PARTFILE)
+        return;
 
-			/* Check for byte swapping and such */
-			if (sumtype & ST_SWAP) {
-				byteswap((char *)&(sum[i].nr), sizeof(uint32_t));
-				byteswap((char *)&(sum[i].flags), sizeof(uint32_t));
-				byteswap((char *)&(sum[i].first), sizeof(time_t));
-				byteswap((char *)&(sum[i].last), sizeof(time_t));
-			}
-		}
-	}
-
-	mclose(fp);
-	if (debug & DB_SUM)
-		std::println("confitems={}", confitems);
-	stt->c_confitems = confitems;
-
-	for (i = 0; i < confitems; i++) {
-		if (!sum[i].nr)
-			continue; /* skip if deleted */
-
-		if (sum[i].nr < 0 || sum[i].nr > MAX_RESPONSES) {
-			std::println("Invalid format of sum file, nr={}", sum[i].nr);
-			break;
-		}
-		if (part[i].nr < 0)
-			sum[i].flags |= IF_FORGOTTEN;
-
-		/* verify it's still linked, didnt used to check sumtime */
-		refresh_link(stt, sum, part, idx, i);
-	}
-
-	for (; i < MAX_ITEMS; i++) { sum[i].flags = sum[i].nr = 0; }
+    if (sumtype & ST_LONG) {
+        /* skip 4 more bytes */
+        // fread((char *)&temp, sizeof(uint32_t), 1, fp);
+        memcpy((char *)&temp, buff + 8, sizeof(uint32_t));
+        if (sumtype & ST_SWAP)
+            byteswap((char *)&temp, sizeof(uint32_t));
+        if (temp != get_hash(config[CF_PARTFILE])) {
+            errno = 0;
+            error("bad participation filename hash for ", config[CF_PARTFILE]);
+        }
+    } else {
+        memcpy((char *)&tshort, buff + 8, sizeof(short));
+        if (sumtype & ST_SWAP)
+            byteswap((char *)&temp, sizeof(short));
+        if (tshort != (short)get_hash(config[CF_PARTFILE])) {
+            errno = 0;
+            error("bad participation filename hash for ", config[CF_PARTFILE]);
+        }
+    }
 
 #ifdef NEWS
-	/* Update ITEM files with new articles */
-	if (stt->c_security & CT_NEWS)
-		refresh_news(sum, part, stt, idx);
+    if (stt->c_security & CT_NEWS)
+        load_article(&stt->c_article, idx);
 #endif
-	refresh_stats(sum, part, stt);
+
+    if (sumtype & ST_LONG) {
+        longsumentry_t longsum[MAX_ITEMS];
+        confitems =
+            fread((char *)longsum, sizeof(longsumentry_t), MAX_ITEMS, fp);
+
+        for (i = 0; i < confitems; i++) {
+            if (!longsum[i].nr)
+                continue; /* skip if deleted */
+
+            if (sumtype & ST_SWAP) {
+                byteswap((char *)&(longsum[i].nr), sizeof(uint32_t));
+                byteswap((char *)&(longsum[i].flags), sizeof(uint32_t));
+                byteswap((char *)&(longsum[i].first), sizeof(time_t));
+                byteswap((char *)&(longsum[i].last), sizeof(time_t));
+            }
+            sum[i].nr = longsum[i].nr;
+            sum[i].flags = longsum[i].flags;
+            sum[i].first = longsum[i].first;
+            sum[i].last = longsum[i].last;
+        }
+
+    } else {
+        confitems = fread((char *)sum, sizeof(sumentry_t), MAX_ITEMS, fp);
+
+        for (i = 0; i < confitems; i++) {
+            if (!sum[i].nr)
+                continue; /* skip if deleted */
+
+            /* Check for byte swapping and such */
+            if (sumtype & ST_SWAP) {
+                byteswap((char *)&(sum[i].nr), sizeof(uint32_t));
+                byteswap((char *)&(sum[i].flags), sizeof(uint32_t));
+                byteswap((char *)&(sum[i].first), sizeof(time_t));
+                byteswap((char *)&(sum[i].last), sizeof(time_t));
+            }
+        }
+    }
+
+    mclose(fp);
+    if (debug & DB_SUM)
+        std::println("confitems={}", confitems);
+    stt->c_confitems = confitems;
+
+    for (i = 0; i < confitems; i++) {
+        if (!sum[i].nr)
+            continue; /* skip if deleted */
+
+        if (sum[i].nr < 0 || sum[i].nr > MAX_RESPONSES) {
+            std::println("Invalid format of sum file, nr={}", sum[i].nr);
+            break;
+        }
+        if (part[i].nr < 0)
+            sum[i].flags |= IF_FORGOTTEN;
+
+        /* verify it's still linked, didnt used to check sumtime */
+        refresh_link(stt, sum, part, idx, i);
+    }
+
+    for (; i < MAX_ITEMS; i++) { sum[i].flags = sum[i].nr = 0; }
+
+#ifdef NEWS
+    /* Update ITEM files with new articles */
+    if (stt->c_security & CT_NEWS)
+        refresh_news(sum, part, stt, idx);
+#endif
+    refresh_stats(sum, part, stt);
 }
 
 void
 dirty_part(int i)
 {
-	part_is_dirty = 1;
+    part_is_dirty = 1;
 }
 
 void
 dirty_sum(int i)
 {
-	sum_is_dirty = 1;
+    sum_is_dirty = 1;
 }
 
 void
@@ -629,55 +624,54 @@ refresh_stats(sumentry_t *sum, /* IN:     Sum array to fill in (optional)    */
     status_t *st               /* IN/OUT: pointer to status structure        */
 )
 {
-	int i, last, first, n;
-	st->i_brandnew = st->i_newresp = st->i_unseen = 0;
-	st->r_totalnewresp = 0;
-	st->i_last = 0;
+    int i, last, first, n;
+    st->i_brandnew = st->i_newresp = st->i_unseen = 0;
+    st->r_totalnewresp = 0;
+    st->i_last = 0;
 
-	/* Find first valid item */
-	i = 0;
-	while (i < MAX_ITEMS &&
-	       (!sum[i].nr || !sum[i].flags || (sum[i].flags & IF_EXPIRED)))
-		i++;
-	first = i + 1;
+    /* Find first valid item */
+    i = 0;
+    while (i < MAX_ITEMS &&
+           (!sum[i].nr || !sum[i].flags || (sum[i].flags & IF_EXPIRED)))
+        i++;
+    first = i + 1;
 
-	/* Find last valid item */
-	i = MAX_ITEMS - 1;
-	while (i >= first &&
-	       (!sum[i].nr || !sum[i].flags || (sum[i].flags & IF_EXPIRED)))
-		i--;
-	last = i + 1;
+    /* Find last valid item */
+    i = MAX_ITEMS - 1;
+    while (i >= first &&
+           (!sum[i].nr || !sum[i].flags || (sum[i].flags & IF_EXPIRED)))
+        i--;
+    last = i + 1;
 
-	for (n = 0, i = first - 1; i < last; i++) {
-		if (sum[i].nr) {
-			if (!sum[i].flags)
-				continue;
-			if (!(sum[i].flags & IF_EXPIRED))
-				n++;
-			if ((sum[i].flags &
-			        (IF_RETIRED | IF_FORGOTTEN | IF_EXPIRED)) &&
-			    (flags & O_FORGET))
-				continue;
-			if (!part[i].nr && sum[i].nr) {
-				st->i_unseen++; /* unseen */
-				if (is_brandnew(&part[i], &sum[i]))
-					st->i_brandnew++;
-			} else if (is_newresp(&part[i], &sum[i]))
-				st->i_newresp++;
-			st->r_totalnewresp += sum[i].nr - abs(part[i].nr);
-		}
-	}
+    for (n = 0, i = first - 1; i < last; i++) {
+        if (sum[i].nr) {
+            if (!sum[i].flags)
+                continue;
+            if (!(sum[i].flags & IF_EXPIRED))
+                n++;
+            if ((sum[i].flags & (IF_RETIRED | IF_FORGOTTEN | IF_EXPIRED)) &&
+                (flags & O_FORGET))
+                continue;
+            if (!part[i].nr && sum[i].nr) {
+                st->i_unseen++; /* unseen */
+                if (is_brandnew(&part[i], &sum[i]))
+                    st->i_brandnew++;
+            } else if (is_newresp(&part[i], &sum[i]))
+                st->i_newresp++;
+            st->r_totalnewresp += sum[i].nr - abs(part[i].nr);
+        }
+    }
 
-	if (!n) {
-		first = 1;
-		last = 0;
-	}
-	st->i_first = first;
-	st->i_last = last;
-	st->i_numitems = n;
+    if (!n) {
+        first = 1;
+        last = 0;
+    }
+    st->i_first = first;
+    st->i_last = last;
+    st->i_numitems = n;
 
-	part_is_dirty = 0;
-	sum_is_dirty = 0;
+    part_is_dirty = 0;
+    sum_is_dirty = 0;
 }
 
 void
@@ -688,18 +682,18 @@ refresh_link(status_t *stt, /* pointer to status structure */
     int i                   /* IN: Item index                         */
 )
 {
-	/* verify it's still linked */
-	if ((sum[i].flags & IF_LINKED) == 0)
-		return;
-	const auto path = std::format("{}/_{}", conflist[idx].location, i + 1);
-	struct stat st;
-	if (stat(path.c_str(), &st) || st.st_nlink < 2) {
-		sum[i].flags &= ~IF_LINKED;
-		dirty_sum(i);
-	}
-	if (st.st_mtime > stt->sumtime) { /* new activity */
-		item_sum(i, sum, part, idx, stt);
-	}
+    /* verify it's still linked */
+    if ((sum[i].flags & IF_LINKED) == 0)
+        return;
+    const auto path = std::format("{}/_{}", conflist[idx].location, i + 1);
+    struct stat st;
+    if (stat(path.c_str(), &st) || st.st_nlink < 2) {
+        sum[i].flags &= ~IF_LINKED;
+        dirty_sum(i);
+    }
+    if (st.st_mtime > stt->sumtime) { /* new activity */
+        item_sum(i, sum, part, idx, stt);
+    }
 }
 /******************************************************************************/
 /* UPDATE THE GLOBAL STATUS STRUCTURE, OPTIONALLY GET ITEM SUBJECTS           */
@@ -713,63 +707,61 @@ get_status(            /* ARGUMENTS:                            */
     int idx            /* IN: Index of conference to process     */
 )
 {
-	sumentry_t s1[MAX_ITEMS];
-	sumentry_t *sum;
-	short i;
-	sum = (s) ? s : s1;
+    sumentry_t s1[MAX_ITEMS];
+    sumentry_t *sum;
+    short i;
+    sum = (s) ? s : s1;
 
-	if (st != (&st_glob))
-		st->sumtime = 0;
-	refresh_sum(0, idx, sum, part, st);
+    if (st != (&st_glob))
+        st->sumtime = 0;
+    refresh_sum(0, idx, sum, part, st);
 
-	/* Are links current? */
-	for (i = 0; i < MAX_ITEMS; i++)
-		refresh_link(st, sum, part, idx, i);
+    /* Are links current? */
+    for (i = 0; i < MAX_ITEMS; i++) refresh_link(st, sum, part, idx, i);
 
-	refresh_stats(sum, part, st);
+    refresh_stats(sum, part, st);
 }
 
 void
 check_mail(int f)
 {
-	static int prev = 0;
-	int f2 = f;
-	std::string mail;
-	struct stat st;
+    static int prev = 0;
+    int f2 = f;
+    std::string mail;
+    struct stat st;
 
-	/*
-	 * Mail is currently only checked in conf.c, when should new mail be
-	 * reported?  At Ok:? or only when join or display new? If conf.c is
-	 * the only place, perhaps it should be moved there. Note: the above
-	 * was fixed when seps were added
-	 */
-	mail = expand("mailbox", DM_VAR);
-	if (mail.empty())
-		mail = getenv("MAIL");
-	if (mail.empty()) {
-		mail = std::format("{}/{}", get_conf_param("maildir", MAILDIR), login);
-	}
-	if (stat(mail.c_str(), &st) == 0 && st.st_size > 0) {
-		status |= S_MAIL;
-		if (st_glob.mailsize && st.st_size > st_glob.mailsize)
-			status |= S_MOREMAIL;
-		st_glob.mailsize = st.st_size;
-	} else {
-		status &= ~S_MAIL;
-		st_glob.mailsize = 0;
-	}
+    /*
+     * Mail is currently only checked in conf.c, when should new mail be
+     * reported?  At Ok:? or only when join or display new? If conf.c is
+     * the only place, perhaps it should be moved there. Note: the above
+     * was fixed when seps were added
+     */
+    mail = expand("mailbox", DM_VAR);
+    if (mail.empty())
+        mail = getenv("MAIL");
+    if (mail.empty()) {
+        mail = std::format("{}/{}", get_conf_param("maildir", MAILDIR), login);
+    }
+    if (stat(mail.c_str(), &st) == 0 && st.st_size > 0) {
+        status |= S_MAIL;
+        if (st_glob.mailsize && st.st_size > st_glob.mailsize)
+            status |= S_MOREMAIL;
+        st_glob.mailsize = st.st_size;
+    } else {
+        status &= ~S_MAIL;
+        st_glob.mailsize = 0;
+    }
 
-	if (status & S_MAIL) {
-		if (!prev)
-			f2 = 1;
-		if (status & S_MOREMAIL) {
-			sepinit(IS_START | IS_ITEM);
-			f2 = 1;
-		}
-		if (f2)
-			confsep(expand("mailmsg", DM_VAR), confidx, &st_glob,
-			    part, 0);
-		status &= ~S_MOREMAIL;
-	}
-	prev = (status & S_MAIL);
+    if (status & S_MAIL) {
+        if (!prev)
+            f2 = 1;
+        if (status & S_MOREMAIL) {
+            sepinit(IS_START | IS_ITEM);
+            f2 = 1;
+        }
+        if (f2)
+            confsep(expand("mailmsg", DM_VAR), confidx, &st_glob, part, 0);
+        status &= ~S_MOREMAIL;
+    }
+    prev = (status & S_MAIL);
 }

--- a/sysop.cc
+++ b/sysop.cc
@@ -39,36 +39,36 @@
 int
 is_sysop(int silent) /* Skip error message? */
 {
-	if (uid == get_nobody_uid()) {
-		if (str::eq(login, get_sysop_login()))
-			return 1;
-	} else if (uid == geteuid())
-		return 1;
-	if (!silent)
-		std::println("Permission denied.");
-	return 0;
+    if (uid == get_nobody_uid()) {
+        if (str::eq(login, get_sysop_login()))
+            return 1;
+    } else if (uid == geteuid())
+        return 1;
+    if (!silent)
+        std::println("Permission denied.");
+    return 0;
 }
 
 void
 reload_conflist(void)
 {
-	if (!(flags & O_QUIET))
-		std::println("Reloading conflist...");
-	const auto &buff = confidx >= 0 ? conflist[confidx].name : "";
-	const auto &path = joinidx >= 0 ? conflist[joinidx].name : "";
-	conflist = grab_list(bbsdir, "conflist", 0);
-	desclist = grab_list(bbsdir, "desclist", 0);
-	for (auto i = 1; i < conflist.size(); i++) {
-		if (str::eq(conflist[0].location, conflist[i].location) ||
-		    match(conflist[0].location, conflist[i].name))
-			defidx = i;
-		if (!buff.empty() && str::eq(buff, conflist[i].name))
-			confidx = i;
-		if (!path.empty() && str::eq(path, conflist[i].name))
-			joinidx = i;
-	}
-	if (defidx < 0)
-		std::println("Warning: bad default {}", conference());
+    if (!(flags & O_QUIET))
+        std::println("Reloading conflist...");
+    const auto &buff = confidx >= 0 ? conflist[confidx].name : "";
+    const auto &path = joinidx >= 0 ? conflist[joinidx].name : "";
+    conflist = grab_list(bbsdir, "conflist", 0);
+    desclist = grab_list(bbsdir, "desclist", 0);
+    for (auto i = 1; i < conflist.size(); i++) {
+        if (str::eq(conflist[0].location, conflist[i].location) ||
+            match(conflist[0].location, conflist[i].name))
+            defidx = i;
+        if (!buff.empty() && str::eq(buff, conflist[i].name))
+            confidx = i;
+        if (!path.empty() && str::eq(path, conflist[i].name))
+            joinidx = i;
+    }
+    if (defidx < 0)
+        std::println("Warning: bad default {}", conference());
 }
 /******************************************************************************/
 /* CREATE A CONFERENCE                                                        */
@@ -79,183 +79,185 @@ cfcreate(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char *cfshort = NULL, *cflong = NULL, *cfemail = NULL, *cfsubdir = NULL,
-	     *cftype = NULL, *cfhosts = NULL;
-	int ok = 1, chacl, previdx;
+    char *cfshort = NULL, *cflong = NULL, *cfemail = NULL, *cfsubdir = NULL,
+         *cftype = NULL, *cfhosts = NULL;
+    int ok = 1, chacl, previdx;
 
-	if (!is_sysop(0))
-		return 1;
+    if (!is_sysop(0))
+        return 1;
 
-	const bool prompt = (flags & O_QUIET) == 0;
-	/* Get configuration information */
-	if (prompt) {
-		std::print("Short name (including underlines): ");
-		std::fflush(stdout);
-	}
-	cfshort = xgets(st_glob.inp, 0);
-	if (!cfshort || !cfshort[0])
-		ok = 0;
+    const bool prompt = (flags & O_QUIET) == 0;
+    /* Get configuration information */
+    if (prompt) {
+        std::print("Short name (including underlines): ");
+        std::fflush(stdout);
+    }
+    cfshort = xgets(st_glob.inp, 0);
+    if (!cfshort || !cfshort[0])
+        ok = 0;
 
-	if (ok) {
-		if (prompt) {
-			std::println("Enter one-line description");
-			std::print("> ");
-			std::fflush(stdout);
-		}
-		cflong = xgets(st_glob.inp, 0);
-		if (!cflong || !cflong[0])
-			ok = 0;
-	}
-	std::string confdir, cfpath;
-	if (ok) {
-		if (prompt) {
-			std::println("Subdirectory [{}]: ", compress(cfshort));
-			std::fflush(stdout);
-		}
-		cfsubdir = xgets(st_glob.inp, 0);
-		if (!cfsubdir[0]) {
-			free(cfsubdir);
-			cfsubdir = estrdup(compress(cfshort).c_str());
-		}
-		confdir = str::concat({get_conf_param("bbsdir", BBSDIR), "/confs"});
-		cfpath = str::join("/", {get_conf_param("confdir", confdir), cfsubdir});
+    if (ok) {
+        if (prompt) {
+            std::println("Enter one-line description");
+            std::print("> ");
+            std::fflush(stdout);
+        }
+        cflong = xgets(st_glob.inp, 0);
+        if (!cflong || !cflong[0])
+            ok = 0;
+    }
+    std::string confdir, cfpath;
+    if (ok) {
+        if (prompt) {
+            std::println("Subdirectory [{}]: ", compress(cfshort));
+            std::fflush(stdout);
+        }
+        cfsubdir = xgets(st_glob.inp, 0);
+        if (!cfsubdir[0]) {
+            free(cfsubdir);
+            cfsubdir = estrdup(compress(cfshort).c_str());
+        }
+        confdir = str::concat({get_conf_param("bbsdir", BBSDIR), "/confs"});
+        cfpath = str::join("/", {get_conf_param("confdir", confdir), cfsubdir});
 
-		if (!cfsubdir || !cfsubdir[0])
-			ok = 0;
-	}
-	if (ok) {
-		if (prompt) {
-			std::print("Fairwitnesses: ");
-			std::fflush(stdout);
-		}
-		cfhosts = xgets(st_glob.inp, 0);
-		if (!cfhosts || !cfhosts[0])
-			ok = 0;
-	}
-	if (ok) {
-		if (prompt) {
-			std::print("Security type: ");
-			std::fflush(stdout);
-		}
-		cftype = xgets(st_glob.inp, 0);
-		if (!cftype || !cftype[0])
-			ok = 0;
-	}
-	if (ok) {
-		const auto prompt =
-		    std::format("Let a {} change the access contro list? ",
-		        fairwitness());
-		chacl = get_yes(prompt, true);
-	}
-	if (ok) {
-		if (prompt) {
-			std::println("Email address(es) (only used for mail type {}s): ",
-			    conference());
-			std::fflush(stdout);
-		}
-		cfemail = xgets(st_glob.inp, 0);
-		if (!cfemail)
-			ok = 0;
-	}
+        if (!cfsubdir || !cfsubdir[0])
+            ok = 0;
+    }
+    if (ok) {
+        if (prompt) {
+            std::print("Fairwitnesses: ");
+            std::fflush(stdout);
+        }
+        cfhosts = xgets(st_glob.inp, 0);
+        if (!cfhosts || !cfhosts[0])
+            ok = 0;
+    }
+    if (ok) {
+        if (prompt) {
+            std::print("Security type: ");
+            std::fflush(stdout);
+        }
+        cftype = xgets(st_glob.inp, 0);
+        if (!cftype || !cftype[0])
+            ok = 0;
+    }
+    if (ok) {
+        const auto prompt = std::format(
+            "Let a {} change the access contro list? ", fairwitness());
+        chacl = get_yes(prompt, true);
+    }
+    if (ok) {
+        if (prompt) {
+            std::println("Email address(es) (only used for mail type {}s): ",
+                conference());
+            std::fflush(stdout);
+        }
+        cfemail = xgets(st_glob.inp, 0);
+        if (!cfemail)
+            ok = 0;
+    }
 
-	/* Create the conference */
-	if (ok) {
-		if (prompt)
-			std::println("Creating conflist entry...");
-		const auto path = str::concat({bbsdir, "/conflist"});
-		const auto content = std::format("{}:{}\n", cfshort, cfpath);
-		ok = write_file(path, content);
-	}
-	if (ok) {
-		if ((flags & O_QUIET) == 0)
-			std::println("Creating desclist entry...");
-		const auto path = str::concat({bbsdir, "/desclist"});
-		const auto content = std::format("{}:{}\n", compress(cfshort), cflong);
-		ok = write_file(path, content);
-	}
-	if (ok && cfemail[0]) {
-		const auto emails = str::split(cfemail, " ");
-		if ((flags & O_QUIET) == 0)
-			std::println("Creating maillist entry...");
-		 /* create maillist entry */
-		const auto path = str::concat({bbsdir, "/maillist"});
-		for (const auto &addr : emails) {
-			const auto line = std::format("{}:{}\n",
-			    addr, compress(cfshort));
-			ok = write_file(path, line);
-			if (!ok)
-				break;
-		}
-	}
-	if (ok) {
-		if (prompt)
-			std::println("Creating directory...");
-		mkdir_all(cfpath, 0755);
-	}
-	if (ok) {
-		if (prompt)
-			std::println("Creating config file...");
-		const auto path = str::concat({cfpath, "/config"}); /* create config file */
-		const auto content = std::format("!<pc02>\n.{}.cf\n0\n{}\n{}\n{}\n",
-		    cfsubdir, cfhosts, cftype, cfemail);
-		ok = write_file(path, content);
-		chmod(path.c_str(), 0644);
-	}
-	if (ok) {
-		if (prompt)
-			std::println("Creating login file...");
-		const auto path = str::concat({cfpath, "/login"}); /* create login file */
-		const auto content = std::format(
-		    "Welcome to the {} {}.  This file may be edited by a {}.\n",
-		    compress(cfshort), conference(), fairwitness());
-		ok = write_file(path, content);
-		chmod(path.c_str(), 0644);
-	}
-	if (ok) {
-		if (!(flags & O_QUIET))
-			std::println("Creating logout file...");
-		const auto path = str::concat({cfpath, "/logout"}); /* create logout file */
-		const auto content = std::format(
-		    "You are now leaving the {} {}.  This file may be edited by a {}.\n",
-		    compress(cfshort), conference(), fairwitness());
-		write_file(path, content);
-		chmod(path.c_str(), 0644);
-	}
-	reload_conflist(); /* Must be done before load_acl() */
-	previdx = confidx; /* Save confidx to restore after expanding
-	                    * macros */
-	confidx = get_idx(compress(cfshort), conflist);
-	if (confidx < 0)
-		ok = 0;
-	load_acl(confidx); /* load acl for new conference */
+    /* Create the conference */
+    if (ok) {
+        if (prompt)
+            std::println("Creating conflist entry...");
+        const auto path = str::concat({bbsdir, "/conflist"});
+        const auto content = std::format("{}:{}\n", cfshort, cfpath);
+        ok = write_file(path, content);
+    }
+    if (ok) {
+        if ((flags & O_QUIET) == 0)
+            std::println("Creating desclist entry...");
+        const auto path = str::concat({bbsdir, "/desclist"});
+        const auto content = std::format("{}:{}\n", compress(cfshort), cflong);
+        ok = write_file(path, content);
+    }
+    if (ok && cfemail[0]) {
+        const auto emails = str::split(cfemail, " ");
+        if ((flags & O_QUIET) == 0)
+            std::println("Creating maillist entry...");
+        /* create maillist entry */
+        const auto path = str::concat({bbsdir, "/maillist"});
+        for (const auto &addr : emails) {
+            const auto line = std::format("{}:{}\n", addr, compress(cfshort));
+            ok = write_file(path, line);
+            if (!ok)
+                break;
+        }
+    }
+    if (ok) {
+        if (prompt)
+            std::println("Creating directory...");
+        mkdir_all(cfpath, 0755);
+    }
+    if (ok) {
+        if (prompt)
+            std::println("Creating config file...");
+        const auto path =
+            str::concat({cfpath, "/config"}); /* create config file */
+        const auto content = std::format("!<pc02>\n.{}.cf\n0\n{}\n{}\n{}\n",
+            cfsubdir, cfhosts, cftype, cfemail);
+        ok = write_file(path, content);
+        chmod(path.c_str(), 0644);
+    }
+    if (ok) {
+        if (prompt)
+            std::println("Creating login file...");
+        const auto path =
+            str::concat({cfpath, "/login"}); /* create login file */
+        const auto content = std::format(
+            "Welcome to the {} {}.  This file may be edited by a {}.\n",
+            compress(cfshort), conference(), fairwitness());
+        ok = write_file(path, content);
+        chmod(path.c_str(), 0644);
+    }
+    if (ok) {
+        if (!(flags & O_QUIET))
+            std::println("Creating logout file...");
+        const auto path =
+            str::concat({cfpath, "/logout"}); /* create logout file */
+        const auto content = std::format("You are now leaving the {} {}.  This "
+                                         "file may be edited by a {}.\n",
+            compress(cfshort), conference(), fairwitness());
+        write_file(path, content);
+        chmod(path.c_str(), 0644);
+    }
+    reload_conflist(); /* Must be done before load_acl() */
+    previdx = confidx; /* Save confidx to restore after expanding
+                        * macros */
+    confidx = get_idx(compress(cfshort), conflist);
+    if (confidx < 0)
+        ok = 0;
+    load_acl(confidx); /* load acl for new conference */
 
-	if (ok) {
-		if (!(flags & O_QUIET))
-			std::println("Creating acl file...");
-		const auto path = str::concat({cfpath, "/acl"}); /* create acl file */
-		std::string content;
-		write_file(path, std::format("r {}\n", expand("racl", DM_VAR)));
-		write_file(path, std::format("w {}\n", expand("wacl", DM_VAR)));
-		write_file(path, std::format("c {}\n", expand("cacl", DM_VAR)));
-		write_file(path, std::format("a {}\n", (chacl) ? "+f:ulist" : "+sysop"));
-		chmod(path.c_str(), 0644);
-	}
-	/* Restore original conference index */
-	confidx = previdx;
+    if (ok) {
+        if (!(flags & O_QUIET))
+            std::println("Creating acl file...");
+        const auto path = str::concat({cfpath, "/acl"}); /* create acl file */
+        std::string content;
+        write_file(path, std::format("r {}\n", expand("racl", DM_VAR)));
+        write_file(path, std::format("w {}\n", expand("wacl", DM_VAR)));
+        write_file(path, std::format("c {}\n", expand("cacl", DM_VAR)));
+        write_file(
+            path, std::format("a {}\n", (chacl) ? "+f:ulist" : "+sysop"));
+        chmod(path.c_str(), 0644);
+    }
+    /* Restore original conference index */
+    confidx = previdx;
 
-	/* Free up space */
-	free(cfshort);
-	free(cflong);
-	free(cfemail);
-	free(cfsubdir);
-	free(cftype);
-	free(cfhosts);
+    /* Free up space */
+    free(cfshort);
+    free(cflong);
+    free(cfemail);
+    free(cfsubdir);
+    free(cftype);
+    free(cfhosts);
 
-	custom_log("cfcreate", M_OK);
+    custom_log("cfcreate", M_OK);
 
-	load_acl(confidx); /* reload acl for current conference */
+    load_acl(confidx); /* reload acl for current conference */
 
-	return 1;
+    return 1;
 }
 /******************************************************************************/
 /* DELETE CURRENT OR OTHER CONFERENCE                                         */
@@ -266,138 +268,138 @@ cfdelete(       /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char *cfshort;
-	sumentry_t fr_sum[MAX_ITEMS];
-	status_t fr_st;
-	partentry_t part2[MAX_ITEMS];
-	int idx = confidx; /* the conference index to delete */
-	FILE *fp;
-	int perm;
+    char *cfshort;
+    sumentry_t fr_sum[MAX_ITEMS];
+    status_t fr_st;
+    partentry_t part2[MAX_ITEMS];
+    int idx = confidx; /* the conference index to delete */
+    FILE *fp;
+    int perm;
 
-	if (!is_sysop(0))
-		return 1;
+    if (!is_sysop(0))
+        return 1;
 
-	/* If no conference was specified, prompt for one */
-	if (argc > 1)
-		cfshort = argv[1];
-	else {
-		if (!(flags & O_QUIET)) {
-			std::print("Short name (including underlines): ");
-			std::fflush(stdout);
-		}
-		cfshort = xgets(st_glob.inp, 0);
-	}
+    /* If no conference was specified, prompt for one */
+    if (argc > 1)
+        cfshort = argv[1];
+    else {
+        if (!(flags & O_QUIET)) {
+            std::print("Short name (including underlines): ");
+            std::fflush(stdout);
+        }
+        cfshort = xgets(st_glob.inp, 0);
+    }
 
-	idx = get_idx(cfshort, conflist);
-	if (argc < 2)
-		free(cfshort);
-	if (idx < 0) {
-		std::println("Cannot access {} {}.", conference(), cfshort);
-		return 1;
-	}
+    idx = get_idx(cfshort, conflist);
+    if (argc < 2)
+        free(cfshort);
+    if (idx < 0) {
+        std::println("Cannot access {} {}.", conference(), cfshort);
+        return 1;
+    }
 
-	/* Verify that conference has no active items */
-	get_status(&fr_st, fr_sum, part2, idx);
-	if (fr_st.i_first <= fr_st.i_last) {
-		std::println("{} is not empty.", conference(1));
-		return 1;
-	}
+    /* Verify that conference has no active items */
+    get_status(&fr_st, fr_sum, part2, idx);
+    if (fr_st.i_first <= fr_st.i_last) {
+        std::println("{} is not empty.", conference(1));
+        return 1;
+    }
 
-	/* Leave conference if we're in it now */
-	if (confidx >= 0 && confidx == idx) {
-		if (!(flags & O_QUIET))
-			std::println("Leaving {}...", conference());
-		leave(0, (char **)0);
-	}
+    /* Leave conference if we're in it now */
+    if (confidx >= 0 && confidx == idx) {
+        if (!(flags & O_QUIET))
+            std::println("Leaving {}...", conference());
+        leave(0, (char **)0);
+    }
 
-	/* Remove all maillist entries */
-	if (fr_st.c_security & CT_EMAIL) {
-		const auto maillist = grab_list(bbsdir, "maillist", 0);
-		if (!maillist.empty()) {
-			const auto path = str::concat({bbsdir, "/maillist"});
-			FILE *fp = mopen(path, O_W);
-			if (fp != NULL) {
-				std::println(fp, "!<hl01>");
-				std::println(fp, "{}", maillist[0].location);
-				for (auto i = 1z; i < maillist.size(); i++)
-					if (!match(maillist[i].location,
-					        conflist[idx].name))
-						std::println(fp, "{}:{}",
-						    maillist[i].name,
-						    maillist[i].location);
-				mclose(fp);
-			}
-		}
-	}
+    /* Remove all maillist entries */
+    if (fr_st.c_security & CT_EMAIL) {
+        const auto maillist = grab_list(bbsdir, "maillist", 0);
+        if (!maillist.empty()) {
+            const auto path = str::concat({bbsdir, "/maillist"});
+            FILE *fp = mopen(path, O_W);
+            if (fp != NULL) {
+                std::println(fp, "!<hl01>");
+                std::println(fp, "{}", maillist[0].location);
+                for (auto i = 1z; i < maillist.size(); i++)
+                    if (!match(maillist[i].location, conflist[idx].name))
+                        std::println(fp, "{}:{}", maillist[i].name,
+                            maillist[i].location);
+                mclose(fp);
+            }
+        }
+    }
 
-	/* If we're using cfadm-owned participation files, delete them */
-	if ((perm = partfile_perm()) == SL_OWNER) {
-		if (!(flags & O_QUIET))
-			std::println("Removing members' participation files...");
-		const auto config = get_config(idx);
-		if (config.size() > CF_PARTFILE) {
-			const auto ulist  = grab_recursive_list(conflist[idx].location, "ulist");
-			for (const auto &user: ulist) {
-				const auto path = get_partdir(user);
-				const auto partfile = str::join("/", {path, config[CF_PARTFILE]});
-				rm(partfile, SL_OWNER);
-				const auto ucflist = grab_file(path, ".cflist",
-				    GF_WORD | GF_SILENT | GF_IGNCMT);
-				if (ucflist.empty())
-					continue;
-				const auto cflistfile = str::concat({path, "/.cflist"});
-				auto newfp = mopen(cflistfile, O_W);
-				if (newfp == NULL)
-					continue;
-				for (const auto &ucf: cflist) {
-					auto k = get_idx(ucf.c_str(), conflist);
-					if (!str::eq(conflist[k].location, conflist[idx].location))
-						std::println(newfp, "{}", ucf);
-				}
-				mclose(newfp);
-			}
-		}
-	}
+    /* If we're using cfadm-owned participation files, delete them */
+    if ((perm = partfile_perm()) == SL_OWNER) {
+        if (!(flags & O_QUIET))
+            std::println("Removing members' participation files...");
+        const auto config = get_config(idx);
+        if (config.size() > CF_PARTFILE) {
+            const auto ulist =
+                grab_recursive_list(conflist[idx].location, "ulist");
+            for (const auto &user : ulist) {
+                const auto path = get_partdir(user);
+                const auto partfile =
+                    str::join("/", {path, config[CF_PARTFILE]});
+                rm(partfile, SL_OWNER);
+                const auto ucflist =
+                    grab_file(path, ".cflist", GF_WORD | GF_SILENT | GF_IGNCMT);
+                if (ucflist.empty())
+                    continue;
+                const auto cflistfile = str::concat({path, "/.cflist"});
+                auto newfp = mopen(cflistfile, O_W);
+                if (newfp == NULL)
+                    continue;
+                for (const auto &ucf : cflist) {
+                    auto k = get_idx(ucf.c_str(), conflist);
+                    if (!str::eq(conflist[k].location, conflist[idx].location))
+                        std::println(newfp, "{}", ucf);
+                }
+                mclose(newfp);
+            }
+        }
+    }
 
-	/* Remove conflist entries */
-	if (!(flags & O_QUIET))
-		std::println("Removing conflist entries...");
-	const auto path = str::concat({bbsdir, "/conflist"});
-	if ((fp = mopen(path, O_W)) != NULL) {
-		std::println(fp, "!<hl01>");
-		std::println(fp, "{}", conflist[0].location);
-		const auto max = conflist.size();
-		for (auto i = 1; i < max; i++)
-			if (!str::eq(conflist[i].location, conflist[idx].location))
-				std::println(fp, "{}:{}",
-				    conflist[i].name, conflist[i].location);
-		mclose(fp);
-	}
+    /* Remove conflist entries */
+    if (!(flags & O_QUIET))
+        std::println("Removing conflist entries...");
+    const auto path = str::concat({bbsdir, "/conflist"});
+    if ((fp = mopen(path, O_W)) != NULL) {
+        std::println(fp, "!<hl01>");
+        std::println(fp, "{}", conflist[0].location);
+        const auto max = conflist.size();
+        for (auto i = 1; i < max; i++)
+            if (!str::eq(conflist[i].location, conflist[idx].location))
+                std::println(
+                    fp, "{}:{}", conflist[i].name, conflist[i].location);
+        mclose(fp);
+    }
 
-	/* Remove desclist entry */
-	if (!(flags & O_QUIET))
-		std::println("Removing desclist entry...");
-	const auto descpath = str::concat({bbsdir, "/desclist"});
-	if ((fp = mopen(descpath, O_W)) != NULL) {
-		std::println(fp, "!<hl01>");
-		std::println(fp, "{}", desclist[0].location);
-		for (auto i = 1; i < desclist.size(); i++)
-			if (!match(desclist[i].name, conflist[idx].name))
-				std::println(fp, "{}:{}",
-				    desclist[i].name, desclist[i].location);
-		mclose(fp);
-	}
+    /* Remove desclist entry */
+    if (!(flags & O_QUIET))
+        std::println("Removing desclist entry...");
+    const auto descpath = str::concat({bbsdir, "/desclist"});
+    if ((fp = mopen(descpath, O_W)) != NULL) {
+        std::println(fp, "!<hl01>");
+        std::println(fp, "{}", desclist[0].location);
+        for (auto i = 1; i < desclist.size(); i++)
+            if (!match(desclist[i].name, conflist[idx].name))
+                std::println(
+                    fp, "{}:{}", desclist[i].name, desclist[i].location);
+        mclose(fp);
+    }
 
-	/* Delete the whole subdirectory */
-	if (!(flags & O_QUIET))
-		std::println("Removing directory...");
-	const auto cmd = std::format("rm -rf {}", conflist[idx].location);
-	system(cmd.c_str());
+    /* Delete the whole subdirectory */
+    if (!(flags & O_QUIET))
+        std::println("Removing directory...");
+    const auto cmd = std::format("rm -rf {}", conflist[idx].location);
+    system(cmd.c_str());
 
-	reload_conflist();
-	custom_log("cfdelete", M_OK);
+    reload_conflist();
+    custom_log("cfdelete", M_OK);
 
-	return 1;
+    return 1;
 }
 
 /* ARGUMENTS: */
@@ -407,31 +409,30 @@ cfdelete(       /* ARGUMENTS:             */
 void
 upd_maillist(int security, const std::vector<std::string> &config, int idx)
 {
-	if ((security & CT_EMAIL) == 0)
-		return;
-	const auto maillist = grab_list(bbsdir, "maillist", 0);
-	std::vector<std::string_view> addr;
-	if (config.size() > CF_EMAIL)
-		addr = str::split(config[CF_EMAIL], " ,");
-	/* Output the contents of the maillist array */
-	const auto path = str::concat({bbsdir, "/maillist"});
-	FILE *fp = mopen(path, O_W);
-	if (fp == NULL)
-		return;
-	std::println(fp, "!<hl01>");
-	std::println(fp, "{}", maillist[0].location);
-	const auto conf_name = compress(conflist[idx].name);
-	auto j = 0z;
-	for (const auto &entry: maillist) {
-		if (str::eq(conf_name, entry.location)) {
-			/* Output the current address for the conference */
-			std::println(fp, "{}:{}", addr[j++], conf_name);
-			continue;
-		}
-		std::println(fp, "{}:{}", entry.name, entry.location);
-	}
-	/* Add any additional addresses */
-	for (; j < addr.size(); j++)
-		std::println(fp, "{}:{}", addr[j], conf_name);
-	mclose(fp);
+    if ((security & CT_EMAIL) == 0)
+        return;
+    const auto maillist = grab_list(bbsdir, "maillist", 0);
+    std::vector<std::string_view> addr;
+    if (config.size() > CF_EMAIL)
+        addr = str::split(config[CF_EMAIL], " ,");
+    /* Output the contents of the maillist array */
+    const auto path = str::concat({bbsdir, "/maillist"});
+    FILE *fp = mopen(path, O_W);
+    if (fp == NULL)
+        return;
+    std::println(fp, "!<hl01>");
+    std::println(fp, "{}", maillist[0].location);
+    const auto conf_name = compress(conflist[idx].name);
+    auto j = 0z;
+    for (const auto &entry : maillist) {
+        if (str::eq(conf_name, entry.location)) {
+            /* Output the current address for the conference */
+            std::println(fp, "{}:{}", addr[j++], conf_name);
+            continue;
+        }
+        std::println(fp, "{}:{}", entry.name, entry.location);
+    }
+    /* Add any additional addresses */
+    for (; j < addr.size(); j++) std::println(fp, "{}:{}", addr[j], conf_name);
+    mclose(fp);
 }

--- a/system.cc
+++ b/system.cc
@@ -42,38 +42,38 @@ extern FILE *conffp;
 void
 process_pipe_input(int fd)
 {
-	char *p, *eb;
-	int n, sz;
-	fd_set rfds;
-	struct timeval tm;
-	/* read output into evalbuf */
-	sz = strlen(evalbuf);
-	eb = evalbuf + sz;
-	FD_ZERO(&rfds);
-	FD_SET(fd, &rfds);
-	tm.tv_sec = 0;
-	tm.tv_usec = 0;
+    char *p, *eb;
+    int n, sz;
+    fd_set rfds;
+    struct timeval tm;
+    /* read output into evalbuf */
+    sz = strlen(evalbuf);
+    eb = evalbuf + sz;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    tm.tv_sec = 0;
+    tm.tv_usec = 0;
 
-	/* do { */
-	/* must do a non-blocking read in case there was no output */
-	if (select(fd + 1, &rfds, NULL, NULL, &tm) > 0) {
-		n = read(fd, eb, sizeof(evalbuf) - 1 - sz);
-		if (n > 0)
-			eb[n] = '\0';
-		if (debug & DB_PIPE) {
-			std::println(stderr, "read in {} chars from pipe", n);
-			fflush(stderr);
-		}
-	}
-	/* } while (n>=0); * repeat until process ends and we get an EOF */
+    /* do { */
+    /* must do a non-blocking read in case there was no output */
+    if (select(fd + 1, &rfds, NULL, NULL, &tm) > 0) {
+        n = read(fd, eb, sizeof(evalbuf) - 1 - sz);
+        if (n > 0)
+            eb[n] = '\0';
+        if (debug & DB_PIPE) {
+            std::println(stderr, "read in {} chars from pipe", n);
+            fflush(stderr);
+        }
+    }
+    /* } while (n>=0); * repeat until process ends and we get an EOF */
 
-	/* Convert all newlines to spaces */
-	for (p = evalbuf; *p; p++) {
-		if (*p == '\n' || *p == '\r')
-			*p = ' ';
-	}
+    /* Convert all newlines to spaces */
+    for (p = evalbuf; *p; p++) {
+        if (*p == '\n' || *p == '\r')
+            *p = ' ';
+    }
 
-	/*std::println("Got !{}! in evalbuf", evalbuf);*/
+    /*std::println("Got !{}! in evalbuf", evalbuf);*/
 }
 
 static int sp_cpid;
@@ -81,14 +81,13 @@ static int sp_cpid;
 int
 smclose(FILE *fp)
 {
-	int statusp, i, wpid;
-	int pid = get_pid(fp);
+    int statusp, i, wpid;
+    int pid = get_pid(fp);
 
-	i = mclose(fp);
-	while ((wpid = waitpid(pid, &statusp, 0)) != pid && wpid != -1)
-		;
+    i = mclose(fp);
+    while ((wpid = waitpid(pid, &statusp, 0)) != pid && wpid != -1);
 
-	return i;
+    return i;
 }
 /******************************************************************************/
 /* SECURE mopen() - OPEN A USER FILE                                          */
@@ -100,57 +99,57 @@ smclose(FILE *fp)
 FILE *
 smopenw(const std::string &file, long flg)
 {
-	int fd[2];
-	FILE *fp;
-	int pid;
+    int fd[2];
+    FILE *fp;
+    int pid;
 
-	if (pipe(fd) < 0)
-		return NULL;
-	if ((fp = fdopen(fd[1], "w")) == NULL)
-		return NULL;
+    if (pipe(fd) < 0)
+        return NULL;
+    if ((fp = fdopen(fd[1], "w")) == NULL)
+        return NULL;
 
-	/* The following two lines are not necessary, and even slow the
-	 * program down, but make seen be more accurate in some cases, since
-	 * less info is buffered by the pager.
-	 */
-	/* fcntl(fd[1], F_SETFL, O_SYNC);
-	   setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
-	 */
+    /* The following two lines are not necessary, and even slow the
+     * program down, but make seen be more accurate in some cases, since
+     * less info is buffered by the pager.
+     */
+    /* fcntl(fd[1], F_SETFL, O_SYNC);
+       setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
+     */
 
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	pid = fork();
-	if (pid) { /* parent */
-		if (pid < 0)
-			return NULL; /* error: couldn't fork */
-		close(fd[0]);
-		status |= S_PIPE;
-		madd(fd[1], file, O_PIPE, pid);
-		return fp;
-	} else { /* child */
-		FILE *ufp;
-		char buff[1024];
-		int len;
-		setuid(getuid());
-		setgid(getgid());
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0);
-		dup(fd[0]);
-		close(fd[1]);
+    pid = fork();
+    if (pid) { /* parent */
+        if (pid < 0)
+            return NULL; /* error: couldn't fork */
+        close(fd[0]);
+        status |= S_PIPE;
+        madd(fd[1], file, O_PIPE, pid);
+        return fp;
+    } else { /* child */
+        FILE *ufp;
+        char buff[1024];
+        int len;
+        setuid(getuid());
+        setgid(getgid());
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0);
+        dup(fd[0]);
+        close(fd[1]);
 
-		if ((ufp = mopen(file, flg)) != NULL) {
-			/* Now copy all standard input to ufp */
-			while ((len = read(0, buff, sizeof(buff))) > 0) {
-				fwrite(buff, len, 1, ufp);
-			}
-			mclose(ufp);
-		}
-		exit(1);
-	}
-	return NULL;
+        if ((ufp = mopen(file, flg)) != NULL) {
+            /* Now copy all standard input to ufp */
+            while ((len = read(0, buff, sizeof(buff))) > 0) {
+                fwrite(buff, len, 1, ufp);
+            }
+            mclose(ufp);
+        }
+        exit(1);
+    }
+    return NULL;
 }
 
 /* RETURNS: Open file pointer, or NULL on error */
@@ -160,73 +159,73 @@ smopenw(const std::string &file, long flg)
 FILE *
 smopenr(const std::string &file, long flg)
 {
-	int fd[2];
-	FILE *fp;
-	int pid;
-	if (pipe(fd) < 0)
-		return NULL;
-	if ((fp = fdopen(fd[0], "r")) == NULL)
-		return NULL;
+    int fd[2];
+    FILE *fp;
+    int pid;
+    if (pipe(fd) < 0)
+        return NULL;
+    if ((fp = fdopen(fd[0], "r")) == NULL)
+        return NULL;
 
-	/* The following two lines are not necessary, and even slow the
-	 * program down, but make seen be more accurate in some cases, since
-	 * less info is buffered by the pager. */
-	/* fcntl(fd[1], F_SETFL, O_SYNC);
-	   setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
-	 */
+    /* The following two lines are not necessary, and even slow the
+     * program down, but make seen be more accurate in some cases, since
+     * less info is buffered by the pager. */
+    /* fcntl(fd[1], F_SETFL, O_SYNC);
+       setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
+     */
 
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	pid = fork();
-	if (pid) { /* parent */
-		if (pid < 0)
-			return NULL; /* error: couldn't fork */
-		close(fd[1]);
-		status |= S_PIPE;
-		madd(fd[0], file, O_PIPE, pid);
-		return fp;
-	} else { /* child */
-		FILE *ufp;
-		char buff[1024];
-		int len;
-		setuid(getuid());
-		setgid(getgid());
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(1);
-		if (status & S_PAGER)
-			fclose(st_glob.outp);
-		dup(fd[1]);
-		close(fd[0]);
+    pid = fork();
+    if (pid) { /* parent */
+        if (pid < 0)
+            return NULL; /* error: couldn't fork */
+        close(fd[1]);
+        status |= S_PIPE;
+        madd(fd[0], file, O_PIPE, pid);
+        return fp;
+    } else { /* child */
+        FILE *ufp;
+        char buff[1024];
+        int len;
+        setuid(getuid());
+        setgid(getgid());
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(1);
+        if (status & S_PAGER)
+            fclose(st_glob.outp);
+        dup(fd[1]);
+        close(fd[0]);
 
-		/* Close stdin, stderr in case they are also pipes */
-		/* 10/28/95: these were 'if 0'ed out, but I'm not sure why.
-		 * Solaris requires this to be done or else the following test
-		 * fails: "source read2" gives duplicate output, where read2
-		 * is: echo normal eval < rh echo duplicated and rh is:
-		 * anything */
-		/* 1/13/97 These were inside the if block below, but if the
-		 * file doesn't exist, then we have the same problem:
-		 * #!/usr/local/bin/bbs -qx debug ioredir set source join yapp
-		 * echo HELLO and the HELLO is printed twice. */
-		close(0);
-		close(2);
+        /* Close stdin, stderr in case they are also pipes */
+        /* 10/28/95: these were 'if 0'ed out, but I'm not sure why.
+         * Solaris requires this to be done or else the following test
+         * fails: "source read2" gives duplicate output, where read2
+         * is: echo normal eval < rh echo duplicated and rh is:
+         * anything */
+        /* 1/13/97 These were inside the if block below, but if the
+         * file doesn't exist, then we have the same problem:
+         * #!/usr/local/bin/bbs -qx debug ioredir set source join yapp
+         * echo HELLO and the HELLO is printed twice. */
+        close(0);
+        close(2);
 
-		/*std::println("opening {} for {:x}", file, flg);*/
-		if ((ufp = mopen(file, flg)) != NULL) {
+        /*std::println("opening {} for {:x}", file, flg);*/
+        if ((ufp = mopen(file, flg)) != NULL) {
 
-			/* Now copy ufp to standard output */
-			while ((len = fread(buff, 1, sizeof(buff), ufp)) > 0) {
-				write(1, buff, len);
-			}
+            /* Now copy ufp to standard output */
+            while ((len = fread(buff, 1, sizeof(buff), ufp)) > 0) {
+                write(1, buff, len);
+            }
 
-			mclose(ufp);
-		}
-		exit(1);
-	}
-	return NULL;
+            mclose(ufp);
+        }
+        exit(1);
+    }
+    return NULL;
 }
 
 /******************************************************************************/
@@ -240,97 +239,97 @@ smopenr(const std::string &file, long flg)
 int
 sdpopen(FILE **finp, FILE **foutp, const std::string &cmd)
 {
-	int fd_tocmd[2];
-	int fd_fromcmd[2];
-	FILE *fin, *fout;
+    int fd_tocmd[2];
+    int fd_fromcmd[2];
+    FILE *fin, *fout;
 
-	if (foutp && pipe(fd_tocmd) < 0)
-		return 0;
+    if (foutp && pipe(fd_tocmd) < 0)
+        return 0;
 
-	if (finp && pipe(fd_fromcmd) < 0) {
-		close(fd_tocmd[0]);
-		close(fd_tocmd[1]);
-		return 0;
-	}
+    if (finp && pipe(fd_fromcmd) < 0) {
+        close(fd_tocmd[0]);
+        close(fd_tocmd[1]);
+        return 0;
+    }
 
-	/* The following two lines are not necessary, and even slow the
-	 * program down, but make seen be more accurate in some cases, since
-	 * less info is buffered by the pager. */
-	/* fcntl(fd[1], F_SETFL, O_SYNC);
-	   setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
-	 */
-	fflush(stdout);
-	fflush(stderr);
-	sp_cpid = fork();
-	if (sp_cpid < 0) {
-		perror("fork failed");
-		return 0;
-	}
-	if (sp_cpid == 0) {
-		// Child.
-		setuid(getuid());
-		setgid(getgid());
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		if (foutp) {
-			close(0);
-			dup(fd_tocmd[0]);
-			close(fd_tocmd[1]);
-		}
-		if (finp) {
-			close(1);
-			dup(fd_fromcmd[1]);
-			close(fd_fromcmd[1]);
-		}
-		if (confidx >= 0)
-			mclose(conffp);
-		if (strpbrk(cmd.c_str(), "<>*?|![]{}~`$&';\\\"") == NULL) {
-			const auto args = str::splits(cmd, " ", true);
-			auto argv = new const char *[args.size() + 1];
-			std::transform(args.begin(), args.end(), argv,
-			    [](const std::string &s) { return s.c_str(); });
-			argv[args.size()] = nullptr;
-			execvp(argv[0], (char * const *)argv);
-		} else {
-			const auto shpathname = expand("shell", DM_VAR);
-			const auto *shpath = shpathname.c_str();
-			const auto *sh = strrchr(shpath, '/');
-			if (sh == nullptr)
-				sh = shpath;
-			else
-				++sh;
-			execl(shpath, sh, "-c", cmd.c_str(), (char *)NULL);
-		}
-		std::println("oops: Can't execute \"{}\"!", cmd);
-		exit(1);
-	}
-	// Parent.
-	status |= S_PIPE;
-	if (debug & DB_PIPE) {
-		std::print(stderr, "(stderr) Opened pipe to '{}': ", cmd);
-		if (finp)
-			std::print(stderr, "in fd {}", fd_fromcmd[0]);
-		if (finp && foutp)
-			std::print(stderr, " ");
-		if (foutp)
-			std::print(stderr, "out fd {}", fd_tocmd[1]);
-		std::println(stderr, ".");
-	}
-	if (foutp) {
-		close(fd_tocmd[0]);
-		madd(fd_tocmd[1], cmd, O_PIPE, sp_cpid);
-		if ((fout = fdopen(fd_tocmd[1], "w")) == NULL)
-			return 0;
-		*foutp = fout;
-	}
-	if (finp) {
-		close(fd_fromcmd[1]);
-		madd(fd_fromcmd[0], cmd, O_PIPE, sp_cpid);
-		if ((fin = fdopen(fd_fromcmd[0], "r")) == NULL)
-			return 0;
-		*finp = fin;
-	}
-	return 1;
+    /* The following two lines are not necessary, and even slow the
+     * program down, but make seen be more accurate in some cases, since
+     * less info is buffered by the pager. */
+    /* fcntl(fd[1], F_SETFL, O_SYNC);
+       setsockopt(fd[1],SOL_SOCKET, SO_SNDBUF, 4, 1);
+     */
+    fflush(stdout);
+    fflush(stderr);
+    sp_cpid = fork();
+    if (sp_cpid < 0) {
+        perror("fork failed");
+        return 0;
+    }
+    if (sp_cpid == 0) {
+        // Child.
+        setuid(getuid());
+        setgid(getgid());
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        if (foutp) {
+            close(0);
+            dup(fd_tocmd[0]);
+            close(fd_tocmd[1]);
+        }
+        if (finp) {
+            close(1);
+            dup(fd_fromcmd[1]);
+            close(fd_fromcmd[1]);
+        }
+        if (confidx >= 0)
+            mclose(conffp);
+        if (strpbrk(cmd.c_str(), "<>*?|![]{}~`$&';\\\"") == NULL) {
+            const auto args = str::splits(cmd, " ", true);
+            auto argv = new const char *[args.size() + 1];
+            std::transform(args.begin(), args.end(), argv,
+                [](const std::string &s) { return s.c_str(); });
+            argv[args.size()] = nullptr;
+            execvp(argv[0], (char *const *)argv);
+        } else {
+            const auto shpathname = expand("shell", DM_VAR);
+            const auto *shpath = shpathname.c_str();
+            const auto *sh = strrchr(shpath, '/');
+            if (sh == nullptr)
+                sh = shpath;
+            else
+                ++sh;
+            execl(shpath, sh, "-c", cmd.c_str(), (char *)NULL);
+        }
+        std::println("oops: Can't execute \"{}\"!", cmd);
+        exit(1);
+    }
+    // Parent.
+    status |= S_PIPE;
+    if (debug & DB_PIPE) {
+        std::print(stderr, "(stderr) Opened pipe to '{}': ", cmd);
+        if (finp)
+            std::print(stderr, "in fd {}", fd_fromcmd[0]);
+        if (finp && foutp)
+            std::print(stderr, " ");
+        if (foutp)
+            std::print(stderr, "out fd {}", fd_tocmd[1]);
+        std::println(stderr, ".");
+    }
+    if (foutp) {
+        close(fd_tocmd[0]);
+        madd(fd_tocmd[1], cmd, O_PIPE, sp_cpid);
+        if ((fout = fdopen(fd_tocmd[1], "w")) == NULL)
+            return 0;
+        *foutp = fout;
+    }
+    if (finp) {
+        close(fd_fromcmd[1]);
+        madd(fd_fromcmd[0], cmd, O_PIPE, sp_cpid);
+        if ((fin = fdopen(fd_fromcmd[0], "r")) == NULL)
+            return 0;
+        *finp = fin;
+    }
+    return 1;
 }
 
 /******************************************************************************/
@@ -342,12 +341,12 @@ sdpopen(FILE **finp, FILE **foutp, const std::string &cmd)
 FILE *
 spopen(const std::string &cmd)
 {
-	if (status & (S_PAGER | S_SOCKET))
-		wputs("Error, pipe already open\n");
-	FILE *fp;
-	if (!sdpopen(NULL, &fp, cmd))
-		return NULL;
-	return fp;
+    if (status & (S_PAGER | S_SOCKET))
+        wputs("Error, pipe already open\n");
+    FILE *fp;
+    if (!sdpopen(NULL, &fp, cmd))
+        return NULL;
+    return fp;
 }
 
 /******************************************************************************/
@@ -360,7 +359,7 @@ spopen(const std::string &cmd)
 int
 spout(int fd, const char *buff)
 {
-	return write(fd, buff, strlen(buff));
+    return write(fd, buff, strlen(buff));
 }
 /******************************************************************************/
 /* CLOSE A SECURE PIPE                                                        */
@@ -368,33 +367,30 @@ spout(int fd, const char *buff)
 int
 sdpclose(FILE *fin, FILE *fout)
 {
-	int i;
-	int statusp, wpid;
-	if (!(status & (S_PAGER | S_PIPE))) {
-		std::println("Error, pipe not open");
-	}
-	if (fout) {
-		if (debug & DB_PIPE) {
-			std::println(stderr, "(stderr) Closing pipe on fd {}",
-			    fileno(fout));
-			std::println("(stdout) Closing pipe on fd {}",
-			    fileno(fout));
-			fflush(stdout);
-		}
-		i = mclose(fout);
-	}
-	if (status & S_PIPE)
-		while ((wpid = waitpid(sp_cpid, &statusp, 0)) != sp_cpid &&
-		       wpid != -1)
-			;
+    int i;
+    int statusp, wpid;
+    if (!(status & (S_PAGER | S_PIPE))) {
+        std::println("Error, pipe not open");
+    }
+    if (fout) {
+        if (debug & DB_PIPE) {
+            std::println(
+                stderr, "(stderr) Closing pipe on fd {}", fileno(fout));
+            std::println("(stdout) Closing pipe on fd {}", fileno(fout));
+            fflush(stdout);
+        }
+        i = mclose(fout);
+    }
+    if (status & S_PIPE)
+        while ((wpid = waitpid(sp_cpid, &statusp, 0)) != sp_cpid && wpid != -1);
 
-	if (fin) {
-		if (status & S_EXECUTE)
-			process_pipe_input(fileno(fin));
-		i = mclose(fin);
-	}
-	status &= ~(S_PIPE | S_PAGER | S_INT);
-	return i;
+    if (fin) {
+        if (status & S_EXECUTE)
+            process_pipe_input(fileno(fin));
+        i = mclose(fin);
+    }
+    status &= ~(S_PIPE | S_PAGER | S_INT);
+    return i;
 }
 /******************************************************************************/
 /* CLOSE A SECURE PIPE                                                        */
@@ -405,7 +401,7 @@ sdpclose(FILE *fin, FILE *fout)
 int
 spclose(FILE *pp)
 {
-	return sdpclose(NULL, pp);
+    return sdpclose(NULL, pp);
 }
 
 int exit_status = 0; /* exit status of last unix command executed */
@@ -418,78 +414,75 @@ int exit_status = 0; /* exit status of last unix command executed */
 int
 unix_cmd(const std::string &cmd)
 {
-	int cpid, wpid;
-	int statusp;
-	int fd[2];
+    int cpid, wpid;
+    int statusp;
+    int fd[2];
 
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	/* Prepare to capture output for a `unix ...` replacement */
-	if (status & S_EXECUTE) {
-		if (pipe(fd) < 0)
-			return -1;
-	}
+    /* Prepare to capture output for a `unix ...` replacement */
+    if (status & S_EXECUTE) {
+        if (pipe(fd) < 0)
+            return -1;
+    }
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		signal(SIGINT, SIG_IGN);
-		signal(SIGPIPE, SIG_IGN);
-		while (
-		    (wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1)
-			;
-		signal(SIGINT, handle_int);
-		signal(SIGPIPE, handle_pipe);
-		if (status & S_EXECUTE) {
-			process_pipe_input(fd[0]);
-		}
-	} else { /* child */
-		setuid(getuid());
-		setgid(getgid());
-		if (status & S_EXECUTE) {
-			close(1);     /* close stdout */
-			dup(fd[1]);   /* reopen pipe-out as stdin */
-			close(fd[0]); /* close pipe-in */
-		}
-		/* If this is a script, and we didn't specify a specific input
-		 * redirection, then restore the REAL stdin */
-		if ((status & S_BATCH) && !(status & S_NOSTDIN)) {
-			close(0);
-			dup(saved_stdin[0].fd); /* dup(real_stdin); */
-		}
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return -1; /* error: couldn't fork */
+        signal(SIGINT, SIG_IGN);
+        signal(SIGPIPE, SIG_IGN);
+        while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1);
+        signal(SIGINT, handle_int);
+        signal(SIGPIPE, handle_pipe);
+        if (status & S_EXECUTE) {
+            process_pipe_input(fd[0]);
+        }
+    } else { /* child */
+        setuid(getuid());
+        setgid(getgid());
+        if (status & S_EXECUTE) {
+            close(1);     /* close stdout */
+            dup(fd[1]);   /* reopen pipe-out as stdin */
+            close(fd[0]); /* close pipe-in */
+        }
+        /* If this is a script, and we didn't specify a specific input
+         * redirection, then restore the REAL stdin */
+        if ((status & S_BATCH) && !(status & S_NOSTDIN)) {
+            close(0);
+            dup(saved_stdin[0].fd); /* dup(real_stdin); */
+        }
 
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		if (confidx >= 0)
-			mclose(conffp);
-		if (strpbrk(cmd.c_str(), "<>*?|![]{}~`$&';\\\"") == NULL) {
-			const auto args = str::splits(cmd, " ", true);
-			auto argv = new const char *[args.size() + 1];
-			std::transform(args.begin(), args.end(), argv,
-			    [](const std::string &s) { return s.c_str(); });
-			argv[args.size()] = nullptr;
-			execvp(argv[0], (char * const *)argv);
-			std::println("oops: Can't execute \"{}\"!", cmd);
-		} else {
-			const auto shvar = expand("shell", DM_VAR);
-			const auto *shpath = shvar.c_str();
-			const auto *sh = strrchr(shpath, '/');
-			if (sh == nullptr)
-				sh = shpath;
-			else
-				++sh;
-			execl(shpath, sh, "-c", cmd.c_str(), (char *)NULL);
-		}
-		exit(1);
-	}
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        if (confidx >= 0)
+            mclose(conffp);
+        if (strpbrk(cmd.c_str(), "<>*?|![]{}~`$&';\\\"") == NULL) {
+            const auto args = str::splits(cmd, " ", true);
+            auto argv = new const char *[args.size() + 1];
+            std::transform(args.begin(), args.end(), argv,
+                [](const std::string &s) { return s.c_str(); });
+            argv[args.size()] = nullptr;
+            execvp(argv[0], (char *const *)argv);
+            std::println("oops: Can't execute \"{}\"!", cmd);
+        } else {
+            const auto shvar = expand("shell", DM_VAR);
+            const auto *shpath = shvar.c_str();
+            const auto *sh = strrchr(shpath, '/');
+            if (sh == nullptr)
+                sh = shpath;
+            else
+                ++sh;
+            execl(shpath, sh, "-c", cmd.c_str(), (char *)NULL);
+        }
+        exit(1);
+    }
 
-
-	/*std::println("UNIX2 ftell={}", ftell(st_glob.inp));*/
-	exit_status = WEXITSTATUS(statusp);
-	return statusp;
+    /*std::println("UNIX2 ftell={}", ftell(st_glob.inp));*/
+    exit_status = WEXITSTATUS(statusp);
+    return statusp;
 }
 /******************************************************************************/
 /* REMOVE A FILE                                                              */
@@ -501,37 +494,36 @@ unix_cmd(const std::string &cmd)
 int
 rm(const std::string &file, int sec)
 {
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
-	if (!sec)
-		return unlink(file.c_str());
-	auto cpid = fork();
-	if (cpid < 0)
-		return -1; /* error: couldn't fork */
-	if (cpid == 0) {
-		/* child */
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0);
-		setuid(getuid());
-		setgid(getgid());
-		exit(unlink(file.c_str()));
-	}
-	/* parent */
-	pid_t wpid;
-	int statusp;
-	while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid > 0)
-		;
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
+    if (!sec)
+        return unlink(file.c_str());
+    auto cpid = fork();
+    if (cpid < 0)
+        return -1; /* error: couldn't fork */
+    if (cpid == 0) {
+        /* child */
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0);
+        setuid(getuid());
+        setgid(getgid());
+        exit(unlink(file.c_str()));
+    }
+    /* parent */
+    pid_t wpid;
+    int statusp;
+    while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid > 0);
 
-	/*
-	 * This Error message removed 7/24/95 at request of janc, so
-	 * that his `gate` editor will not give this error
-	 *
-	 * if (statusp) error("removing ",file);
-	 */
+    /*
+     * This Error message removed 7/24/95 at request of janc, so
+     * that his `gate` editor will not give this error
+     *
+     * if (statusp) error("removing ",file);
+     */
 
-	return statusp;
+    return statusp;
 }
 /******************************************************************************/
 /* SECURELY COPY ONE FILE TO ANOTHER                                          */
@@ -544,60 +536,58 @@ rm(const std::string &file, int sec)
 int
 copy_file(const std::string &src, const std::string &dest, int sec)
 {
-	FILE *fsrc, *fdest;
-	int c;
-	int cpid, wpid;
-	int statusp;
-	long mod;
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    FILE *fsrc, *fdest;
+    int c;
+    int cpid, wpid;
+    int statusp;
+    long mod;
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		while (
-		    (wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1)
-			;
-	} else { /* child */
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0);
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return -1; /* error: couldn't fork */
+        while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1);
+    } else { /* child */
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0);
 
-		if (confidx >= 0)
-			mclose(conffp);
+        if (confidx >= 0)
+            mclose(conffp);
 
-		mod = O_W;
-		if (!sec && (st_glob.c_security & CT_BASIC))
-			mod |= O_PRIVATE;
+        mod = O_W;
+        if (!sec && (st_glob.c_security & CT_BASIC))
+            mod |= O_PRIVATE;
 
-		if (sec) { /* cfadm to user */
-			if ((fsrc = mopen(src, O_R)) == NULL)
-				exit(1);
-			setuid(getuid());
-			setgid(getgid());
-			if ((fdest = mopen(dest, mod)) == NULL) {
-				mclose(fsrc);
-				exit(1);
-			}
-		} else { /* user to cfadm */
-			if ((fdest = mopen(dest, mod)) == NULL)
-				exit(1);
-			setuid(getuid());
-			setgid(getgid());
-			if ((fsrc = mopen(src, O_R)) == NULL) {
-				mclose(fdest);
-				exit(1);
-			}
-		}
+        if (sec) { /* cfadm to user */
+            if ((fsrc = mopen(src, O_R)) == NULL)
+                exit(1);
+            setuid(getuid());
+            setgid(getgid());
+            if ((fdest = mopen(dest, mod)) == NULL) {
+                mclose(fsrc);
+                exit(1);
+            }
+        } else { /* user to cfadm */
+            if ((fdest = mopen(dest, mod)) == NULL)
+                exit(1);
+            setuid(getuid());
+            setgid(getgid());
+            if ((fsrc = mopen(src, O_R)) == NULL) {
+                mclose(fdest);
+                exit(1);
+            }
+        }
 
-		while ((c = fgetc(fsrc)) != EOF) fputc(c, fdest);
-		mclose(fdest);
-		mclose(fsrc);
-		exit(0);
-	}
-	return statusp;
+        while ((c = fgetc(fsrc)) != EOF) fputc(c, fdest);
+        mclose(fdest);
+        mclose(fsrc);
+        exit(0);
+    }
+    return statusp;
 }
 /******************************************************************************/
 /* SECURELY MOVE ONE FILE TO ANOTHER                                          */
@@ -610,42 +600,41 @@ copy_file(const std::string &src, const std::string &dest, int sec)
 int
 move_file(const std::string &src, const std::string &dest, int sec)
 {
-	int cpid, wpid, statusp;
-	int ret;
+    int cpid, wpid, statusp;
+    int ret;
 
-	if (sec == SL_OWNER) {
-		ret = rename(src.c_str(), dest.c_str());
-		if (ret < 0)
-			error("renaming ", src);
-		return ret;
-	}
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    if (sec == SL_OWNER) {
+        ret = rename(src.c_str(), dest.c_str());
+        if (ret < 0)
+            error("renaming ", src);
+        return ret;
+    }
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid < 0)
-		return -1; /* error: couldn't fork */
-	if (cpid > 0) {    /* parent */
-		while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1)
-			;
-	} else { /* child */
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0);
+    cpid = fork();
+    if (cpid < 0)
+        return -1;  /* error: couldn't fork */
+    if (cpid > 0) { /* parent */
+        while ((wpid = waitpid(cpid, &statusp, 0)) != cpid && wpid != -1);
+    } else { /* child */
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0);
 
-		if (confidx >= 0)
-			mclose(conffp);
+        if (confidx >= 0)
+            mclose(conffp);
 
-		setuid(getuid());
-		setgid(getgid());
+        setuid(getuid());
+        setgid(getgid());
 
-		exit(rename(src.c_str(), dest.c_str()));
-	}
-	if (statusp)
-		error("renaming ", src);
+        exit(rename(src.c_str(), dest.c_str()));
+    }
+    if (statusp)
+        error("renaming ", src);
 
-	return statusp;
+    return statusp;
 }
 
 /******************************************************************************/
@@ -659,24 +648,24 @@ move_file(const std::string &src, const std::string &dest, int sec)
 int
 priv_edit(const std::string &dir, const std::string &file, int flags)
 {
-	std::string origfile(dir);
-	if (!file.empty()) {
-		origfile.append("/");
-		origfile.append(file);
-	}
-	auto cfbuffer = str::concat({work, "/cf.buffer"});
-	/* Copy file to cf.buffer owned by user */
-	copy_file(origfile, cfbuffer, SL_USER); /* Assume readable by user? XXX */
-	/* Edit it */
-	auto ret = edit(cfbuffer, "", flags & 1);
-	if (!ret) {
-		std::println("Aborting...");
-		return 0;
-	}
-	if ((flags & 2) || get_yes("Ok to install this? ", false))
-		copy_file(cfbuffer, origfile, SL_OWNER);
-	rm(cfbuffer, SL_USER);
-	return ret;
+    std::string origfile(dir);
+    if (!file.empty()) {
+        origfile.append("/");
+        origfile.append(file);
+    }
+    auto cfbuffer = str::concat({work, "/cf.buffer"});
+    /* Copy file to cf.buffer owned by user */
+    copy_file(origfile, cfbuffer, SL_USER); /* Assume readable by user? XXX */
+    /* Edit it */
+    auto ret = edit(cfbuffer, "", flags & 1);
+    if (!ret) {
+        std::println("Aborting...");
+        return 0;
+    }
+    if ((flags & 2) || get_yes("Ok to install this? ", false))
+        copy_file(cfbuffer, origfile, SL_OWNER);
+    rm(cfbuffer, SL_USER);
+    return ret;
 }
 
 /* RETURNS: (nothing)                       */
@@ -687,129 +676,129 @@ priv_edit(const std::string &dir, const std::string &file, int flags)
 int
 edit(const std::string &dir, const std::string &file, bool visual)
 {
-	struct stat st;
+    struct stat st;
 
-	std::string origfile(dir);
-	if (!file.empty()) {
-		origfile.append("/");
-		origfile.append(file);
-	}
+    std::string origfile(dir);
+    if (!file.empty()) {
+        origfile.append("/");
+        origfile.append(file);
+    }
 
-	const auto ed = expand(visual ? "visual" : "editor", DM_VAR);
+    const auto ed = expand(visual ? "visual" : "editor", DM_VAR);
 
-	if (str::eq(ed, "builtin")) {
-		flags &= ~O_EDALWAYS;
+    if (str::eq(ed, "builtin")) {
+        flags &= ~O_EDALWAYS;
 
-		/* Copy file to user's cf.buffer */
-		auto cfbuffer = str::concat({work, "/cf.buffer"});
-		const auto is_cfbuffer = (cfbuffer == origfile);
-		if (!is_cfbuffer)
-			copy_file(origfile, cfbuffer, SL_USER);
-		if (text_loop(0, "text")) {
-			/* Now install cf.buffer contents in original filename
-			 */
-			if (!is_cfbuffer) {
-				copy_file(cfbuffer, origfile, SL_USER);
-				rm(cfbuffer, SL_USER);
-			}
-		}
-	} else {
-		const auto cmd = str::join(" ", {ed, origfile});
-		unix_cmd(cmd);
-	}
+        /* Copy file to user's cf.buffer */
+        auto cfbuffer = str::concat({work, "/cf.buffer"});
+        const auto is_cfbuffer = (cfbuffer == origfile);
+        if (!is_cfbuffer)
+            copy_file(origfile, cfbuffer, SL_USER);
+        if (text_loop(0, "text")) {
+            /* Now install cf.buffer contents in original filename
+             */
+            if (!is_cfbuffer) {
+                copy_file(cfbuffer, origfile, SL_USER);
+                rm(cfbuffer, SL_USER);
+            }
+        }
+    } else {
+        const auto cmd = str::join(" ", {ed, origfile});
+        unix_cmd(cmd);
+    }
 
-	return stat(origfile.c_str(), &st) == 0;
+    return stat(origfile.c_str(), &st) == 0;
 }
 
 /* RETURNS: 1 on success, 0 on failure */
 int
-ssave_dbm(const std::string &userfile, const std::string_view &key, const std::string_view &value)
+ssave_dbm(const std::string &userfile, const std::string_view &key,
+    const std::string_view &value)
 {
-	const auto flags = GDBM_READER|GDBM_WRITER|GDBM_WRCREAT;
-	auto db = gdbm_open(userfile.c_str(), 0, flags, 0644, nullptr);
-	if (db == nullptr)
-		return 0;
-	datum dkey;
-	dkey.dptr = (char *)key.data();
-	dkey.dsize = key.size();
-	datum dvalue;
-	dvalue.dptr = (char *)value.data();
-	dvalue.dsize = value.size();
-	gdbm_store(db, dkey, dvalue, GDBM_REPLACE);
-	gdbm_close(db);
-	return 1;
+    const auto flags = GDBM_READER | GDBM_WRITER | GDBM_WRCREAT;
+    auto db = gdbm_open(userfile.c_str(), 0, flags, 0644, nullptr);
+    if (db == nullptr)
+        return 0;
+    datum dkey;
+    dkey.dptr = (char *)key.data();
+    dkey.dsize = key.size();
+    datum dvalue;
+    dvalue.dptr = (char *)value.data();
+    dvalue.dsize = value.size();
+    gdbm_store(db, dkey, dvalue, GDBM_REPLACE);
+    gdbm_close(db);
+    return 1;
 }
 
 /* RETURNS: 1 on success, 0 on failure */
 int
-save_dbm(const std::string &userfile, const std::string_view &key, const std::string_view &value, int suid)
+save_dbm(const std::string &userfile, const std::string_view &key,
+    const std::string_view &value, int suid)
 {
 
-	if (suid == SL_OWNER) {
-		return ssave_dbm(userfile, key, value);
+    if (suid == SL_OWNER) {
+        return ssave_dbm(userfile, key, value);
 
-	} else { /* suid==SL_USER */
-		fflush(stdout);
-		if (status & S_PAGER)
-			fflush(st_glob.outp);
-		auto cpid = fork();
-		if (cpid < 0)
-			return -1; /* error: couldn't fork */
-		if (cpid == 0) { /* child */
-			signal(SIGINT, SIG_DFL);
-			signal(SIGPIPE, SIG_DFL);
-			close(0);
+    } else { /* suid==SL_USER */
+        fflush(stdout);
+        if (status & S_PAGER)
+            fflush(st_glob.outp);
+        auto cpid = fork();
+        if (cpid < 0)
+            return -1;   /* error: couldn't fork */
+        if (cpid == 0) { /* child */
+            signal(SIGINT, SIG_DFL);
+            signal(SIGPIPE, SIG_DFL);
+            close(0);
 
-			setuid(getuid());
-			setgid(getgid());
-			exit(!ssave_dbm(userfile, key, value));
-		}
-		/* Parent */
-		int wpid, status;
-		while ((wpid = waitpid(cpid, &status, 0)) != cpid && wpid > 0)
-			;
-		return !status;
-	}
+            setuid(getuid());
+            setgid(getgid());
+            exit(!ssave_dbm(userfile, key, value));
+        }
+        /* Parent */
+        int wpid, status;
+        while ((wpid = waitpid(cpid, &status, 0)) != cpid && wpid > 0);
+        return !status;
+    }
 }
 
 void
 dump_dbm(const std::string &userfile)
 {
-	auto db = gdbm_open(userfile.c_str(), 0, GDBM_READER, 0644, nullptr);
-	if (db == nullptr) {
-		perror(userfile.c_str());
-		return;
-	}
-	datum dkey = gdbm_firstkey(db);
-	while (dkey.dptr != nullptr) {
-		datum dval = gdbm_fetch(db, dkey);
-		std::println("{:.{}}: {:.{}}",
-		    (const char *)dkey.dptr, dkey.dsize,
-		    (const char *)dval.dptr, dval.dsize);
-		datum next = gdbm_nextkey(db, dkey);
-		free(dkey.dptr);
-		dkey = next;
-	}
-	gdbm_close(db);
+    auto db = gdbm_open(userfile.c_str(), 0, GDBM_READER, 0644, nullptr);
+    if (db == nullptr) {
+        perror(userfile.c_str());
+        return;
+    }
+    datum dkey = gdbm_firstkey(db);
+    while (dkey.dptr != nullptr) {
+        datum dval = gdbm_fetch(db, dkey);
+        std::println("{:.{}}: {:.{}}", (const char *)dkey.dptr, dkey.dsize,
+            (const char *)dval.dptr, dval.dsize);
+        datum next = gdbm_nextkey(db, dkey);
+        free(dkey.dptr);
+        dkey = next;
+    }
+    gdbm_close(db);
 }
 
 static std::string
 sget_dbm(const std::string &userfile, const std::string_view &key)
 {
-	const auto flags = GDBM_READER|GDBM_WRITER|GDBM_WRCREAT;
-	auto db = gdbm_open(userfile.c_str(), 0, flags, 0644, nullptr);
-	if (db == nullptr)
-		return "";
-	datum dkey;
-	dkey.dptr = (char *)key.data();
-	dkey.dsize = key.size();
-	datum dvalue = gdbm_fetch(db, dkey);
-	gdbm_close(db);
-	if (dvalue.dptr == nullptr)
-		return "";
-	std::string value((const char *)dvalue.dptr, dvalue.dsize);
-	free(dvalue.dptr);
-	return value;
+    const auto flags = GDBM_READER | GDBM_WRITER | GDBM_WRCREAT;
+    auto db = gdbm_open(userfile.c_str(), 0, flags, 0644, nullptr);
+    if (db == nullptr)
+        return "";
+    datum dkey;
+    dkey.dptr = (char *)key.data();
+    dkey.dsize = key.size();
+    datum dvalue = gdbm_fetch(db, dkey);
+    gdbm_close(db);
+    if (dvalue.dptr == nullptr)
+        return "";
+    std::string value((const char *)dvalue.dptr, dvalue.dsize);
+    free(dvalue.dptr);
+    return value;
 }
 
 /* This function must use a pipe to send back the string */
@@ -817,50 +806,49 @@ sget_dbm(const std::string &userfile, const std::string_view &key)
 std::string
 get_dbm(const std::string &userfile, const std::string_view &key, int suid)
 {
-	if (suid == SL_OWNER) {
-		return sget_dbm(userfile, key);
+    if (suid == SL_OWNER) {
+        return sget_dbm(userfile, key);
 
-	} else { /* suid==SL_USER */
-		int fd[2];
+    } else { /* suid==SL_USER */
+        int fd[2];
 
-		/* Open a pipe to use to pass string back through */
-		if (pipe(fd) < 0)
-			return "";
+        /* Open a pipe to use to pass string back through */
+        if (pipe(fd) < 0)
+            return "";
 
-		/* Flush output to avoid duplication */
-		fflush(stdout);
-		if (status & S_PAGER)
-			fflush(st_glob.outp);
+        /* Flush output to avoid duplication */
+        fflush(stdout);
+        if (status & S_PAGER)
+            fflush(st_glob.outp);
 
-		auto cpid = fork();
-		if (cpid < 0)
-			return ""; /* error: couldn't fork */
-		if (cpid == 0) {
-			/* child */
-			signal(SIGINT, SIG_DFL);
-			signal(SIGPIPE, SIG_DFL);
-			close(0);
-			close(fd[0]);
+        auto cpid = fork();
+        if (cpid < 0)
+            return ""; /* error: couldn't fork */
+        if (cpid == 0) {
+            /* child */
+            signal(SIGINT, SIG_DFL);
+            signal(SIGPIPE, SIG_DFL);
+            close(0);
+            close(fd[0]);
 
-			setuid(getuid());
-			setgid(getgid());
+            setuid(getuid());
+            setgid(getgid());
 
-			const auto str = sget_dbm(userfile, key);
-			write(fd[1], str.c_str(), str.size());
-			close(fd[1]);
-			exit(0);
-		}
-		/* parent */
-		close(fd[1]);
-		char buf[4096];
-		ssize_t n = read(fd[0], buf, sizeof(buf));
-		close(fd[0]);
-		std::string value(buf, n);
-		int wpid, status;
-		while ((wpid = waitpid(cpid, &status, 0)) != cpid && wpid > 0)
-			;
-		if (n <= 0)
-			return "";
-		return std::string(buf, n);
-	}
+            const auto str = sget_dbm(userfile, key);
+            write(fd[1], str.c_str(), str.size());
+            close(fd[1]);
+            exit(0);
+        }
+        /* parent */
+        close(fd[1]);
+        char buf[4096];
+        ssize_t n = read(fd[0], buf, sizeof(buf));
+        close(fd[0]);
+        std::string value(buf, n);
+        int wpid, status;
+        while ((wpid = waitpid(cpid, &status, 0)) != cpid && wpid > 0);
+        if (n <= 0)
+            return "";
+        return std::string(buf, n);
+    }
 }

--- a/user.cc
+++ b/user.cc
@@ -44,35 +44,35 @@ static int listsize;
 uid_t
 get_nobody_uid(void)
 {
-	static uid_t nobody_uid = 0;
+    static uid_t nobody_uid = 0;
 
-	/* Resolve uid for "nobody" if needed */
-	if (nobody_uid == 0) {
-		const auto nobody = get_conf_param("nobody", NOBODY);
-		const struct passwd *nuid = getpwnam(nobody.c_str());
-		if (nuid != NULL)
-			nobody_uid = nuid->pw_uid;
-	}
+    /* Resolve uid for "nobody" if needed */
+    if (nobody_uid == 0) {
+        const auto nobody = get_conf_param("nobody", NOBODY);
+        const struct passwd *nuid = getpwnam(nobody.c_str());
+        if (nuid != NULL)
+            nobody_uid = nuid->pw_uid;
+    }
 
-	return nobody_uid;
+    return nobody_uid;
 }
 
 const std::string &
 get_sysop_login(void)
 {
-	static std::string cfadm;
-	if (cfadm.empty()) {
-		if (getuid() == get_nobody_uid())
-			cfadm = get_conf_param("sysop", cfadm);
-		if (cfadm.empty()) {
-			struct passwd *pwd = getpwuid(geteuid());
-			if (pwd != nullptr)
-				cfadm = pwd->pw_name;
-		}
-		if (cfadm.empty())
-			cfadm = "cfadm";
-	}
-	return cfadm;
+    static std::string cfadm;
+    if (cfadm.empty()) {
+        if (getuid() == get_nobody_uid())
+            cfadm = get_conf_param("sysop", cfadm);
+        if (cfadm.empty()) {
+            struct passwd *pwd = getpwuid(geteuid());
+            if (pwd != nullptr)
+                cfadm = pwd->pw_name;
+        }
+        if (cfadm.empty())
+            cfadm = "cfadm";
+    }
+    return cfadm;
 }
 
 #ifdef WWW
@@ -81,112 +81,108 @@ get_sysop_login(void)
 std::string
 get_userfile(const std::string_view &who, int *suid)
 {
-	int nullsuid;
-	if (suid == nullptr) suid = &nullsuid;
+    int nullsuid;
+    if (suid == nullptr)
+        suid = &nullsuid;
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true")) {
-		const auto filename =
-		    std::format("{}/{:c}/{:c}/{}/{}",
-		        get_conf_param("userhome", USER_HOME), tolower(who[0]),
-		        tolower(who[1]), who, who);
-		*suid = SL_USER;
-		return filename;
-	}
+    if (match(get_conf_param("userdbm", USERDBM), "true")) {
+        const auto filename = std::format("{}/{:c}/{:c}/{}/{}",
+            get_conf_param("userhome", USER_HOME), tolower(who[0]),
+            tolower(who[1]), who, who);
+        *suid = SL_USER;
+        return filename;
+    }
 #endif
-	const auto file = get_conf_param("userfile", USER_FILE);
-	if (file[0] == '~' && file[1] == '/') {
-		const auto filename =
-		    std::format("{}/{:c}/{:c}/{}/{}",
-		        get_conf_param("userhome", USER_HOME), tolower(who[0]),
-		        tolower(who[1]), who, file.c_str() + 2);
-		*suid = SL_USER;
-		return filename;
-	}
-	*suid = SL_OWNER;
-	return file;
+    const auto file = get_conf_param("userfile", USER_FILE);
+    if (file[0] == '~' && file[1] == '/') {
+        const auto filename = std::format("{}/{:c}/{:c}/{}/{}",
+            get_conf_param("userhome", USER_HOME), tolower(who[0]),
+            tolower(who[1]), who, file.c_str() + 2);
+        *suid = SL_USER;
+        return filename;
+    }
+    *suid = SL_OWNER;
+    return file;
 }
 /*
  * A "local" user is one whose identity exists only inside Yapp,
  * rather than having their own Unix account.
  */
 static int
-get_local_user(
-    const std::string_view &login,	/* IN: login to find */
-    std::string &fullname,    		/* OUT: full name (or NULL) */
-    std::string &home,			/* OUT: home directory to use (or NULL) */
-    std::string &email			/* OUT: email address (or NULL) */
+get_local_user(const std::string_view &login, /* IN: login to find */
+    std::string &fullname,                    /* OUT: full name (or NULL) */
+    std::string &home, /* OUT: home directory to use (or NULL) */
+    std::string &email /* OUT: email address (or NULL) */
 )
 {
-	FILE *fp;
-	std::string buff;
-	int suid;
+    FILE *fp;
+    std::string buff;
+    int suid;
 
-	/* Retrieve information from user file (could be in user dir) */
-	if (debug & DB_USER)
-		std::println("called get_local_user(\"{}\")", login);
+    /* Retrieve information from user file (could be in user dir) */
+    if (debug & DB_USER)
+        std::println("called get_local_user(\"{}\")", login);
 
-	const auto filename = get_userfile(login, &suid);
+    const auto filename = get_userfile(login, &suid);
 
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true")) {
-		struct stat st;
-		const auto path = str::concat({filename, ".db"});
-		if (stat(path.c_str(), &st))
-			return 0;
-		auto homepath = std::format("{}/{}",
-		    get_conf_param("userhome", USER_HOME), login);
-		if (access(homepath.c_str(), X_OK))
-			homepath = std::format("{}/{:c}/{:c}/{}",
-			    get_conf_param("userhome", USER_HOME),
-			    tolower(login[0]), tolower(login[1]),
-			    login);
-		home = homepath;
-		fullname = get_dbm(filename, "fullname", SL_USER);
-		email = get_dbm(filename, "email", SL_USER);
-		return 1;
-	}
+    if (match(get_conf_param("userdbm", USERDBM), "true")) {
+        struct stat st;
+        const auto path = str::concat({filename, ".db"});
+        if (stat(path.c_str(), &st))
+            return 0;
+        auto homepath =
+            std::format("{}/{}", get_conf_param("userhome", USER_HOME), login);
+        if (access(homepath.c_str(), X_OK))
+            homepath = std::format("{}/{:c}/{:c}/{}",
+                get_conf_param("userhome", USER_HOME), tolower(login[0]),
+                tolower(login[1]), login);
+        home = homepath;
+        fullname = get_dbm(filename, "fullname", SL_USER);
+        email = get_dbm(filename, "email", SL_USER);
+        return 1;
+    }
 #endif
 
-	if (suid == SL_USER) {
-		/* Here, it's okay for it not to exist, since that just means
-		 * it's not a web user */
-		if ((fp = smopenr(filename, O_R | O_SILENT)) == NULL)
-			return 0;
-	} else {
-		if ((fp = mopen(filename, O_R)) == NULL)
-			return 0;
-	}
-	while (ngets(buff, fp)) {
-		const auto field = str::splits(buff, ":", false);
-		if (field.empty())
-			continue;
-		if (str::eq(field[0], login)) {
-			fullname = field[1];
-			email = field[2];
-			auto homepath = std::format("{}/{}",
-			    get_conf_param("userhome", USER_HOME), login);
-			if (access(homepath.c_str(), X_OK))
-				homepath = std::format("{}/{:c}/{:c}/{}",
-				    get_conf_param("userhome", USER_HOME),
-				    tolower(login[0]), tolower(login[1]),
-				    login);
-			home = homepath;
-			if (suid == SL_USER)
-				smclose(fp);
-			else
-				mclose(fp);
-			if (debug & DB_USER)
-				std::println("get_local_user found (\"{}\",\"{}\")",
-				    login, fullname);
-			return 1;
-		}
-	}
-	if (suid == SL_USER)
-		smclose(fp);
-	else
-		mclose(fp);
+    if (suid == SL_USER) {
+        /* Here, it's okay for it not to exist, since that just means
+         * it's not a web user */
+        if ((fp = smopenr(filename, O_R | O_SILENT)) == NULL)
+            return 0;
+    } else {
+        if ((fp = mopen(filename, O_R)) == NULL)
+            return 0;
+    }
+    while (ngets(buff, fp)) {
+        const auto field = str::splits(buff, ":", false);
+        if (field.empty())
+            continue;
+        if (str::eq(field[0], login)) {
+            fullname = field[1];
+            email = field[2];
+            auto homepath = std::format(
+                "{}/{}", get_conf_param("userhome", USER_HOME), login);
+            if (access(homepath.c_str(), X_OK))
+                homepath = std::format("{}/{:c}/{:c}/{}",
+                    get_conf_param("userhome", USER_HOME), tolower(login[0]),
+                    tolower(login[1]), login);
+            home = homepath;
+            if (suid == SL_USER)
+                smclose(fp);
+            else
+                mclose(fp);
+            if (debug & DB_USER)
+                std::println(
+                    "get_local_user found (\"{}\",\"{}\")", login, fullname);
+            return 1;
+        }
+    }
+    if (suid == SL_USER)
+        smclose(fp);
+    else
+        mclose(fp);
 
-	return 0;
+    return 0;
 }
 #endif
 
@@ -212,102 +208,100 @@ get_local_user(
 /* IN: user ID or 0 for lookup by login */
 /* IN: if uid is 0, login is name to find */
 int
-get_user(uid_t *uid, std::string &login, std::string &fullname, std::string &home, std::string &email)
+get_user(uid_t *uid, std::string &login, std::string &fullname,
+    std::string &home, std::string &email)
 {
-	char *tmp;
-	struct passwd *pwd = NULL;
+    char *tmp;
+    struct passwd *pwd = NULL;
 
-	if (debug & DB_USER)
-		std::println("called get_user({},\"{}\")",
-		    uid ? *uid : 0, login);
+    if (debug & DB_USER)
+        std::println("called get_user({},\"{}\")", uid ? *uid : 0, login);
 
-	/* Case 1: Get current WWW user getuid=nobody,  uid=0, login=0 -> get
-	 * current WWW user info getuid=nobody,  uid=nobody, login=0 -> get
-	 * current WWW user info */
-	if (getuid() == get_nobody_uid() &&
-	    (!*uid || *uid == get_nobody_uid()) && login.empty() &&
-	    (tmp = getenv("REMOTE_USER")) && tmp[0]) {
-		*uid = get_nobody_uid();
-		login = tmp;
-		return get_local_user(login, fullname, home, email);
-	}
+    /* Case 1: Get current WWW user getuid=nobody,  uid=0, login=0 -> get
+     * current WWW user info getuid=nobody,  uid=nobody, login=0 -> get
+     * current WWW user info */
+    if (getuid() == get_nobody_uid() && (!*uid || *uid == get_nobody_uid()) &&
+        login.empty() && (tmp = getenv("REMOTE_USER")) && tmp[0]) {
+        *uid = get_nobody_uid();
+        login = tmp;
+        return get_local_user(login, fullname, home, email);
+    }
 
-	/* If blank spec, get Unix user getuid!=nobody, uid=0, login=0 -> get
-	 * current Unix user info */
-	if ((*uid) == 0 && login.empty()) {
-		*uid = getuid();
+    /* If blank spec, get Unix user getuid!=nobody, uid=0, login=0 -> get
+     * current Unix user info */
+    if ((*uid) == 0 && login.empty()) {
+        *uid = getuid();
 
-		tmp = getlogin();
+        tmp = getlogin();
 #ifdef HAVE_CUSERID
-		if (!tmp)
-			tmp = cuserid(NULL);
+        if (!tmp)
+            tmp = cuserid(NULL);
 #endif
 
-		/* For some really odd reason, I have observed Solaris
-		 * reporting the login (from both getlogin() and cuserid()) as
-		 * "LOGIN". Let's just pretend we got a NULL returned instead.
-		 */
-		if (tmp && str::eq(tmp, "LOGIN"))
-			tmp = NULL;
+        /* For some really odd reason, I have observed Solaris
+         * reporting the login (from both getlogin() and cuserid()) as
+         * "LOGIN". Let's just pretend we got a NULL returned instead.
+         */
+        if (tmp && str::eq(tmp, "LOGIN"))
+            tmp = NULL;
 
-		if (tmp) {
-			if (!(pwd = getpwnam(tmp))) {
-				if (debug & DB_USER)
-					std::println("getpwnam failed to get anything for login {}",
-					    tmp);
-				return 0;
-			}
+        if (tmp) {
+            if (!(pwd = getpwnam(tmp))) {
+                if (debug & DB_USER)
+                    std::println(
+                        "getpwnam failed to get anything for login {}", tmp);
+                return 0;
+            }
 
-			/* Verify that UID = Login's UID */
-			if (pwd->pw_uid == *uid)
-				login = tmp;
-		}
-	} else if ((*uid) == 0) { /* search by login */
-		/* uid=0, login there -> search Unix, then WWW by login */
-		if ((pwd = getpwnam(login.c_str())) == nullptr) {
-			/* search Unix first then WWW */
-			return get_local_user(login, fullname, home, email);
-		}
-		*uid = pwd->pw_uid;
-	}
+            /* Verify that UID = Login's UID */
+            if (pwd->pw_uid == *uid)
+                login = tmp;
+        }
+    } else if ((*uid) == 0) { /* search by login */
+        /* uid=0, login there -> search Unix, then WWW by login */
+        if ((pwd = getpwnam(login.c_str())) == nullptr) {
+            /* search Unix first then WWW */
+            return get_local_user(login, fullname, home, email);
+        }
+        *uid = pwd->pw_uid;
+    }
 
-	/* Ok, now *uid is valid */
-	if (login.empty()) {
-		/* uid != 0, login=0       -> search Unix by uid */
-		if (!(pwd = getpwuid(*uid)))
-			return 0;
-		login = pwd->pw_name;
-	}
-	if (!pwd)
-		pwd = getpwuid(*uid);
-	if (debug & DB_USER)
-		std::println("get_user saw ({},\"{}\",\"{}\")", *uid, login, fullname);
+    /* Ok, now *uid is valid */
+    if (login.empty()) {
+        /* uid != 0, login=0       -> search Unix by uid */
+        if (!(pwd = getpwuid(*uid)))
+            return 0;
+        login = pwd->pw_name;
+    }
+    if (!pwd)
+        pwd = getpwuid(*uid);
+    if (debug & DB_USER)
+        std::println("get_user saw ({},\"{}\",\"{}\")", *uid, login, fullname);
 
+    /* uid=nobody, login there -> search WWW by login */
+    if (*uid == get_nobody_uid() &&
+        !str::eq(login, get_conf_param("nobody", NOBODY))) {
+        return get_local_user(login, fullname, home, email);
+    }
 
-	/* uid=nobody, login there -> search WWW by login */
-	if (*uid == get_nobody_uid() &&
-	    !str::eq(login, get_conf_param("nobody", NOBODY)))
-	{
-		return get_local_user(login, fullname, home, email);
-	}
+    /* uid other, login there  -> grab extra info for Unix user */
+    if (!pwd)
+        return 0;
+    home = pwd->pw_dir;
 
-	/* uid other, login there  -> grab extra info for Unix user */
-	if (!pwd)
-		return 0;
-	home = pwd->pw_dir;
+    fullname = "Unknown";
+    const auto namestrs =
+        str::splits(pwd->pw_gecos, expand("gecos", DM_VAR), false);
+    if (!namestrs.empty())
+        fullname = namestrs[0];
 
-	fullname = "Unknown";
-	const auto namestrs = str::splits(pwd->pw_gecos, expand("gecos", DM_VAR), false);
-	if (!namestrs.empty())
-		fullname = namestrs[0];
+    if (debug & DB_USER)
+        std::println(
+            "get_user found ({},\"{}\",\"{}\")", *uid, login, fullname);
 
-	if (debug & DB_USER)
-		std::println("get_user found ({},\"{}\",\"{}\")",
-		    *uid, login, fullname);
+    email = std::format("{}@{}", login, hostname);
 
-	email = std::format("{}@{}", login, hostname);
-
-	return 1;
+    return 1;
 }
 /*
  * The slow way: search through userfile.   This only works if
@@ -316,51 +310,51 @@ get_user(uid_t *uid, std::string &login, std::string &fullname, std::string &hom
 const char *
 email2login(const std::string_view &email)
 {
-	int suid;
-	FILE *fp;
-	std::string buff;
-	static std::string login;
+    int suid;
+    FILE *fp;
+    std::string buff;
+    static std::string login;
 
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true")) {
-		/* If it's true, then we don't have a good way to verify
-		 * registered users at the moment.  In the future, we might
-		 * want to have a dbm file indexed by email address. XXX */
-		return NULL;
-	}
+    if (match(get_conf_param("userdbm", USERDBM), "true")) {
+        /* If it's true, then we don't have a good way to verify
+         * registered users at the moment.  In the future, we might
+         * want to have a dbm file indexed by email address. XXX */
+        return NULL;
+    }
 #endif
 
-	/* Make sure there's a single user file */
-	login.clear();
-	const auto userfile = get_userfile(login, &suid);
-	if (suid == SL_USER)
-		return NULL; /* No good way to do this either */
-	if ((fp = mopen(userfile, O_R)) == NULL)
-		return NULL;
+    /* Make sure there's a single user file */
+    login.clear();
+    const auto userfile = get_userfile(login, &suid);
+    if (suid == SL_USER)
+        return NULL; /* No good way to do this either */
+    if ((fp = mopen(userfile, O_R)) == NULL)
+        return NULL;
 
-	const auto partsA = str::split(email, "@");
-	if (partsA.size() < 2) {
-		mclose(fp);
-		return NULL;
-	}
+    const auto partsA = str::split(email, "@");
+    if (partsA.size() < 2) {
+        mclose(fp);
+        return NULL;
+    }
 
-	/* Search for email address */
-	while (ngets(buff, fp)) {
-		const auto field = str::split(buff, ":", false);
-		if (field.size() < 3)
-			continue;
-		const auto partsB = str::split(field[2], "@");
-		if (partsB.size() < 2)
-			continue;
-		if (partsA[0] == partsB[0] && partsA[1].ends_with(partsB[1])) {
-			login = field[0];
-			mclose(fp);
-			return login.c_str();
-		}
-	}
-	mclose(fp);
+    /* Search for email address */
+    while (ngets(buff, fp)) {
+        const auto field = str::split(buff, ":", false);
+        if (field.size() < 3)
+            continue;
+        const auto partsB = str::split(field[2], "@");
+        if (partsB.size() < 2)
+            continue;
+        if (partsA[0] == partsB[0] && partsA[1].ends_with(partsB[1])) {
+            login = field[0];
+            mclose(fp);
+            return login.c_str();
+        }
+    }
+    mclose(fp);
 
-	return nullptr;
+    return nullptr;
 }
 
 #ifdef WWW
@@ -382,10 +376,10 @@ static unsigned char itoa64[] = /* 0 ... 63 => ascii - 64 */
 static void
 to64(char *s, long v, int n)
 {
-	while (--n >= 0) {
-		*s++ = itoa64[v & 0x3f];
-		v >>= 6;
-	}
+    while (--n >= 0) {
+        *s++ = itoa64[v & 0x3f];
+        v >>= 6;
+    }
 }
 
 #ifdef INCLUDE_EXTRA_COMMANDS
@@ -393,44 +387,43 @@ to64(char *s, long v, int n)
 std::string
 get_passwd(const std::string_view &who)
 {
-	if (who.empty())
-		return "";
+    if (who.empty())
+        return "";
 
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true") &&
-	    str::eq(get_conf_param("userfile", USER_FILE),
-	        get_conf_param("passfile", PASS_FILE)))
-	{
-		int suid;
-		const auto userfile = get_userfile(login, &suid);
-		return get_dbm(userfile, "passwd", SL_USER);
-	}
+    if (match(get_conf_param("userdbm", USERDBM), "true") &&
+        str::eq(get_conf_param("userfile", USER_FILE),
+            get_conf_param("passfile", PASS_FILE))) {
+        int suid;
+        const auto userfile = get_userfile(login, &suid);
+        return get_dbm(userfile, "passwd", SL_USER);
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Check local user file */
-	FILE *fp = mopen(get_conf_param("passfile", PASS_FILE), O_R);
-	if (fp == NULL) {
-		error("opening", " user file");
-		exit(1);
-	}
-	std::string line;
-	while (ngets(line, fp)) {
-		if (line.empty() || line[0] == '#')
-			continue;
-		auto w = line.find(':');
-		if (w != std::string::npos) {
-			const auto wline = std::string_view(line).substr(0, w);
-			line.erase(w);
-			if (who == wline) {
-				mclose(fp);
-				line.erase(0, w + 1);
-				return line;
-			}
-		}
-	}
-	mclose(fp);
+    /* Check local user file */
+    FILE *fp = mopen(get_conf_param("passfile", PASS_FILE), O_R);
+    if (fp == NULL) {
+        error("opening", " user file");
+        exit(1);
+    }
+    std::string line;
+    while (ngets(line, fp)) {
+        if (line.empty() || line[0] == '#')
+            continue;
+        auto w = line.find(':');
+        if (w != std::string::npos) {
+            const auto wline = std::string_view(line).substr(0, w);
+            line.erase(w);
+            if (who == wline) {
+                mclose(fp);
+                line.erase(0, w + 1);
+                return line;
+            }
+        }
+    }
+    mclose(fp);
 
-	return "";
+    return "";
 }
 #endif
 
@@ -443,27 +436,27 @@ static std::string
 make_ticket(const std::string &key, time_t tm)
 {
 #ifdef int_CRYPT
-	char buff[MAX_LINE_LENGTH];
-	int len;
+    char buff[MAX_LINE_LENGTH];
+    int len;
 #endif
-	char salt[3];
-	salt[2] = '\0';
-	srand(tm);
-	to64(&salt[0], rand(), 2);
-	salt[2] = '\0';
+    char salt[3];
+    salt[2] = '\0';
+    srand(tm);
+    to64(&salt[0], rand(), 2);
+    salt[2] = '\0';
 #ifdef int_CRYPT
-	len = key.size();
-	const char *p = key.data();
-	std::string out(crypt(p, salt));
-	strcpy(buff, crypt(p, salt));
-	p += 8;
-	while (p - key.data() < len) {
-		strcat(buff, crypt(p, salt) + 2);
-		p += 8;
-	}
-	return std::string(buff);
+    len = key.size();
+    const char *p = key.data();
+    std::string out(crypt(p, salt));
+    strcpy(buff, crypt(p, salt));
+    p += 8;
+    while (p - key.data() < len) {
+        strcat(buff, crypt(p, salt) + 2);
+        p += 8;
+    }
+    return std::string(buff);
 #else
-	return std::string(crypt(key, salt));
+    return std::string(crypt(key, salt));
 #endif
 }
 
@@ -476,65 +469,65 @@ make_ticket(const std::string &key, time_t tm)
 std::string
 get_ticket(time_t tm, const std::string_view &who)
 {
-	time_t rtm;
+    time_t rtm;
 
-	/* Validate timestamp */
-	time(&rtm);
-	if (!tm)
-		tm = rtm;
+    /* Validate timestamp */
+    time(&rtm);
+    if (!tm)
+        tm = rtm;
 
-	if (tm > rtm || tm < rtm - TIMEDELTA) {
-		return "";
-	}
+    if (tm > rtm || tm < rtm - TIMEDELTA) {
+        return "";
+    }
 
-	/* Validate login */
-	const auto password = get_passwd(who);
-	if (password.empty()) {
-		return "";
-	}
+    /* Validate login */
+    const auto password = get_passwd(who);
+    if (password.empty()) {
+        return "";
+    }
 
-	/* Output ticket */
-	return str::join(":", {std::to_string(tm), std::string(who), make_ticket(password, tm)});
+    /* Output ticket */
+    return str::join(
+        ":", {std::to_string(tm), std::string(who), make_ticket(password, tm)});
 }
 
 static int
 do_authenticate(const std::string &ticket)
 {
 
-	/* Only "nobody" can authenticate */
-	if ((status & S_NOAUTH) == 0) {
-		std::println("You are already authenticated.");
-		return 0;
-	}
-	const auto field = str::split(ticket, ":", false);
-	if (field.empty())
-		return 0;
+    /* Only "nobody" can authenticate */
+    if ((status & S_NOAUTH) == 0) {
+        std::println("You are already authenticated.");
+        return 0;
+    }
+    const auto field = str::split(ticket, ":", false);
+    if (field.empty())
+        return 0;
 
-	time_t tm = str::toi(field[0]);
-	auto ticket1 = get_ticket(tm, field[1]);
-	if (!ticket.empty() && ticket == ticket1) {
-		login = field[1];
-		status &= ~S_NOAUTH;
-		return 1;
-	}
+    time_t tm = str::toi(field[0]);
+    auto ticket1 = get_ticket(tm, field[1]);
+    if (!ticket.empty() && ticket == ticket1) {
+        login = field[1];
+        status &= ~S_NOAUTH;
+        return 1;
+    }
 
-	return 0;
+    return 0;
 }
 #endif /* INCLUDE_EXTRA_COMMANDS */
 
 std::string
 get_partdir(const std::string_view &login)
 {
-	const auto pdir = get_conf_param("partdir", "work");
-	if (match(pdir, "work"))
-		return work;
-	else {
-		const auto path = std::format("{}/{:c}/{:c}/{}",
-		    pdir, tolower(login[0]),
-		    tolower(login[1]), login);
-		mkdir_all(path, 0700);
-		return path;
-	}
+    const auto pdir = get_conf_param("partdir", "work");
+    if (match(pdir, "work"))
+        return work;
+    else {
+        const auto path = std::format("{}/{:c}/{:c}/{}", pdir,
+            tolower(login[0]), tolower(login[1]), login);
+        mkdir_all(path, 0700);
+        return path;
+    }
 }
 /*
  * Assuming login is already set, do everything else necessary to initialize
@@ -547,195 +540,186 @@ get_partdir(const std::string_view &login)
 void
 login_user(void)
 {
-	/* preserve original flags throughout */
-	static int old_flags = 0, first_call = 1;
+    /* preserve original flags throughout */
+    static int old_flags = 0, first_call = 1;
 
-	if (first_call) {
-		first_call = 0;
-		old_flags = (flags & (O_READONLY | O_OBSERVE));
-	}
+    if (first_call) {
+        first_call = 0;
+        old_flags = (flags & (O_READONLY | O_OBSERVE));
+    }
 
-	/* Reset home */
-	if (!get_user(&uid, login, st_glob.fullname, home, email)) {
-		error("reading ", "user entry");
-		endbbs(2);
-	}
+    /* Reset home */
+    if (!get_user(&uid, login, st_glob.fullname, home, email)) {
+        error("reading ", "user entry");
+        endbbs(2);
+    }
 
-	/* Set mailbox macro */
-	std::string mail(getenv("MAIL"));
-	if (mail.empty())
-		mail = std::format("{}/{}",get_conf_param("maildir", MAILDIR), login);
-	def_macro("mailbox", DM_VAR, mail);
+    /* Set mailbox macro */
+    std::string mail(getenv("MAIL"));
+    if (mail.empty())
+        mail = std::format("{}/{}", get_conf_param("maildir", MAILDIR), login);
+    def_macro("mailbox", DM_VAR, mail);
 
-	/* Set global variable "work" */
-	if (access(home.c_str(), X_OK)) {
-		if (!str::eq(login, get_conf_param("nobody", NOBODY)))
-			error("accessing ", home);
+    /* Set global variable "work" */
+    if (access(home.c_str(), X_OK)) {
+        if (!str::eq(login, get_conf_param("nobody", NOBODY)))
+            error("accessing ", home);
 
-		/* If can't access home directory, continue as an observer */
-		flags |= O_READONLY | O_OBSERVE;
-	} else {
-		/* restore original readonly/observe flag settings */
-		flags = (flags & ~(O_READONLY | O_OBSERVE)) | old_flags;
-	}
-	work = home + "/.cfdir";
-	if (access(work.c_str(), X_OK))
-		work = home;
+        /* If can't access home directory, continue as an observer */
+        flags |= O_READONLY | O_OBSERVE;
+    } else {
+        /* restore original readonly/observe flag settings */
+        flags = (flags & ~(O_READONLY | O_OBSERVE)) | old_flags;
+    }
+    work = home + "/.cfdir";
+    if (access(work.c_str(), X_OK))
+        work = home;
 
-	/* Set partdir (must be done before refresh_list() below) */
-	partdir = get_partdir(login);
+    /* Set partdir (must be done before refresh_list() below) */
+    partdir = get_partdir(login);
 
-	/* Read in PARTDIR/.cflist */
-	listtime = 0;
-	refresh_list();
+    /* Read in PARTDIR/.cflist */
+    listtime = 0;
+    refresh_list();
 
-	/* Execute user's cfonce file */
-	std::string buff(work);
-	source(work, ".cfonce", 0, SL_USER);
+    /* Execute user's cfonce file */
+    std::string buff(work);
+    source(work, ".cfonce", 0, SL_USER);
 
 #ifdef INCLUDE_EXTRA_COMMANDS
-	/* If "work" changed above, do the cflist again */
-	if (!str::eq(work, buff)) { /* for cfdir command */
-		source(work, ".cfonce", 0, SL_USER);
-		refresh_list();
-	}
+    /* If "work" changed above, do the cflist again */
+    if (!str::eq(work, buff)) { /* for cfdir command */
+        source(work, ".cfonce", 0, SL_USER);
+        refresh_list();
+    }
 #endif /* INCLUDE_EXTRA_COMMANDS */
 
-	/* Reset fullname -- why??? */
-	if (!get_user(&uid, login, st_glob.fullname, home, email)) {
-		error("reading ", "user entry");
-		endbbs(2);
-	}
+    /* Reset fullname -- why??? */
+    if (!get_user(&uid, login, st_glob.fullname, home, email)) {
+        error("reading ", "user entry");
+        endbbs(2);
+    }
 }
 
 int
 partfile_perm(void)
 {
-	static int ret = -1;
-	if (ret < 0)
-		ret = (match(get_conf_param("partdir", "work"), "work"))
-		          ? SL_USER
-		          : SL_OWNER;
-	return ret;
+    static int ret = -1;
+    if (ret < 0)
+        ret = (match(get_conf_param("partdir", "work"), "work")) ? SL_USER
+                                                                 : SL_OWNER;
+    return ret;
 }
 
 /* fp is password file */
 void
 add_password(const std::string_view &login, const char *password, FILE *fp)
 {
-	char *cpw, salt[3];
+    char *cpw, salt[3];
 
-	srand((int)time((time_t *)NULL));
-	to64(&salt[0], rand(), 2);
-	salt[2] = '\0';
-	cpw = crypt(password, salt);
-	std::println(fp, "{}:{}", login, cpw);
-	error("warning", std::format("!{}", salt));
+    srand((int)time((time_t *)NULL));
+    to64(&salt[0], rand(), 2);
+    salt[2] = '\0';
+    cpw = crypt(password, salt);
+    std::println(fp, "{}:{}", login, cpw);
+    error("warning", std::format("!{}", salt));
 }
 /* Sanity check on fullname */
 bool
 sane_fullname(const std::string_view &name)
 {
-	for (const auto c: name)
-		if (c == ':' || c == '|' || !isprint(c))
-			return false;
-	return true;
+    for (const auto c : name)
+        if (c == ':' || c == '|' || !isprint(c))
+            return false;
+    return true;
 }
 /* Sanity check on email */
 static bool
 sane_email(const std::string_view &addr)
 {
-	for (const auto c: addr)
-		if (c == ':' || c == '|' || !isprint(c))
-			return 0;
-	return 1;
+    for (const auto c : addr)
+        if (c == ':' || c == '|' || !isprint(c))
+            return 0;
+    return 1;
 }
 /* others contains a list of variables to save to the dbm file,
  * excluding fullname, email, passwd
  */
 static int
 save_user_info(
-    const std::string_view &newlogin,
-    const std::string_view &newname,
-    const std::string_view &newemail,
-    const char *newpass,
-    const char *others /* IN: other vars to save (space-sep), or NULL for none */
+    const std::string_view &newlogin, const std::string_view &newname,
+    const std::string_view &newemail, const char *newpass,
+    const char
+        *others /* IN: other vars to save (space-sep), or NULL for none */
 )
 {
-	FILE *fp, *out = stdout;
-	int suid;
-	const auto userfilename = get_userfile(newlogin, &suid);
+    FILE *fp, *out = stdout;
+    int suid;
+    const auto userfilename = get_userfile(newlogin, &suid);
 
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true")) {
-		if (!save_dbm(userfilename, "fullname", newname, SL_USER) ||
-		    !save_dbm(userfilename, "email", newemail, SL_USER) ||
-		    (str::eq(get_conf_param("userfile", USER_FILE),
-		        get_conf_param("passfile", PASS_FILE)) &&
-		    !save_dbm(userfilename, "passwd", newpass, SL_USER)))
-		{
-			const auto msg =
-			    std::format("ERROR: Couldn't modify user file {}\n",
-			        userfilename);
-			wfputs(msg, out);
-			return 0;
-		}
+    if (match(get_conf_param("userdbm", USERDBM), "true")) {
+        if (!save_dbm(userfilename, "fullname", newname, SL_USER) ||
+            !save_dbm(userfilename, "email", newemail, SL_USER) ||
+            (str::eq(get_conf_param("userfile", USER_FILE),
+                 get_conf_param("passfile", PASS_FILE)) &&
+                !save_dbm(userfilename, "passwd", newpass, SL_USER))) {
+            const auto msg = std::format(
+                "ERROR: Couldn't modify user file {}\n", userfilename);
+            wfputs(msg, out);
+            return 0;
+        }
 
-		/* step through others and save those, except
-		 * fullname/email/passwd */
-		if (others) {
-			const auto list = str::split(others, " ");
-			for (size_t i = 0; i < list.size(); i++) {
-				const auto var = expand(list[i], DM_VAR);
-				if (!var.empty() &&
-				    !save_dbm(userfilename, list[i], var, SL_USER))
-				{
-					wfputs(
-					    std::format(
-					        "ERROR: Couldn't modify user file {}\n",
-					        userfilename),
-					    out);
-					return 0;
-				}
-			}
-		}
-	} else {
+        /* step through others and save those, except
+         * fullname/email/passwd */
+        if (others) {
+            const auto list = str::split(others, " ");
+            for (size_t i = 0; i < list.size(); i++) {
+                const auto var = expand(list[i], DM_VAR);
+                if (!var.empty() &&
+                    !save_dbm(userfilename, list[i], var, SL_USER)) {
+                    wfputs(std::format("ERROR: Couldn't modify user file {}\n",
+                               userfilename),
+                        out);
+                    return 0;
+                }
+            }
+        }
+    } else {
 #endif /* HAVE_DBM_OPEN */
 
-		if (suid == SL_USER)
-			fp = smopenw(userfilename, O_A);
-		else
-			fp = mopen(userfilename, O_A);
-		if (fp == NULL) {
-			error("opening ", userfilename);
-			wfputs(
-			    std::format(
-			        "ERROR: Couldn't modify user file {} \n",
-			        userfilename),
-			    out);
-			return 0;
-		}
-		std::println(fp, "{}:{}:{}", newlogin, newname, newemail);
-		if (suid == SL_USER)
-			smclose(fp);
-		else
-			mclose(fp);
+        if (suid == SL_USER)
+            fp = smopenw(userfilename, O_A);
+        else
+            fp = mopen(userfilename, O_A);
+        if (fp == NULL) {
+            error("opening ", userfilename);
+            wfputs(std::format(
+                       "ERROR: Couldn't modify user file {} \n", userfilename),
+                out);
+            return 0;
+        }
+        std::println(fp, "{}:{}:{}", newlogin, newname, newemail);
+        if (suid == SL_USER)
+            smclose(fp);
+        else
+            mclose(fp);
 
 #ifdef HAVE_DBM_OPEN
-	}
+    }
 #endif
 
-	/* Add password to passfile */
-	if ((fp = mopen(get_conf_param("passfile", PASS_FILE), O_A)) == NULL) {
-		error("opening", " passwd file");
-		exit(1);
-	}
+    /* Add password to passfile */
+    if ((fp = mopen(get_conf_param("passfile", PASS_FILE), O_A)) == NULL) {
+        error("opening", " passwd file");
+        exit(1);
+    }
 
-	/* Encrypt password and save in file */
-	add_password(newlogin, newpass, fp);
-	mclose(fp);
+    /* Encrypt password and save in file */
+    add_password(newlogin, newpass, fp);
+    mclose(fp);
 
-	return 1;
+    return 1;
 }
 /*
  * Generate a random 8-character password in static buffer
@@ -745,17 +729,17 @@ save_user_info(
 char *
 random_password(void)
 {
-	static char buff[10];
-	int seed;
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	seed = (getpid() << 16) | (tv.tv_usec & 0xFFFF);
-	srandom(seed);
-	to64(buff, random(), 4);
-	to64(buff + 4, random(), 4);
-	buff[8] = '\0';
+    static char buff[10];
+    int seed;
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    seed = (getpid() << 16) | (tv.tv_usec & 0xFFFF);
+    srandom(seed);
+    to64(buff, random(), 4);
+    to64(buff + 4, random(), 4);
+    buff[8] = '\0';
 
-	return buff;
+    return buff;
 }
 
 /* Send email to current user with their password */
@@ -763,34 +747,35 @@ random_password(void)
 int
 email_password(const char *pass)
 {
-	/* Compose email with their password */
-	const auto filename = std::format("/tmp/notify.{}", getpid());
-	def_macro("password", DM_VAR, pass);
-	FILE *fout = mopen(filename, O_W);
-	if (fout == NULL) {
-		error("opening ", filename);
-		return 0;
-	}
-	const auto filein = str::concat({expand("wwwdir", DM_VAR), "/templates/newuser.email"});
-	FILE *fin = mopen(filein, O_R);
-	if (fin == NULL) {
-		error("opening ", filein);
-		return 0;
-	}
-	char *str;
-	while ((str = xgets(fin, stdin_stack_top)) != NULL) {
-		fitemsep(fout, str, 0);
-		free(str);
-	}
-	mclose(fin);
-	mclose(fout);
-	undef_name("password");
+    /* Compose email with their password */
+    const auto filename = std::format("/tmp/notify.{}", getpid());
+    def_macro("password", DM_VAR, pass);
+    FILE *fout = mopen(filename, O_W);
+    if (fout == NULL) {
+        error("opening ", filename);
+        return 0;
+    }
+    const auto filein =
+        str::concat({expand("wwwdir", DM_VAR), "/templates/newuser.email"});
+    FILE *fin = mopen(filein, O_R);
+    if (fin == NULL) {
+        error("opening ", filein);
+        return 0;
+    }
+    char *str;
+    while ((str = xgets(fin, stdin_stack_top)) != NULL) {
+        fitemsep(fout, str, 0);
+        free(str);
+    }
+    mclose(fin);
+    mclose(fout);
+    undef_name("password");
 
-	/* Send it off */
-	unix_cmd(std::format("{} -t < {}",
-	    get_conf_param("sendmail", SENDMAIL), filename));
-	unlink(filename.c_str());
-	return 1;
+    /* Send it off */
+    unix_cmd(std::format(
+        "{} -t < {}", get_conf_param("sendmail", SENDMAIL), filename));
+    unlink(filename.c_str());
+    return 1;
 }
 
 /* command: newuser login  - just checks for validity */
@@ -803,235 +788,228 @@ email_password(const char *pass)
 int
 newuser(int argc, char **argv)
 {
-	struct stat st;
-	char *others = NULL;
-	std::string newlogin;
-	char newpass1[MAX_LINE_LENGTH];
-	char newpass2[MAX_LINE_LENGTH];
-	std::string newname;
-	std::string newemail;
-	FILE *out = stdout;
-	int cpid, wpid;
-	int normaluser;
-	if (status & S_EXECUTE)
-		out = NULL;
+    struct stat st;
+    char *others = NULL;
+    std::string newlogin;
+    char newpass1[MAX_LINE_LENGTH];
+    char newpass2[MAX_LINE_LENGTH];
+    std::string newname;
+    std::string newemail;
+    FILE *out = stdout;
+    int cpid, wpid;
+    int normaluser;
+    if (status & S_EXECUTE)
+        out = NULL;
 
-	normaluser =
-	    (getuid() == get_nobody_uid() || getuid() == geteuid()) ? 0 : 1;
+    normaluser =
+        (getuid() == get_nobody_uid() || getuid() == geteuid()) ? 0 : 1;
 
-	/* #ifdef XXX */
-	/*
-	 * 8/10/96 put this code back in because we currently only support
-	 * running newuser from the nobody account
-	 */
-	/* Only the "nobody" account can do newuser */
-	if (getuid() != get_nobody_uid()) {
-		wfputs("You already have a login.\n", out);
-		return 1;
-	}
-	/* #endif XXX */
+    /* #ifdef XXX */
+    /*
+     * 8/10/96 put this code back in because we currently only support
+     * running newuser from the nobody account
+     */
+    /* Only the "nobody" account can do newuser */
+    if (getuid() != get_nobody_uid()) {
+        wfputs("You already have a login.\n", out);
+        return 1;
+    }
+    /* #endif XXX */
 
-	/* Get new login */
-	if (normaluser) {
-		newlogin = login;
-		newname = fullname;
-		newemail = email;
-	} else {
-		if (argc > 1)
-			newlogin = argv[1];
-		else {
-			std::print("Choose a login: ");
-			ngets(newlogin, st_glob.inp);
-		}
+    /* Get new login */
+    if (normaluser) {
+        newlogin = login;
+        newname = fullname;
+        newemail = email;
+    } else {
+        if (argc > 1)
+            newlogin = argv[1];
+        else {
+            std::print("Choose a login: ");
+            ngets(newlogin, st_glob.inp);
+        }
 
-		/* Sanity check on login */
-		if (newlogin.size() < 2) {
-			wfputs(
-			    "Login must be at least 2 characters long\n", out);
-			return 1;
-		}
-		for (const char *p = newlogin.c_str(); *p; p++)
-			if (!isalnum(*p)) {
-				const auto msg = std::format(
-				    "Illegal character '{:c}' (ascii {}) in "
-				    "login.  Please choose another login.\n",
-				    *p, *p);
-				wfputs(msg, out);
-				return 1;
-			}
+        /* Sanity check on login */
+        if (newlogin.size() < 2) {
+            wfputs("Login must be at least 2 characters long\n", out);
+            return 1;
+        }
+        for (const char *p = newlogin.c_str(); *p; p++)
+            if (!isalnum(*p)) {
+                const auto msg =
+                    std::format("Illegal character '{:c}' (ascii {}) in "
+                                "login.  Please choose another login.\n",
+                        *p, *p);
+                wfputs(msg, out);
+                return 1;
+            }
 
-		/* Check to see if login is already in Unix or local use */
-		if (getpwnam(newlogin.c_str())) {
-			const auto cmd = str::concat({"/usr/local/bin/webuser ", newlogin});
-			int err = unix_cmd(cmd);
-			if (err)
-				wfputs("Couldn't create web account.\n", out);
-			else
-				wfputs("Web account created\n", out);
-			return 1;
-		}
-		std::string fn, h, e;
-		if (get_local_user(newlogin, fn, h, e)) {
-			const auto msg = std::format(
-			    "The login \"{}\" is already in use.  Please "
-			    "choose another login\n",
-			    newlogin);
-			wfputs(msg, out);
-			return 1;
-		}
+        /* Check to see if login is already in Unix or local use */
+        if (getpwnam(newlogin.c_str())) {
+            const auto cmd = str::concat({"/usr/local/bin/webuser ", newlogin});
+            int err = unix_cmd(cmd);
+            if (err)
+                wfputs("Couldn't create web account.\n", out);
+            else
+                wfputs("Web account created\n", out);
+            return 1;
+        }
+        std::string fn, h, e;
+        if (get_local_user(newlogin, fn, h, e)) {
+            const auto msg =
+                std::format("The login \"{}\" is already in use.  Please "
+                            "choose another login\n",
+                    newlogin);
+            wfputs(msg, out);
+            return 1;
+        }
 
-		/* First command form simply tests legality of login */
-		if (argc < 3) {
-			wfputs("Login is legal\n", out);
-			return 1;
-		}
-	}
+        /* First command form simply tests legality of login */
+        if (argc < 3) {
+            wfputs("Login is legal\n", out);
+            return 1;
+        }
+    }
 
-	if (match(get_conf_param("verifyemail", VERIFY_EMAIL), "true")) {
-		strcpy(newpass1, random_password());
-	} else {
-		/* Get new pass1 */
-		if (!normaluser && argc > 2)
-			strcpy(newpass1, argv[2]);
-		else {
-			strcpy(newpass1, getpass("New password: "));
-		}
+    if (match(get_conf_param("verifyemail", VERIFY_EMAIL), "true")) {
+        strcpy(newpass1, random_password());
+    } else {
+        /* Get new pass1 */
+        if (!normaluser && argc > 2)
+            strcpy(newpass1, argv[2]);
+        else {
+            strcpy(newpass1, getpass("New password: "));
+        }
 
-		/* Get new pass2 */
-		if (!normaluser && argc > 3)
-			strcpy(newpass2, argv[3]);
-		else {
-			strcpy(newpass2, getpass("New password (again): "));
-		}
+        /* Get new pass2 */
+        if (!normaluser && argc > 3)
+            strcpy(newpass2, argv[3]);
+        else {
+            strcpy(newpass2, getpass("New password (again): "));
+        }
 
-		/* Sanity checks on passwords */
-		if (!str::eq(newpass1, newpass2)) {
-			wfputs("The two copies of your password do not match. "
-			       "Please try again.",
-			    out);
-			return 1;
-		}
-		argc -= 2;
-		argv += 2;
-	}
+        /* Sanity checks on passwords */
+        if (!str::eq(newpass1, newpass2)) {
+            wfputs("The two copies of your password do not match. "
+                   "Please try again.",
+                out);
+            return 1;
+        }
+        argc -= 2;
+        argv += 2;
+    }
 
-	if (!normaluser) {
-		/* Get new fullname */
-		if (argc > 2)
-			newname = argv[2];
-		else {
-			std::print("Full name: ");
-			fflush(stdout);
-			ngets(newname, st_glob.inp);
-		}
+    if (!normaluser) {
+        /* Get new fullname */
+        if (argc > 2)
+            newname = argv[2];
+        else {
+            std::print("Full name: ");
+            fflush(stdout);
+            ngets(newname, st_glob.inp);
+        }
 
-		/* Sanity check on fullname */
-		if (!sane_fullname(newname)) {
-			wfputs("Illegal character in fullname.  Please try "
-			       "again.\n",
-			    out);
-			return 1;
-		}
+        /* Sanity check on fullname */
+        if (!sane_fullname(newname)) {
+            wfputs("Illegal character in fullname.  Please try "
+                   "again.\n",
+                out);
+            return 1;
+        }
 
-		/* Get new email */
-		if (argc > 3)
-			newemail = argv[3];
-		else {
-			std::println("Email address: ");
-			fflush(stdout);
-			ngets(newemail, st_glob.inp);
-		}
+        /* Get new email */
+        if (argc > 3)
+            newemail = argv[3];
+        else {
+            std::println("Email address: ");
+            fflush(stdout);
+            ngets(newemail, st_glob.inp);
+        }
 
-		/* Sanity check on email */
-		if (!sane_email(newemail.c_str())) {
-			wfputs(
-			    "Illegal character in email address.  Please try "
-			    "again.\n",
-			    out);
-			return 1;
-		}
+        /* Sanity check on email */
+        if (!sane_email(newemail.c_str())) {
+            wfputs("Illegal character in email address.  Please try "
+                   "again.\n",
+                out);
+            return 1;
+        }
 #ifdef HAVE_DBM_OPEN
-		/* argv[4] contains a list of variables to save to the dbm
-		 * file, excluding fullname, email, passwd */
-		if (argc > 4)
-			others = argv[4];
+        /* argv[4] contains a list of variables to save to the dbm
+         * file, excluding fullname, email, passwd */
+        if (argc > 4)
+            others = argv[4];
 #endif
-	}
+    }
 
-	/* Make a home directory */
-	const auto homedir = std::format("{}/{:c}/{:c}/{}",
-	    get_conf_param("userhome", USER_HOME),
-	    tolower(newlogin[0]), tolower(newlogin[1]), newlogin);
-	/* FORK */
-	fflush(stdout);
-	if (status & S_PAGER)
-		fflush(st_glob.outp);
+    /* Make a home directory */
+    const auto homedir =
+        std::format("{}/{:c}/{:c}/{}", get_conf_param("userhome", USER_HOME),
+            tolower(newlogin[0]), tolower(newlogin[1]), newlogin);
+    /* FORK */
+    fflush(stdout);
+    if (status & S_PAGER)
+        fflush(st_glob.outp);
 
-	cpid = fork();
-	if (cpid) { /* parent */
-		if (cpid < 0)
-			return 1; /* error: couldn't fork */
-		while ((wpid = wait((int *)0)) != cpid && wpid != -1)
-			;
-	} else { /* child */
-		signal(SIGINT, SIG_DFL);
-		signal(SIGPIPE, SIG_DFL);
-		close(0);
+    cpid = fork();
+    if (cpid) { /* parent */
+        if (cpid < 0)
+            return 1; /* error: couldn't fork */
+        while ((wpid = wait((int *)0)) != cpid && wpid != -1);
+    } else { /* child */
+        signal(SIGINT, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        close(0);
 
-		setuid(getuid());
-		setgid(getgid());
+        setuid(getuid());
+        setgid(getgid());
 
-		mkdir_all(homedir, 0755);
-		exit(0);
-	}
+        mkdir_all(homedir, 0755);
+        exit(0);
+    }
 
-	/* Now test to make sure it succeeded */
-	if (stat(homedir.c_str(), &st) || st.st_uid != getuid()) {
-		error("creating ", homedir);
-		wfputs(
-		    "System administrator needs to check file permissions on "
-		    "web home dir.\n",
-		    out);
-		return 1;
-	}
+    /* Now test to make sure it succeeded */
+    if (stat(homedir.c_str(), &st) || st.st_uid != getuid()) {
+        error("creating ", homedir);
+        wfputs("System administrator needs to check file permissions on "
+               "web home dir.\n",
+            out);
+        return 1;
+    }
 
-	/* Save newuser info to user file (could be done in user dir) */
-	save_user_info(newlogin, newname, newemail, newpass1, others);
+    /* Save newuser info to user file (could be done in user dir) */
+    save_user_info(newlogin, newname, newemail, newpass1, others);
 
-	/* Set partdir */
-	/* Copy templates to user's home directory */
-	partdir = get_partdir(newlogin);
+    /* Set partdir */
+    /* Copy templates to user's home directory */
+    partdir = get_partdir(newlogin);
 
-	/* copy default .cflist */
-	copy_file(str::concat({bbsdir, "/defaults/.cflist"}),
-	    str::concat({partdir, "/.cflist"}),
-	    partfile_perm());
+    /* copy default .cflist */
+    copy_file(str::concat({bbsdir, "/defaults/.cflist"}),
+        str::concat({partdir, "/.cflist"}), partfile_perm());
 
-	/* copy default .cfrc */
-	copy_file(str::concat({bbsdir, "/defaults/.cfrc"}),
-	    str::concat({homedir, "/.cfrc"}),
-	    SL_USER);
+    /* copy default .cfrc */
+    copy_file(str::concat({bbsdir, "/defaults/.cfrc"}),
+        str::concat({homedir, "/.cfrc"}), SL_USER);
 
-	/* copy default .cfonce */
-	copy_file(str::concat({bbsdir, "/defaults/.cfonce"}),
-	    str::concat({homedir, "/.cfonce"}),
-	    SL_USER);
+    /* copy default .cfonce */
+    copy_file(str::concat({bbsdir, "/defaults/.cfonce"}),
+        str::concat({homedir, "/.cfonce"}), SL_USER);
 
-	if (match(get_conf_param("verifyemail", VERIFY_EMAIL), "true")) {
-		/* Set fields which might be referenced */
-		login = newlogin;
-		st_glob.fullname = newname;
-		email = newemail;
-		home = homedir;
+    if (match(get_conf_param("verifyemail", VERIFY_EMAIL), "true")) {
+        /* Set fields which might be referenced */
+        login = newlogin;
+        st_glob.fullname = newname;
+        email = newemail;
+        home = homedir;
 
-		email_password(newpass1);
-		wfputs("You are now registered and should receive email "
-		       "shortly.\n",
-		    out);
-	} else {
-		wfputs("You are now registered and may log in.\n", out);
-	}
-	return 1;
+        email_password(newpass1);
+        wfputs("You are now registered and should receive email "
+               "shortly.\n",
+            out);
+    } else {
+        wfputs("You are now registered and may log in.\n", out);
+    }
+    return 1;
 }
 
 #ifdef INCLUDE_EXTRA_COMMANDS
@@ -1040,19 +1018,19 @@ newuser(int argc, char **argv)
 int
 authenticate(int argc, char **argv)
 {
-	if (argc != 2) {
-		std::println("Usage: authenticate ticket");
-		return 1;
-	}
+    if (argc != 2) {
+        std::println("Usage: authenticate ticket");
+        return 1;
+    }
 
-	/* Trash newline */
-	if (argv[1][strlen(argv[1]) - 1] == '\n')
-		argv[1][strlen(argv[1]) - 1] = '\0';
-	if (do_authenticate(argv[1]))
-		login_user();
-	else
-		std::println("Authentication failed.");
-	return 1;
+    /* Trash newline */
+    if (argv[1][strlen(argv[1]) - 1] == '\n')
+        argv[1][strlen(argv[1]) - 1] = '\0';
+    if (do_authenticate(argv[1]))
+        login_user();
+    else
+        std::println("Authentication failed.");
+    return 1;
 }
 #endif /* INCLUDE_EXTRA_COMMANDS */
 #endif /* WWW */
@@ -1068,30 +1046,31 @@ authenticate(int argc, char **argv)
 static void
 force_refresh_list(const std::string &path)
 {
-	struct stat st{};
-	if (stat(path.c_str(), &st) < 0)
-		return;
+    struct stat st{};
+    if (stat(path.c_str(), &st) < 0)
+        return;
 
-	current = -1;
-	cflist = grab_file(partdir, ".cflist", GF_WORD | GF_SILENT | GF_IGNCMT);
+    current = -1;
+    cflist = grab_file(partdir, ".cflist", GF_WORD | GF_SILENT | GF_IGNCMT);
 
-	/* Set up cfliststr */
-	std::vector<std::string_view> cflistvs(cflist.begin(), cflist.end());
-	cfliststr = " " + str::join(" ", cflistvs) + (!cflistvs.empty() ? " " : "");
+    /* Set up cfliststr */
+    std::vector<std::string_view> cflistvs(cflist.begin(), cflist.end());
+    cfliststr = " " + str::join(" ", cflistvs) + (!cflistvs.empty() ? " " : "");
 
-	listtime = st.st_mtime;
-	listsize = st.st_size;
+    listtime = st.st_mtime;
+    listsize = st.st_size;
 }
 
 void
 refresh_list(void)
 {
-	if (cfliststr.empty())
-		cfliststr = " ";
-	struct stat st{};
-	const auto path = std::format("{}/{}", partdir, ".cflist");
-	if (stat(path.c_str(), &st) >= 0 && (st.st_mtime != listtime || st.st_size != listsize))
-		force_refresh_list(path);
+    if (cfliststr.empty())
+        cfliststr = " ";
+    struct stat st{};
+    const auto path = std::format("{}/{}", partdir, ".cflist");
+    if (stat(path.c_str(), &st) >= 0 &&
+        (st.st_mtime != listtime || st.st_size != listsize))
+        force_refresh_list(path);
 }
 
 /*
@@ -1101,28 +1080,28 @@ static void
 add_cflist(const std::string_view &cfname)
 {
 
-	const auto path = std::format("{}/{}", partdir, ".cflist");
-	force_refresh_list(path);
-	auto perm = partfile_perm();
-	if (perm == SL_USER) {
-		FILE *fp = smopenw(path, O_A);
-		if (fp == nullptr)
-			return;
-		std::println(fp, "{}", cfname);
-		smclose(fp);
-	} else { /* SL_OWNER */
-		FILE *fp = mopen(path, O_A);
-		if (fp == nullptr)
-			return;
-		std::println(fp, "{}", cfname);
-		mclose(fp);
-	}
-	/*
-	 * Manually add to cflist in memory.
-	 * We don't use `refresh_list` because it may
-	 * have changed less than 1 second ago.
-	 */
-	force_refresh_list(path);
+    const auto path = std::format("{}/{}", partdir, ".cflist");
+    force_refresh_list(path);
+    auto perm = partfile_perm();
+    if (perm == SL_USER) {
+        FILE *fp = smopenw(path, O_A);
+        if (fp == nullptr)
+            return;
+        std::println(fp, "{}", cfname);
+        smclose(fp);
+    } else { /* SL_OWNER */
+        FILE *fp = mopen(path, O_A);
+        if (fp == nullptr)
+            return;
+        std::println(fp, "{}", cfname);
+        mclose(fp);
+    }
+    /*
+     * Manually add to cflist in memory.
+     * We don't use `refresh_list` because it may
+     * have changed less than 1 second ago.
+     */
+    force_refresh_list(path);
 }
 
 /********************************************************/
@@ -1133,72 +1112,71 @@ add_cflist(const std::string_view &cfname)
 int
 del_cflist(const std::string &cfname)
 {
-	FILE *newfp;
-	int perm = partfile_perm();
+    FILE *newfp;
+    int perm = partfile_perm();
 
-	const auto path = std::format("{}/{}", partdir, ".cflist");
-	force_refresh_list(path);
+    const auto path = std::format("{}/{}", partdir, ".cflist");
+    force_refresh_list(path);
 
-	/* First see if it's in the list at all */
-	auto it = std::find(cflist.begin(), cflist.end(), cfname);
-	if (it == cflist.end())
-		return 0;
-	cflist.erase(it);
+    /* First see if it's in the list at all */
+    auto it = std::find(cflist.begin(), cflist.end(), cfname);
+    if (it == cflist.end())
+        return 0;
+    cflist.erase(it);
 
-	if (perm == SL_USER)
-		newfp = smopenw(path, O_W);
-	else /* SL_OWNER */
-		newfp = mopen(path, O_W);
-	if (newfp == NULL) {
-		std::println("Couldn't open .cflist for writing");
-		return 0;
-	}
-	for (const auto &cf: cflist)
-		std::println(newfp, "{}", cf);
+    if (perm == SL_USER)
+        newfp = smopenw(path, O_W);
+    else /* SL_OWNER */
+        newfp = mopen(path, O_W);
+    if (newfp == NULL) {
+        std::println("Couldn't open .cflist for writing");
+        return 0;
+    }
+    for (const auto &cf : cflist) std::println(newfp, "{}", cf);
 
-	if (perm == SL_USER)
-		smclose(newfp);
-	else /* SL_OWNER */
-		mclose(newfp);
+    if (perm == SL_USER)
+        smclose(newfp);
+    else /* SL_OWNER */
+        mclose(newfp);
 
-	force_refresh_list(path);
+    force_refresh_list(path);
 
-	return 1;
+    return 1;
 }
 
 void
 show_cflist(void)
 {
-	refresh_list();
-	for (auto i = 0; i < cflist.size(); i++)
-		std::println("{} {}", (current == i) ? "-->" : "   ", cflist[i]);
+    refresh_list();
+    for (auto i = 0; i < cflist.size(); i++)
+        std::println("{} {}", (current == i) ? "-->" : "   ", cflist[i]);
 }
 
 /* The "cflist" command */
 int
 do_cflist(int argc, char **argv)
 {
-	int i;
+    int i;
 
-	if (argc > 2 && match(argv[1], "a_dd")) {
-		for (i = 2; i < argc; i++) add_cflist(argv[i]);
-	} else if (argc > 2 && match(argv[1], "d_elete")) {
-		for (i = 2; i < argc; i++) del_cflist(argv[i]);
-	} else if (argc == 2 && match(argv[1], "s_how")) {
-		show_cflist();
-	} else if (argc == 2 && match(argv[1], "r_estart")) {
-		if (cflist.empty()) {
-			current = -1;
-			do_next(0, nullptr);
-		}
-	} else {
-		std::println("usage: cflist add <{}> ...", conference(0));
-		std::println("       cflist delete <{}> ...", conference(0));
-		std::println("       cflist show");
-		std::println("       cflist restart");
-	}
+    if (argc > 2 && match(argv[1], "a_dd")) {
+        for (i = 2; i < argc; i++) add_cflist(argv[i]);
+    } else if (argc > 2 && match(argv[1], "d_elete")) {
+        for (i = 2; i < argc; i++) del_cflist(argv[i]);
+    } else if (argc == 2 && match(argv[1], "s_how")) {
+        show_cflist();
+    } else if (argc == 2 && match(argv[1], "r_estart")) {
+        if (cflist.empty()) {
+            current = -1;
+            do_next(0, nullptr);
+        }
+    } else {
+        std::println("usage: cflist add <{}> ...", conference(0));
+        std::println("       cflist delete <{}> ...", conference(0));
+        std::println("       cflist show");
+        std::println("       cflist restart");
+    }
 
-	return 1;
+    return 1;
 }
 
 /*
@@ -1210,224 +1188,219 @@ chfn(           /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	std::string newname;
-	std::string newemail;
-	FILE *fp = NULL, *tmp = NULL, *out = stdout;
-	const char *oldname = NULL;
-	char tmpname[MAX_LINE_LENGTH];
-	std::string line;
-	char *w;
-	char *oldemail = NULL;
-	int found = 0, suid;
+    std::string newname;
+    std::string newemail;
+    FILE *fp = NULL, *tmp = NULL, *out = stdout;
+    const char *oldname = NULL;
+    char tmpname[MAX_LINE_LENGTH];
+    std::string line;
+    char *w;
+    char *oldemail = NULL;
+    int found = 0, suid;
 #ifdef HAVE_DBM_OPEN
-	int dbm = 0;
-	char oldnamebuff[MAX_LINE_LENGTH];
-	char oldemailbuff[MAX_LINE_LENGTH];
+    int dbm = 0;
+    char oldnamebuff[MAX_LINE_LENGTH];
+    char oldemailbuff[MAX_LINE_LENGTH];
 #endif /* HAVE_DBM_OPEN */
 
-	if (status & S_EXECUTE)
-		out = NULL;
+    if (status & S_EXECUTE)
+        out = NULL;
 
-	/* If it's a Unix user, do a normal chfn command */
-	if (getuid() != get_nobody_uid()) {
-		unix_cmd("/usr/bin/chfn");
+    /* If it's a Unix user, do a normal chfn command */
+    if (getuid() != get_nobody_uid()) {
+        unix_cmd("/usr/bin/chfn");
 
-		/* Reload fullname */
-		if (!get_user(&uid, login, fullname, home, email)) {
-			error("reading ", "user entry");
-			endbbs(2);
-		}
-		return 1;
-	}
+        /* Reload fullname */
+        if (!get_user(&uid, login, fullname, home, email)) {
+            error("reading ", "user entry");
+            endbbs(2);
+        }
+        return 1;
+    }
 
-	/* Insure that the user has authenticated */
-	if (status & S_NOAUTH) {
-		wfputs("You are not authenticated.\n", out);
-		return 1;
-	}
-	const auto userfile = get_userfile(login, &suid);
+    /* Insure that the user has authenticated */
+    if (status & S_NOAUTH) {
+        wfputs("You are not authenticated.\n", out);
+        return 1;
+    }
+    const auto userfile = get_userfile(login, &suid);
 
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true")) {
-		strcpy(oldnamebuff, get_dbm(userfile, "fullname", SL_USER).c_str());
-		strcpy(oldemailbuff, get_dbm(userfile, "email", SL_USER).c_str());
-		if (!oldnamebuff[0] && !oldemailbuff[0]) {
-			error("opening ", userfile);
-			return 1;
-		}
-		found = 1;
-		dbm = 1;
-		oldname = oldnamebuff;
-		oldemail = oldemailbuff;
-	}
-	if (!dbm) {
+    if (match(get_conf_param("userdbm", USERDBM), "true")) {
+        strcpy(oldnamebuff, get_dbm(userfile, "fullname", SL_USER).c_str());
+        strcpy(oldemailbuff, get_dbm(userfile, "email", SL_USER).c_str());
+        if (!oldnamebuff[0] && !oldemailbuff[0]) {
+            error("opening ", userfile);
+            return 1;
+        }
+        found = 1;
+        dbm = 1;
+        oldname = oldnamebuff;
+        oldemail = oldemailbuff;
+    }
+    if (!dbm) {
 #endif /* HAVE_DBM_OPEN */
 
-		/* Open old userfile (could be in user dir) */
-		if (suid == SL_USER)
-			fp = smopenr(userfile, O_R);
-		else
-			fp = mopen(userfile, O_R);
-		if (fp == NULL) {
-			error("opening ", userfile);
-			exit(1);
-		}
+        /* Open old userfile (could be in user dir) */
+        if (suid == SL_USER)
+            fp = smopenr(userfile, O_R);
+        else
+            fp = mopen(userfile, O_R);
+        if (fp == NULL) {
+            error("opening ", userfile);
+            exit(1);
+        }
 
-		/* Open new userfile */
-		const auto tmpname = std::format("{}.{}", userfile, getpid());
-		if (suid == SL_USER)
-			tmp = smopenw(tmpname, O_W);
-		else
-			tmp = mopen(tmpname, O_W);
-		if (tmp == NULL) {
-			error("opening ", tmpname);
-			exit(1);
-		}
+        /* Open new userfile */
+        const auto tmpname = std::format("{}.{}", userfile, getpid());
+        if (suid == SL_USER)
+            tmp = smopenw(tmpname, O_W);
+        else
+            tmp = mopen(tmpname, O_W);
+        if (tmp == NULL) {
+            error("opening ", tmpname);
+            exit(1);
+        }
 
-		/* Find login in user file */
-		while (ngets(line, fp)) {
-			if (line.empty() || line[0] == '#') {
-				std::println(tmp, "{}", line);
-				continue;
-			}
-			char *cline = line.data();
-			if ((w = strchr(cline, ':')) != NULL) {
-				*w = '\0';
-				if (!str::eq(login, cline))
-					std::println(tmp, "{}:{}", cline, w + 1);
-				else {
-					found = 1;
-					oldname = w + 1;
-					oldemail = strchr(w + 1, ':');
-					if (!oldemail)
-						continue;
-					*oldemail++ = '\0';
-					break;
-				}
-			}
-		}
+        /* Find login in user file */
+        while (ngets(line, fp)) {
+            if (line.empty() || line[0] == '#') {
+                std::println(tmp, "{}", line);
+                continue;
+            }
+            char *cline = line.data();
+            if ((w = strchr(cline, ':')) != NULL) {
+                *w = '\0';
+                if (!str::eq(login, cline))
+                    std::println(tmp, "{}:{}", cline, w + 1);
+                else {
+                    found = 1;
+                    oldname = w + 1;
+                    oldemail = strchr(w + 1, ':');
+                    if (!oldemail)
+                        continue;
+                    *oldemail++ = '\0';
+                    break;
+                }
+            }
+        }
 
-		/* Verify that it's a user account, not a Unix account */
-		if (!found) {
-			wfputs("Couldn't find local Yapp user information.\n",
-			    out);
-			if (suid == SL_USER) {
-				smclose(tmp);
-				smclose(fp);
-			} else {
-				mclose(tmp);
-				mclose(fp);
-			}
-			return 1;
-		}
+        /* Verify that it's a user account, not a Unix account */
+        if (!found) {
+            wfputs("Couldn't find local Yapp user information.\n", out);
+            if (suid == SL_USER) {
+                smclose(tmp);
+                smclose(fp);
+            } else {
+                mclose(tmp);
+                mclose(fp);
+            }
+            return 1;
+        }
 #ifdef HAVE_DBM_OPEN
-	}
+    }
 #endif
 
-	/* Get new fullname */
-	if (argc > 1)
-		newname = argv[1];
-	else {
-		if (!(flags & O_QUIET)) {
-			std::println("Your old name is: {}", oldname);
-			std::print("Enter replacement or return to keep old? ");
-		}
-		if (!ngets(newname, st_glob.inp) || newname.empty()) {
-			wfputs("Name not changed.\n", out);
-		} else {
-			wfputs("Fullname changed.\n", out);
-		}
-	}
+    /* Get new fullname */
+    if (argc > 1)
+        newname = argv[1];
+    else {
+        if (!(flags & O_QUIET)) {
+            std::println("Your old name is: {}", oldname);
+            std::print("Enter replacement or return to keep old? ");
+        }
+        if (!ngets(newname, st_glob.inp) || newname.empty()) {
+            wfputs("Name not changed.\n", out);
+        } else {
+            wfputs("Fullname changed.\n", out);
+        }
+    }
 
-	/* Get new email */
-	if (argc > 2)
-		newemail = argv[2];
-	else {
-		if (!(flags & O_QUIET)) {
-			std::println("Your old email address is: {}", oldemail);
-			std::print("Enter replacement or return to keep old? ");
-		}
-		if (!ngets(newemail, st_glob.inp) || newemail.empty()) {
-			wfputs("Email address not changed.\n", out);
-			newemail = oldemail;
-		} else
-			wfputs("Email address changed.\n", out);
-	}
+    /* Get new email */
+    if (argc > 2)
+        newemail = argv[2];
+    else {
+        if (!(flags & O_QUIET)) {
+            std::println("Your old email address is: {}", oldemail);
+            std::print("Enter replacement or return to keep old? ");
+        }
+        if (!ngets(newemail, st_glob.inp) || newemail.empty()) {
+            wfputs("Email address not changed.\n", out);
+            newemail = oldemail;
+        } else
+            wfputs("Email address changed.\n", out);
+    }
 
-	/* Sanity check on fullname */
-	if (!sane_fullname(newname)) {
-		wfputs(
-		    "Illegal character in fullname.  Please try again.\n", out);
+    /* Sanity check on fullname */
+    if (!sane_fullname(newname)) {
+        wfputs("Illegal character in fullname.  Please try again.\n", out);
 #ifdef HAVE_DBM_OPEN
-		if (!dbm) {
+        if (!dbm) {
 #endif
 
-			if (suid == SL_USER) {
-				smclose(tmp);
-				smclose(fp);
-			} else {
-				mclose(tmp);
-				mclose(fp);
-			}
+            if (suid == SL_USER) {
+                smclose(tmp);
+                smclose(fp);
+            } else {
+                mclose(tmp);
+                mclose(fp);
+            }
 #ifdef HAVE_DBM_OPEN
-		}
+        }
 #endif
-		return 1;
-	}
+        return 1;
+    }
 
-	/* Sanity check on email */
-	if (!sane_email(newemail)) {
-		wfputs(
-		    "Illegal character in email address.  Please try again.\n",
-		    out);
+    /* Sanity check on email */
+    if (!sane_email(newemail)) {
+        wfputs("Illegal character in email address.  Please try again.\n", out);
 #ifdef HAVE_DBM_OPEN
-		if (!dbm) {
+        if (!dbm) {
 #endif
 
-			if (suid == SL_USER) {
-				smclose(tmp);
-				smclose(fp);
-			} else {
-				mclose(tmp);
-				mclose(fp);
-			}
+            if (suid == SL_USER) {
+                smclose(tmp);
+                smclose(fp);
+            } else {
+                mclose(tmp);
+                mclose(fp);
+            }
 #ifdef HAVE_DBM_OPEN
-		}
+        }
 #endif
-		return 1;
-	}
+        return 1;
+    }
 #ifdef HAVE_DBM_OPEN
-	if (dbm) {
-		save_dbm(userfile, "fullname", newname, SL_USER);
-		save_dbm(userfile, "email", newemail, SL_USER);
-		return 1;
-	}
+    if (dbm) {
+        save_dbm(userfile, "fullname", newname, SL_USER);
+        save_dbm(userfile, "email", newemail, SL_USER);
+        return 1;
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Insert new one */
-	std::println(tmp, "{}:{}:{}", login, newname, newemail);
+    /* Insert new one */
+    std::println(tmp, "{}:{}:{}", login, newname, newemail);
 
-	/* Copy remainder of file */
-	while (ngets(line, fp))
-		std::println(tmp, "{}", line);
+    /* Copy remainder of file */
+    while (ngets(line, fp)) std::println(tmp, "{}", line);
 
-	if (suid == SL_USER) {
-		smclose(tmp);
-		smclose(fp);
-	} else {
-		mclose(tmp);
-		mclose(fp);
-	}
+    if (suid == SL_USER) {
+        smclose(tmp);
+        smclose(fp);
+    } else {
+        mclose(tmp);
+        mclose(fp);
+    }
 
-	move_file(tmpname, userfile, suid);
-	/*
-	   if (rename(tmpname, userfile)) {
-	      error("renaming ", tmpname);
-	      exit(1);
-	   }
-	*/
+    move_file(tmpname, userfile, suid);
+    /*
+       if (rename(tmpname, userfile)) {
+          error("renaming ", tmpname);
+          exit(1);
+       }
+    */
 
-	return 1;
+    return 1;
 }
 /*
  * Change user password
@@ -1439,194 +1412,185 @@ passwd(         /* ARGUMENTS:             */
     char **argv /* Argument list       */
 )
 {
-	char oldpass[MAX_LINE_LENGTH], newpass1[MAX_LINE_LENGTH],
-	    newpass2[MAX_LINE_LENGTH];
-	FILE *fp = NULL, *tmp = NULL, *out = stdout;
-	const char *passfile = NULL;
-	char tmpname[MAX_LINE_LENGTH];
-	std::string line;
-	char *w = NULL;
-	char *cpw;
-	int found = 0;
+    char oldpass[MAX_LINE_LENGTH], newpass1[MAX_LINE_LENGTH],
+        newpass2[MAX_LINE_LENGTH];
+    FILE *fp = NULL, *tmp = NULL, *out = stdout;
+    const char *passfile = NULL;
+    char tmpname[MAX_LINE_LENGTH];
+    std::string line;
+    char *w = NULL;
+    char *cpw;
+    int found = 0;
 #ifdef HAVE_DBM_OPEN
-	int dbm = 0;
-	char savedpass[MAX_LINE_LENGTH];
-	const char *userfile = NULL;
+    int dbm = 0;
+    char savedpass[MAX_LINE_LENGTH];
+    const char *userfile = NULL;
 #endif /* HAVE_DBM_OPEN */
 
-	if (status & S_EXECUTE)
-		out = NULL;
+    if (status & S_EXECUTE)
+        out = NULL;
 
-	/* If it's a Unix user, do a normal passwd command */
-	if (getuid() != get_nobody_uid()) {
-		unix_cmd("/usr/bin/passwd");
-		return 1;
-	}
-	if (status & S_NOAUTH) {
-		wfputs("You are not authenticated.\n", out);
-		return 1;
-	}
+    /* If it's a Unix user, do a normal passwd command */
+    if (getuid() != get_nobody_uid()) {
+        unix_cmd("/usr/bin/passwd");
+        return 1;
+    }
+    if (status & S_NOAUTH) {
+        wfputs("You are not authenticated.\n", out);
+        return 1;
+    }
 #ifdef HAVE_DBM_OPEN
-	if (match(get_conf_param("userdbm", USERDBM), "true") &&
-	    str::eq(get_conf_param("userfile", USER_FILE),
-	        get_conf_param("passfile", PASS_FILE)))
-	{
-		int suid;
-		const auto userfile = get_userfile(login, &suid);
-		strcpy(savedpass, get_dbm(userfile, "passwd", SL_USER).c_str());
-		if (!savedpass[0]) {
-			error("opening ", userfile);
-			return 1;
-		}
-		found = 1;
-		dbm = 1;
-	}
-	if (!dbm) {
+    if (match(get_conf_param("userdbm", USERDBM), "true") &&
+        str::eq(get_conf_param("userfile", USER_FILE),
+            get_conf_param("passfile", PASS_FILE))) {
+        int suid;
+        const auto userfile = get_userfile(login, &suid);
+        strcpy(savedpass, get_dbm(userfile, "passwd", SL_USER).c_str());
+        if (!savedpass[0]) {
+            error("opening ", userfile);
+            return 1;
+        }
+        found = 1;
+        dbm = 1;
+    }
+    if (!dbm) {
 #endif /* HAVE_DBM_OPEN */
 
-		/* Open old passfile */
-		const auto passfile = get_conf_param("passfile", PASS_FILE);
-		if ((fp = mopen(passfile, O_R)) == NULL) {
-			error("opening ", passfile);
-			exit(1);
-		}
+        /* Open old passfile */
+        const auto passfile = get_conf_param("passfile", PASS_FILE);
+        if ((fp = mopen(passfile, O_R)) == NULL) {
+            error("opening ", passfile);
+            exit(1);
+        }
 
-		/* Open new passfile */
-		const auto tmpname = std::format("{}.{}", passfile, getpid());
-		if ((tmp = mopen(tmpname, O_W)) == NULL) {
-			error("opening ", tmpname);
-			exit(1);
-		}
+        /* Open new passfile */
+        const auto tmpname = std::format("{}.{}", passfile, getpid());
+        if ((tmp = mopen(tmpname, O_W)) == NULL) {
+            error("opening ", tmpname);
+            exit(1);
+        }
 
-		/* Find login in pass file */
-		while (ngets(line, fp)) {
-			if (line.empty() || line[0] == '#') {
-				std::println(tmp, "{}", line);
-				continue;
-			}
-			const auto w = line.find(':');
-			if (w != std::string::npos) {
-				const auto lineview = std::string_view(line);
-				const auto user = lineview.substr(0, w);
-				const auto pass = lineview.substr(w + 1);
-				if (!str::eq(login, line))
-					std::println(tmp, "{}:{}", user, pass);
-				else {
-					found = 1;
-					break;
-				}
-			}
-		}
+        /* Find login in pass file */
+        while (ngets(line, fp)) {
+            if (line.empty() || line[0] == '#') {
+                std::println(tmp, "{}", line);
+                continue;
+            }
+            const auto w = line.find(':');
+            if (w != std::string::npos) {
+                const auto lineview = std::string_view(line);
+                const auto user = lineview.substr(0, w);
+                const auto pass = lineview.substr(w + 1);
+                if (!str::eq(login, line))
+                    std::println(tmp, "{}:{}", user, pass);
+                else {
+                    found = 1;
+                    break;
+                }
+            }
+        }
 
-		/* Verify that it's a user account, not a Unix account */
-		if (!found) {
-			wfputs("You're not using a local Yapp account.\n", out);
-			mclose(tmp);
-			mclose(fp);
-			return 1;
-		}
+        /* Verify that it's a user account, not a Unix account */
+        if (!found) {
+            wfputs("You're not using a local Yapp account.\n", out);
+            mclose(tmp);
+            mclose(fp);
+            return 1;
+        }
 #ifdef HAVE_DBM_OPEN
-	}
+    }
 #endif
 
-	/* Get old password */
-	if (argc > 1)
-		strcpy(oldpass, argv[1]);
-	else {
-		wfputs("Old password: ", out);
-		fflush(out);
-		strcpy(oldpass, getpass(""));
-	}
+    /* Get old password */
+    if (argc > 1)
+        strcpy(oldpass, argv[1]);
+    else {
+        wfputs("Old password: ", out);
+        fflush(out);
+        strcpy(oldpass, getpass(""));
+    }
 
-	/* Verify old password */
+    /* Verify old password */
 #ifdef HAVE_DBM_OPEN
-	if (dbm) {
-		if (!str::eq(oldpass, savedpass)) {
-			wfputs(
-			    "You did not enter your old password correctly.\n",
-			    out);
-			return 1;
-		}
-	} else {
+    if (dbm) {
+        if (!str::eq(oldpass, savedpass)) {
+            wfputs("You did not enter your old password correctly.\n", out);
+            return 1;
+        }
+    } else {
 #endif
 
-		cpw = crypt(oldpass, w + 1);
-		if (!str::eq(cpw, w + 1)) {
-			wfputs(
-			    "You did not enter your old password correctly.\n",
-			    out);
-			mclose(tmp);
-			mclose(fp);
-			return 1;
-		}
+        cpw = crypt(oldpass, w + 1);
+        if (!str::eq(cpw, w + 1)) {
+            wfputs("You did not enter your old password correctly.\n", out);
+            mclose(tmp);
+            mclose(fp);
+            return 1;
+        }
 #ifdef HAVE_DBM_OPEN
-	}
+    }
 #endif
 
-	if (argc > 2)
-		strcpy(newpass1, argv[2]);
-	else {
-		wfputs("New password: ", out);
-		fflush(out);
-		strcpy(newpass1, getpass(""));
-	}
+    if (argc > 2)
+        strcpy(newpass1, argv[2]);
+    else {
+        wfputs("New password: ", out);
+        fflush(out);
+        strcpy(newpass1, getpass(""));
+    }
 
-	if (argc > 3)
-		strcpy(newpass2, argv[3]);
-	else {
-		wfputs("Retype new password: ", out);
-		fflush(out);
-		strcpy(newpass2, getpass(""));
-	}
+    if (argc > 3)
+        strcpy(newpass2, argv[3]);
+    else {
+        wfputs("Retype new password: ", out);
+        fflush(out);
+        strcpy(newpass2, getpass(""));
+    }
 
-	if (!newpass1[0] || !newpass2[0] || !str::eq(newpass1, newpass2)) {
-		wfputs(
-		    "The two copies of your password do not match. Please try "
-		    "again.\n",
-		    out);
+    if (!newpass1[0] || !newpass2[0] || !str::eq(newpass1, newpass2)) {
+        wfputs("The two copies of your password do not match. Please try "
+               "again.\n",
+            out);
 #ifdef HAVE_DBM_OPEN
-		if (!dbm) {
+        if (!dbm) {
 #endif
-			mclose(tmp);
-			mclose(fp);
+            mclose(tmp);
+            mclose(fp);
 #ifdef HAVE_DBM_OPEN
-		}
+        }
 #endif
-		return 1;
-	}
+        return 1;
+    }
 #ifdef HAVE_DBM_OPEN
-	if (dbm &&
-	    str::eq(get_conf_param("userfile", USER_FILE),
-	        get_conf_param("passfile", PASS_FILE)))
-	{
-		save_dbm(userfile, "passwd", newpass1, SL_USER);
-		wfputs("Password changed.\n", out);
-		return 1;
-	}
+    if (dbm && str::eq(get_conf_param("userfile", USER_FILE),
+                   get_conf_param("passfile", PASS_FILE))) {
+        save_dbm(userfile, "passwd", newpass1, SL_USER);
+        wfputs("Password changed.\n", out);
+        return 1;
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Encrypt new one */
-	add_password(login, newpass1, tmp);
-	/*
-	   (void)srand((int)time((time_t *)NULL));
-	   to64(&salt[0],rand(),2);
-	   cpw = crypt(newpass1,salt);
-	   std::println(tmp, "{}:{}", login, cpw);
-	*/
+    /* Encrypt new one */
+    add_password(login, newpass1, tmp);
+    /*
+       (void)srand((int)time((time_t *)NULL));
+       to64(&salt[0],rand(),2);
+       cpw = crypt(newpass1,salt);
+       std::println(tmp, "{}:{}", login, cpw);
+    */
 
-	/* Copy remainder of file */
-	while (ngets(line, fp))
-		std::println(tmp, "{}", line);
+    /* Copy remainder of file */
+    while (ngets(line, fp)) std::println(tmp, "{}", line);
 
-	if (fp)
-		mclose(fp);
-	if (tmp)
-		mclose(tmp);
+    if (fp)
+        mclose(fp);
+    if (tmp)
+        mclose(tmp);
 
-	if (rename(tmpname, passfile)) {
-		error("renaming ", tmpname);
-		exit(1);
-	}
-	wfputs("Password changed.\n", out);
-	return 1;
+    if (rename(tmpname, passfile)) {
+        error("renaming ", tmpname);
+        exit(1);
+    }
+    wfputs("Password changed.\n", out);
+    return 1;
 }

--- a/util.cc
+++ b/util.cc
@@ -15,142 +15,140 @@
 char *
 makeword(char *line, char stop)
 {
-	const char *sep = strchr(line, stop);
-	char *word;
-	size_t llen, wlen;
+    const char *sep = strchr(line, stop);
+    char *word;
+    size_t llen, wlen;
 
-	if (sep == NULL)
-		return estrdup("");
-	llen = strlen(line);
-	wlen = sep - line;
-	word = estrndup(line, wlen);
-	memmove(line, line + wlen, llen - wlen);
+    if (sep == NULL)
+        return estrdup("");
+    llen = strlen(line);
+    wlen = sep - line;
+    word = estrndup(line, wlen);
+    memmove(line, line + wlen, llen - wlen);
 
-	return word;
+    return word;
 }
 
 char *
 fmakeword(FILE *f, char stop, int *cl)
 {
-	int wsize;
-	char *word;
-	int ll;
-	wsize = 102400;
-	ll = 0;
-	word = (char *)emalloc(wsize + 1);
+    int wsize;
+    char *word;
+    int ll;
+    wsize = 102400;
+    ll = 0;
+    word = (char *)emalloc(wsize + 1);
 
-	while (1) {
-		word[ll] = (char)fgetc(f);
-		if (ll == wsize) {
-			word[ll + 1] = '\0';
-			wsize += 102400;
-			word = (char *)erealloc(word, wsize + 1);
-		}
-		--(*cl);
-		if ((word[ll] == stop) || (feof(f)) || (!(*cl))) {
-			if (word[ll] != stop)
-				ll++;
-			word[ll] = '\0';
-			return word;
-		}
-		++ll;
-	}
+    while (1) {
+        word[ll] = (char)fgetc(f);
+        if (ll == wsize) {
+            word[ll + 1] = '\0';
+            wsize += 102400;
+            word = (char *)erealloc(word, wsize + 1);
+        }
+        --(*cl);
+        if ((word[ll] == stop) || (feof(f)) || (!(*cl))) {
+            if (word[ll] != stop)
+                ll++;
+            word[ll] = '\0';
+            return word;
+        }
+        ++ll;
+    }
 }
 
 char
 x2c(char *what)
 {
-	char digit;
-	digit =
-	    (what[0] >= 'A' ? ((what[0] & 0xdf) - 'A') + 10 : (what[0] - '0'));
-	digit *= 16;
-	digit +=
-	    (what[1] >= 'A' ? ((what[1] & 0xdf) - 'A') + 10 : (what[1] - '0'));
-	return (digit);
+    char digit;
+    digit = (what[0] >= 'A' ? ((what[0] & 0xdf) - 'A') + 10 : (what[0] - '0'));
+    digit *= 16;
+    digit += (what[1] >= 'A' ? ((what[1] & 0xdf) - 'A') + 10 : (what[1] - '0'));
+    return (digit);
 }
 
 void
 unescape_url(char *url)
 {
-	int x, y;
-	for (x = 0, y = 0; url[y]; ++x, ++y) {
-		if ((url[x] = url[y]) == '%') {
-			url[x] = x2c(&url[y + 1]);
-			y += 2;
-		}
-	}
-	url[x] = '\0';
+    int x, y;
+    for (x = 0, y = 0; url[y]; ++x, ++y) {
+        if ((url[x] = url[y]) == '%') {
+            url[x] = x2c(&url[y + 1]);
+            y += 2;
+        }
+    }
+    url[x] = '\0';
 }
 
 void
 plustospace(char *str)
 {
-	int x;
-	for (x = 0; str[x]; x++)
-		if (str[x] == '+')
-			str[x] = ' ';
+    int x;
+    for (x = 0; str[x]; x++)
+        if (str[x] == '+')
+            str[x] = ' ';
 }
 
 int
 rind(char *s, char c)
 {
-	int x;
-	for (x = strlen(s) - 1; x != -1; x--)
-		if (s[x] == c)
-			return x;
-	return -1;
+    int x;
+    for (x = strlen(s) - 1; x != -1; x--)
+        if (s[x] == c)
+            return x;
+    return -1;
 }
 
 int
 ygetline(char *s, int n, FILE *f)
 {
-	int i = 0;
-	while (1) {
-		s[i] = (char)fgetc(f);
+    int i = 0;
+    while (1) {
+        s[i] = (char)fgetc(f);
 
-		if (s[i] == CR)
-			s[i] = fgetc(f);
+        if (s[i] == CR)
+            s[i] = fgetc(f);
 
-		if ((s[i] == 0x4) || (s[i] == LF) || (i == (n - 1))) {
-			s[i] = '\0';
-			return (feof(f) ? 1 : 0);
-		}
-		++i;
-	}
+        if ((s[i] == 0x4) || (s[i] == LF) || (i == (n - 1))) {
+            s[i] = '\0';
+            return (feof(f) ? 1 : 0);
+        }
+        ++i;
+    }
 }
 
 void
 send_fd(FILE *src, FILE *dst)
 {
-	int c;
-	for (;;) {
-		c = fgetc(src);
-		if (feof(src))
-			return;
-		fputc(c, dst);
-	}
+    int c;
+    for (;;) {
+        c = fgetc(src);
+        if (feof(src))
+            return;
+        fputc(c, dst);
+    }
 }
 
 void
 escape_shell_cmd(char *cmd)
 {
-	int x, y, l;
-	l = strlen(cmd);
-	for (x = 0; cmd[x]; x++) {
-		if (strchr("&;`'\"|*?~<>^()[]{}$\\", cmd[x]) != NULL) {
-			for (y = l + 1; y > x; y--) cmd[y] = cmd[y - 1];
-			l++; /* length has been increased */
-			cmd[x] = '\\';
-			x++; /* skip the character */
-		}
-	}
+    int x, y, l;
+    l = strlen(cmd);
+    for (x = 0; cmd[x]; x++) {
+        if (strchr("&;`'\"|*?~<>^()[]{}$\\", cmd[x]) != NULL) {
+            for (y = l + 1; y > x; y--) cmd[y] = cmd[y - 1];
+            l++; /* length has been increased */
+            cmd[x] = '\\';
+            x++; /* skip the character */
+        }
+    }
 }
 
 void
 html_header(char *title)
 {
-	std::println("Content-type: text/html");
-	std::print("\n");
-	std::print("<HTML><HEAD><TITLE>{}</TITLE></HEAD>", title);
-	std::println("<BODY><H1>{}</H1>", title);
+    std::println("Content-type: text/html");
+    std::print("\n");
+    std::print("<HTML><HEAD><TITLE>{}</TITLE></HEAD>", title);
+    std::println("<BODY><H1>{}</H1>", title);
 }

--- a/webuser.cc
+++ b/webuser.cc
@@ -8,7 +8,6 @@
  *  cannot get the encrypted form of the user's password.
  */
 
-
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -28,8 +27,8 @@
 
 #include "str.h"
 
-#undef HAVE_GETSPNAM     /* Solaris                  */
-#undef HAVE_DBM_OPEN     /* Most platforms have dbm_open()          */
+#undef HAVE_GETSPNAM /* Solaris                  */
+#undef HAVE_DBM_OPEN /* Most platforms have dbm_open()          */
 
 #ifdef HAVE_DBM_OPEN
 #include <ndbm.h>
@@ -70,25 +69,23 @@ int num_params = 0;
 void
 get_yapp_conf(void)
 {
-	FILE *fp;
-	char buff[256], *ptr;
-	for (int i = 0; conf[i]; i++) {
-		if ((fp = fopen(conf[i], "r")) != NULL) {
-			while (num_params < MAX_PARAMS &&
-			       fgets(buff, sizeof(buff), fp)) {
-				if (buff[0] == '#' ||
-				    !(ptr = strchr(buff, ':')))
-					continue;
-				*ptr++ = '\0';
-				if (ptr[strlen(ptr) - 1] == '\n')
-					ptr[strlen(ptr) - 1] = '\0';
-				strcpy(param_key[num_params], buff);
-				strcpy(param_value[num_params++], ptr);
-			}
-			fclose(fp);
-			return;
-		}
-	}
+    FILE *fp;
+    char buff[256], *ptr;
+    for (int i = 0; conf[i]; i++) {
+        if ((fp = fopen(conf[i], "r")) != NULL) {
+            while (num_params < MAX_PARAMS && fgets(buff, sizeof(buff), fp)) {
+                if (buff[0] == '#' || !(ptr = strchr(buff, ':')))
+                    continue;
+                *ptr++ = '\0';
+                if (ptr[strlen(ptr) - 1] == '\n')
+                    ptr[strlen(ptr) - 1] = '\0';
+                strcpy(param_key[num_params], buff);
+                strcpy(param_value[num_params++], ptr);
+            }
+            fclose(fp);
+            return;
+        }
+    }
 }
 /* Look up the value of a yapp configuration option */
 /* OUT: value of requested parameter */
@@ -97,11 +94,11 @@ get_yapp_conf(void)
 const char *
 get_conf_param(const char *name, const char *def)
 {
-	for (int i = 0; i < num_params; i++) {
-		if (str::eq(param_key[i], name))
-			return param_value[i];
-	}
-	return def;
+    for (int i = 0; i < num_params; i++) {
+        if (str::eq(param_key[i], name))
+            return param_value[i];
+    }
+    return def;
 }
 /* Get the home directory used when logging in from the web */
 /* IN: login */
@@ -109,9 +106,8 @@ get_conf_param(const char *name, const char *def)
 std::string
 get_homedir(const std::string_view &login)
 {
-	return std::format("{}/{:c}/{:c}/{}",
-	    get_conf_param("userhome", USER_HOME),
-	    tolower(login[0]), tolower(login[1]), login);
+    return std::format("{}/{:c}/{:c}/{}", get_conf_param("userhome", USER_HOME),
+        tolower(login[0]), tolower(login[1]), login);
 }
 /* Get the directory holding the user's participation files */
 /* OUT: participation file directory */
@@ -119,16 +115,16 @@ get_homedir(const std::string_view &login)
 const char *
 get_partdir(const char *login)
 {
-	static std::string partdir;
+    static std::string partdir;
 
-	const char *pd = get_conf_param("partdir", "work");
-	if (str::eq(pd, "work"))
-		partdir = get_homedir(login);
-	else {
-		partdir = std::format("{}/{:c}/{:c}/{}",
-		    pd, tolower(login[0]), tolower(login[1]), login);
-	}
-	return partdir.c_str();
+    const char *pd = get_conf_param("partdir", "work");
+    if (str::eq(pd, "work"))
+        partdir = get_homedir(login);
+    else {
+        partdir = std::format(
+            "{}/{:c}/{:c}/{}", pd, tolower(login[0]), tolower(login[1]), login);
+    }
+    return partdir.c_str();
 }
 /* Figure out where the user's information should be stored */
 /* OUT: filename of user's information file */
@@ -138,68 +134,68 @@ get_partdir(const char *login)
 std::string
 get_userfile(const std::string_view &login, uid_t *uid, gid_t *gid)
 {
-	static std::string path;
-	const auto home = get_homedir(login);
+    static std::string path;
+    const auto home = get_homedir(login);
 
 #ifdef HAVE_DBM_OPEN
-	/* If userdbm=true then it's in ~/<login> */
-	if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
-		path = std::format("{}/{:c}/{:c}/{}/{}",
-		    get_conf_param("userhome", USER_HOME), tolower(login[0]),
-		    tolower(login[1]), login, login);
-		if (uid)
-			*uid = nobody.pw_uid;
-		if (gid)
-			*gid = nobody.pw_gid;
-		return path.c_str();
-	}
+    /* If userdbm=true then it's in ~/<login> */
+    if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
+        path = std::format("{}/{:c}/{:c}/{}/{}",
+            get_conf_param("userhome", USER_HOME), tolower(login[0]),
+            tolower(login[1]), login, login);
+        if (uid)
+            *uid = nobody.pw_uid;
+        if (gid)
+            *gid = nobody.pw_gid;
+        return path.c_str();
+    }
 #endif
 
-	/* Otherwise it's in the location specified by userfile */
-	std::string file = get_conf_param("userfile", USER_FILE);
-	if (file[0] == '~' && file[1] == '/') {
-		file = std::format("{}/{}", home, file.c_str() + 2);
-		if (uid)
-			*uid = nobody.pw_uid;
-		if (gid)
-			*gid = nobody.pw_gid;
-	} else {
-		if (uid)
-			*uid = cfadm.pw_uid;
-		if (gid)
-			*gid = cfadm.pw_gid;
-	}
-	return file;
+    /* Otherwise it's in the location specified by userfile */
+    std::string file = get_conf_param("userfile", USER_FILE);
+    if (file[0] == '~' && file[1] == '/') {
+        file = std::format("{}/{}", home, file.c_str() + 2);
+        if (uid)
+            *uid = nobody.pw_uid;
+        if (gid)
+            *gid = nobody.pw_gid;
+    } else {
+        if (uid)
+            *uid = cfadm.pw_uid;
+        if (gid)
+            *gid = cfadm.pw_gid;
+    }
+    return file;
 }
 
 #ifdef HAVE_DBM_OPEN
 int /* RETURNS: 1 on success, 0 on failure */
 save_dbm(DBM *db, const char *keystr, const char *valstr)
 {
-	datum dkey, dval;
-	dkey.dptr = (void *)keystr;
-	dkey.dsize = strlen(keystr) + 1;
-	dval.dptr = (void *)valstr;
-	dval.dsize = strlen(valstr) + 1;
+    datum dkey, dval;
+    dkey.dptr = (void *)keystr;
+    dkey.dsize = strlen(keystr) + 1;
+    dval.dptr = (void *)valstr;
+    dval.dsize = strlen(valstr) + 1;
 
-	return dbm_store(db, dkey, dval, DBM_REPLACE);
+    return dbm_store(db, dkey, dval, DBM_REPLACE);
 }
 
 const char *
 get_dbm(const char *userfile, const char *keystr)
 {
-	datum dkey, dval;
-	DBM *db;
-	db = dbm_open(userfile, O_RDWR, 0644);
-	if (!db)
-		return "";
+    datum dkey, dval;
+    DBM *db;
+    db = dbm_open(userfile, O_RDWR, 0644);
+    if (!db)
+        return "";
 
-	dkey.dptr = (void *)keystr;
-	dkey.dsize = strlen(keystr) + 1;
-	dval = dbm_fetch(db, dkey);
-	dbm_close(db);
+    dkey.dptr = (void *)keystr;
+    dkey.dsize = strlen(keystr) + 1;
+    dval = dbm_fetch(db, dkey);
+    dbm_close(db);
 
-	return (dval.dptr) ? dval.dptr : "";
+    return (dval.dptr) ? dval.dptr : "";
 }
 #endif /* HAVE_DBM_OPEN */
 
@@ -208,70 +204,71 @@ get_dbm(const char *userfile, const char *keystr)
 /* IN: full name */
 /* IN: email address */
 void
-create_user_info(const std::string_view &login, const std::string_view &fullname, const std::string_view &email)
+create_user_info(const std::string_view &login,
+    const std::string_view &fullname, const std::string_view &email)
 {
-	FILE *fp, *tmp;
-	uid_t uid;
-	gid_t gid;
-	const auto userfile = get_userfile(login, &uid, &gid);
-	char buff[256];
+    FILE *fp, *tmp;
+    uid_t uid;
+    gid_t gid;
+    const auto userfile = get_userfile(login, &uid, &gid);
+    char buff[256];
 
 #ifdef HAVE_DBM_OPEN
-	/* Support DBM files */
-	if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
-		datum dkey, dval;
-		DBM *db;
-		if ((db = dbm_open(userfile, O_RDWR | O_CREAT, 0644)) == NULL) {
-			perror("dbm_open");
-			exit(1);
-		}
-		if (save_dbm(db, "fullname", fullname) ||
-		    save_dbm(db, "email", email)) {
-			perror("dbm_store");
-			exit(1);
-		}
-		dbm_close(db);
+    /* Support DBM files */
+    if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
+        datum dkey, dval;
+        DBM *db;
+        if ((db = dbm_open(userfile, O_RDWR | O_CREAT, 0644)) == NULL) {
+            perror("dbm_open");
+            exit(1);
+        }
+        if (save_dbm(db, "fullname", fullname) ||
+            save_dbm(db, "email", email)) {
+            perror("dbm_store");
+            exit(1);
+        }
+        dbm_close(db);
 
-		chown(userfile, uid, gid);
-		chmod(userfile, 0644);
+        chown(userfile, uid, gid);
+        chmod(userfile, 0644);
 
-		return;
-	}
+        return;
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Support flat text files */
+    /* Support flat text files */
 
-	/* Open new userfile */
-	const auto pathtmp = std::format("{}.{}", userfile, getpid());
-	if ((tmp = fopen(pathtmp.c_str(), "w")) == NULL) {
-		const auto msg = std::string("fopen ") + pathtmp;
-		perror(msg.c_str());
-		exit(1);
-	}
+    /* Open new userfile */
+    const auto pathtmp = std::format("{}.{}", userfile, getpid());
+    if ((tmp = fopen(pathtmp.c_str(), "w")) == NULL) {
+        const auto msg = std::string("fopen ") + pathtmp;
+        perror(msg.c_str());
+        exit(1);
+    }
 
-	if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
-		const auto ustr = std::format("{}:", login);
-		while (fgets(buff, sizeof(buff), fp)) {
-			const auto line = std::string_view(buff);
-			/* Find login in user file */
-			if (line.starts_with(ustr))
-				/* Add user's info to userfile */
-				std::println(tmp, "{}:{}:{}", login, fullname, email);
-			else
-				/* Copy rest of file */
-				std::print(tmp, "{}", line);
-		}
-		fclose(fp);
-	}
+    if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
+        const auto ustr = std::format("{}:", login);
+        while (fgets(buff, sizeof(buff), fp)) {
+            const auto line = std::string_view(buff);
+            /* Find login in user file */
+            if (line.starts_with(ustr))
+                /* Add user's info to userfile */
+                std::println(tmp, "{}:{}:{}", login, fullname, email);
+            else
+                /* Copy rest of file */
+                std::print(tmp, "{}", line);
+        }
+        fclose(fp);
+    }
 
-	/* Commit the changes */
-	fclose(tmp);
-	if (rename(pathtmp.c_str(), userfile.c_str())) {
-		perror("rename");
-		exit(1);
-	}
-	chown(userfile.c_str(), uid, gid);
-	chmod(userfile.c_str(), 0644);
+    /* Commit the changes */
+    fclose(tmp);
+    if (rename(pathtmp.c_str(), userfile.c_str())) {
+        perror("rename");
+        exit(1);
+    }
+    chown(userfile.c_str(), uid, gid);
+    chmod(userfile.c_str(), 0644);
 }
 /* Get the local hostname for use in constructing a full email address */
 /* IN : size of buffer */
@@ -279,27 +276,27 @@ create_user_info(const std::string_view &login, const std::string_view &fullname
 void
 get_local_hostname(char *buff, int len)
 {
-	buff[0] = '\0';
-	if (gethostname(buff, len))
-		perror("getting host name");
+    buff[0] = '\0';
+    if (gethostname(buff, len))
+        perror("getting host name");
 
-	/* If hostname is not fully qualified, try to get it from
-	 * /etc/resolv.conf */
-	if (!strchr(buff, '.')) {
-		FILE *fp;
-		if ((fp = fopen("/etc/resolv.conf", "r")) != NULL) {
-			char line[256], field[80], value[80];
-			while (fgets(line, sizeof(line), fp)) {
-				if (sscanf(line, "%s%s", field, value) == 2 &&
-				    str::eq(field, "domain")) {
-					strlcat(buff, ".", len);
-					strlcat(buff, value, len);
-					break;
-				}
-			}
-			fclose(fp);
-		}
-	}
+    /* If hostname is not fully qualified, try to get it from
+     * /etc/resolv.conf */
+    if (!strchr(buff, '.')) {
+        FILE *fp;
+        if ((fp = fopen("/etc/resolv.conf", "r")) != NULL) {
+            char line[256], field[80], value[80];
+            while (fgets(line, sizeof(line), fp)) {
+                if (sscanf(line, "%s%s", field, value) == 2 &&
+                    str::eq(field, "domain")) {
+                    strlcat(buff, ".", len);
+                    strlcat(buff, value, len);
+                    break;
+                }
+            }
+            fclose(fp);
+        }
+    }
 }
 /* Create a web password file entry and home directory */
 void
@@ -309,116 +306,117 @@ create_web_account(char *login, /* IN : login to create */
     gid_t gid                   /* IN : group ID of 'nobody' */
 )
 {
-	FILE *fp, *tmp;
-	const char *passfile = get_conf_param("passfile", PASS_FILE);
-	char buff[256];
+    FILE *fp, *tmp;
+    const char *passfile = get_conf_param("passfile", PASS_FILE);
+    char buff[256];
 
-	if (!str::eq(passfile, get_conf_param("userfile", USER_FILE))) {
-		/* Open new .htpasswd file */
-		const auto tmpname = std::format("{}.{}", passfile, getpid());
-		if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
-			const auto msg = std::format("fopen {}", tmpname);
-			perror(msg.c_str());
-			exit(1);
-		}
+    if (!str::eq(passfile, get_conf_param("userfile", USER_FILE))) {
+        /* Open new .htpasswd file */
+        const auto tmpname = std::format("{}.{}", passfile, getpid());
+        if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
+            const auto msg = std::format("fopen {}", tmpname);
+            perror(msg.c_str());
+            exit(1);
+        }
 
-		if ((fp = fopen(passfile, "r")) != NULL) {
-			const auto ustr = std::format("{}:", login);
-			while (fgets(buff, sizeof(buff), fp)) {
-				const auto line = std::string_view(buff);
-				/* Find login in pass file */
-				if (line.starts_with(ustr))
-					/* Add password to .htpasswd */
-					std::println(tmp, "{}:{}", login, passwd);
-				else
-					/* Copy remainder of file */
-					std::print(tmp, "%s", line);
-			}
-			fclose(fp);
-		}
+        if ((fp = fopen(passfile, "r")) != NULL) {
+            const auto ustr = std::format("{}:", login);
+            while (fgets(buff, sizeof(buff), fp)) {
+                const auto line = std::string_view(buff);
+                /* Find login in pass file */
+                if (line.starts_with(ustr))
+                    /* Add password to .htpasswd */
+                    std::println(tmp, "{}:{}", login, passwd);
+                else
+                    /* Copy remainder of file */
+                    std::print(tmp, "%s", line);
+            }
+            fclose(fp);
+        }
 
-		/* Commit the changes */
-		fclose(tmp);
-		if (rename(tmpname.c_str(), passfile)) {
-			perror("rename");
-			exit(1);
-		}
-		chown(passfile, cfadm.pw_uid, cfadm.pw_gid);
-		chmod(passfile, 0644);
-	}
+        /* Commit the changes */
+        fclose(tmp);
+        if (rename(tmpname.c_str(), passfile)) {
+            perror("rename");
+            exit(1);
+        }
+        chown(passfile, cfadm.pw_uid, cfadm.pw_gid);
+        chmod(passfile, 0644);
+    }
 
-	/* Make user's web home directory (and any subdirs needed before it) */
-	auto home = std::format("{}/{:c}", get_conf_param("userhome", USER_HOME),
-	    tolower(login[0]));
-	const char *chome = home.c_str();
-	mkdir(chome, 0755);
-	if (chown(chome, uid, gid))
-		perror(chome);
-	home.push_back('/');
-	home.push_back(tolower(login[1]));
-	chome = home.c_str();
-	mkdir(chome, 0755);
-	if (chown(chome, uid, gid))
-		perror(chome);
-	home.push_back('/');
-	home.append(login);
-	chome = home.c_str();
-	mkdir(chome, 0755);
-	if (chown(chome, uid, gid))
-		perror(chome);
+    /* Make user's web home directory (and any subdirs needed before it) */
+    auto home = std::format(
+        "{}/{:c}", get_conf_param("userhome", USER_HOME), tolower(login[0]));
+    const char *chome = home.c_str();
+    mkdir(chome, 0755);
+    if (chown(chome, uid, gid))
+        perror(chome);
+    home.push_back('/');
+    home.push_back(tolower(login[1]));
+    chome = home.c_str();
+    mkdir(chome, 0755);
+    if (chown(chome, uid, gid))
+        perror(chome);
+    home.push_back('/');
+    home.append(login);
+    chome = home.c_str();
+    mkdir(chome, 0755);
+    if (chown(chome, uid, gid))
+        perror(chome);
 }
 
 void
 usage(void)
 {
-	std::println(std::cerr,
-	    "Yapp {} (c)1996 Armidale Software\n usage: webuser [-dehlprsuv] [login]",
-	    VERSION);
-	std::println(std::cerr, " -d        Disable logins to account");
-	std::println(std::cerr, " -e        Enable disabled account");
-	std::println(std::cerr, " -h        Help (display this text)");
-	std::println(std::cerr, " -l        List all web accounts");
-	std::println(std::cerr, " -p        Change password on account");
-	std::println(std::cerr, " -r        Remove account");
-	std::println(std::cerr, " -s        Show account information");
-	std::println(std::cerr,
-	    " -u        Create/update web account and password (default)");
-	std::println(std::cerr, " -v        Version (display this text)");
-	std::println(std::cerr, " login     Specify Unix login");
-	exit(1);
+    std::println(std::cerr,
+        "Yapp {} (c)1996 Armidale Software\n usage: webuser [-dehlprsuv] "
+        "[login]",
+        VERSION);
+    std::println(std::cerr, " -d        Disable logins to account");
+    std::println(std::cerr, " -e        Enable disabled account");
+    std::println(std::cerr, " -h        Help (display this text)");
+    std::println(std::cerr, " -l        List all web accounts");
+    std::println(std::cerr, " -p        Change password on account");
+    std::println(std::cerr, " -r        Remove account");
+    std::println(std::cerr, " -s        Show account information");
+    std::println(std::cerr,
+        " -u        Create/update web account and password (default)");
+    std::println(std::cerr, " -v        Version (display this text)");
+    std::println(std::cerr, " login     Specify Unix login");
+    exit(1);
 }
 
 char *
 get_web_password(char *login) /* IN : login to find */
 {
-	const char *passfile = get_conf_param("passfile", PASS_FILE);
-	FILE *fp;
-	static char buff[256];
+    const char *passfile = get_conf_param("passfile", PASS_FILE);
+    FILE *fp;
+    static char buff[256];
 
 #ifdef HAVE_DBM_OPEN
-	if (str::eq(get_conf_param("userdbm", USERDBM), "true") &&
-	    str::eq(get_conf_param("userfile", USER_FILE),
-	        get_conf_param("passfile", PASS_FILE))) {
-		char *userfile = get_userfile(login, NULL, NULL);
-		return get_dbm(userfile, "passwd");
-	}
+    if (str::eq(get_conf_param("userdbm", USERDBM), "true") &&
+        str::eq(get_conf_param("userfile", USER_FILE),
+            get_conf_param("passfile", PASS_FILE))) {
+        char *userfile = get_userfile(login, NULL, NULL);
+        return get_dbm(userfile, "passwd");
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Find login in pass file */
-	if ((fp = fopen(passfile, "r")) != NULL) {
-		const auto ustr = std::format("{}:", login);
-		while (fgets(buff, sizeof(buff), fp)) {
-			const auto line = std::string_view(buff);
-			if (line.starts_with(ustr)) {
-				if (buff[strlen(buff) - 1] == '\n')
-					buff[strlen(buff) - 1] = '\0';
-				fclose(fp);
-				return buff + ustr.size(); /* start of password */
-			}
-		}
-		fclose(fp);
-	}
-	return 0;
+    /* Find login in pass file */
+    if ((fp = fopen(passfile, "r")) != NULL) {
+        const auto ustr = std::format("{}:", login);
+        while (fgets(buff, sizeof(buff), fp)) {
+            const auto line = std::string_view(buff);
+            if (line.starts_with(ustr)) {
+                if (buff[strlen(buff) - 1] == '\n')
+                    buff[strlen(buff) - 1] = '\0';
+                fclose(fp);
+                return buff + ustr.size(); /* start of password */
+            }
+        }
+        fclose(fp);
+    }
+    return 0;
 }
 
 void
@@ -427,32 +425,32 @@ get_user_info(char *login, /* IN : Unix login    */
     char *email            /* OUT: Email address */
 )
 {
-	static char buff[256];
-	FILE *fp;
-	const auto userfile = get_userfile(login, NULL, NULL);
+    static char buff[256];
+    FILE *fp;
+    const auto userfile = get_userfile(login, NULL, NULL);
 
 #ifdef HAVE_DBM_OPEN
-	if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
-		strcpy(fullname, get_dbm(userfile, "fullname"));
-		strcpy(email, get_dbm(userfile, "email"));
-		return;
-	}
+    if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
+        strcpy(fullname, get_dbm(userfile, "fullname"));
+        strcpy(email, get_dbm(userfile, "email"));
+        return;
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	/* Find login in user file */
-	if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
-		const auto ustr = std::format("{}:", login);
-		while (fgets(buff, sizeof(buff), fp)) {
-			const auto line = std::string_view(buff);
-			if (line.starts_with(ustr)) {
-				(void)strtok(buff, ":\n");
-				strcpy(fullname, strtok(NULL, ":\n"));
-				strcpy(email, strtok(NULL, ":\n"));
-				break;
-			}
-		}
-		fclose(fp);
-	}
+    /* Find login in user file */
+    if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
+        const auto ustr = std::format("{}:", login);
+        while (fgets(buff, sizeof(buff), fp)) {
+            const auto line = std::string_view(buff);
+            if (line.starts_with(ustr)) {
+                (void)strtok(buff, ":\n");
+                strcpy(fullname, strtok(NULL, ":\n"));
+                strcpy(email, strtok(NULL, ":\n"));
+                break;
+            }
+        }
+        fclose(fp);
+    }
 }
 /* Make a web account with the same password as a Unix account */
 void
@@ -460,492 +458,491 @@ update(char *login /* IN: Unix login */
 )
 {
 #ifdef HAVE_GETSPNAM
-	struct spwd *spw;
+    struct spwd *spw;
 #endif
-	struct passwd *pw, user;
-	char hostname[MAXHOSTNAMELEN];
-	/* If root, usradm, or nobody, then allow arbitrary login to be
-	 * specified */
-	pw = getpwuid(getuid());
-	if (pw && (pw->pw_uid == 0 || pw->pw_uid == usradm.pw_uid ||
-	              pw->pw_uid == nobody.pw_uid))
-		pw = getpwnam(login);
-	else if (!str::eq(login, getlogin())) {
-		std::println("webuser: Permission denied");
-		exit(1);
-	}
-	if (pw == NULL) {
-		std::println("webuser: no such login");
-		exit(1);
-	}
-	if (!pw->pw_uid) {
-		std::println("webuser: cannot create a web account with root access");
-		exit(1);
-	}
-	memcpy(&user, pw, sizeof(user)); /* save everything */
+    struct passwd *pw, user;
+    char hostname[MAXHOSTNAMELEN];
+    /* If root, usradm, or nobody, then allow arbitrary login to be
+     * specified */
+    pw = getpwuid(getuid());
+    if (pw && (pw->pw_uid == 0 || pw->pw_uid == usradm.pw_uid ||
+                  pw->pw_uid == nobody.pw_uid))
+        pw = getpwnam(login);
+    else if (!str::eq(login, getlogin())) {
+        std::println("webuser: Permission denied");
+        exit(1);
+    }
+    if (pw == NULL) {
+        std::println("webuser: no such login");
+        exit(1);
+    }
+    if (!pw->pw_uid) {
+        std::println("webuser: cannot create a web account with root access");
+        exit(1);
+    }
+    memcpy(&user, pw, sizeof(user)); /* save everything */
 
-	/* Construct home directory */
+    /* Construct home directory */
 #ifdef HAVE_GETSPNAM
-	spw = getspnam(pw->pw_name); /* get encrypted password */
-	create_web_account(
-	    user.pw_name, spw->sp_pwdp, nobody.pw_uid, nobody.pw_gid);
+    spw = getspnam(pw->pw_name); /* get encrypted password */
+    create_web_account(
+        user.pw_name, spw->sp_pwdp, nobody.pw_uid, nobody.pw_gid);
 #else
-	create_web_account(
-	    user.pw_name, user.pw_passwd, nobody.pw_uid, nobody.pw_gid);
+    create_web_account(
+        user.pw_name, user.pw_passwd, nobody.pw_uid, nobody.pw_gid);
 #endif
 
-	/* Construct email address */
-	get_local_hostname(hostname, sizeof(hostname));
-	const auto email = std::format("{}@{}", user.pw_name, hostname);
+    /* Construct email address */
+    get_local_hostname(hostname, sizeof(hostname));
+    const auto email = std::format("{}@{}", user.pw_name, hostname);
 
-	/* Add web user information */
-	create_user_info(user.pw_name, strtok(user.pw_gecos, ","), email);
+    /* Add web user information */
+    create_user_info(user.pw_name, strtok(user.pw_gecos, ","), email);
 }
 /* Re-enable a disabled web account */
 void
 enable(char *login /* IN: Web login */
 )
 {
-	char *old_ep;
-	/* Only root and usradm may do this */
-	if (getuid() != 0 && getuid() != usradm.pw_uid) {
-		std::println("webuser: Permission denied");
-		exit(1);
-	}
+    char *old_ep;
+    /* Only root and usradm may do this */
+    if (getuid() != 0 && getuid() != usradm.pw_uid) {
+        std::println("webuser: Permission denied");
+        exit(1);
+    }
 
-	/* Get old password */
-	old_ep = get_web_password(login);
-	if (!old_ep) {
-		std::println("webuser: no such login '{}'", login);
-		exit(1);
-	}
+    /* Get old password */
+    old_ep = get_web_password(login);
+    if (!old_ep) {
+        std::println("webuser: no such login '{}'", login);
+        exit(1);
+    }
 
-	/* Make sure it isn't already enabled */
-	if (strncmp(old_ep, "*:", 2)) {
-		std::println("webuser: '{}' is already enabled", login);
-		exit(1);
-	}
+    /* Make sure it isn't already enabled */
+    if (strncmp(old_ep, "*:", 2)) {
+        std::println("webuser: '{}' is already enabled", login);
+        exit(1);
+    }
 
-	/* Change password */
-	create_web_account(login, old_ep + 2, nobody.pw_uid, nobody.pw_gid);
+    /* Change password */
+    create_web_account(login, old_ep + 2, nobody.pw_uid, nobody.pw_gid);
 }
 /* Disable a web account */
 void
 disable(char *login /* IN: Web login */
 )
 {
-	char *old_ep;
-	char new_ep[256];
-	/* Only root and usradm may do this */
-	if (getuid() != 0 && getuid() != usradm.pw_uid) {
-		std::println("webuser: Permission denied");
-		exit(1);
-	}
+    char *old_ep;
+    char new_ep[256];
+    /* Only root and usradm may do this */
+    if (getuid() != 0 && getuid() != usradm.pw_uid) {
+        std::println("webuser: Permission denied");
+        exit(1);
+    }
 
-	/* Get old password */
-	old_ep = get_web_password(login);
-	if (!old_ep) {
-		std::println("webuser: no such login '{}'", login);
-		exit(1);
-	}
+    /* Get old password */
+    old_ep = get_web_password(login);
+    if (!old_ep) {
+        std::println("webuser: no such login '{}'", login);
+        exit(1);
+    }
 
-	/* Make sure it isn't already disabled */
-	if (!strncmp(old_ep, "*:", 2)) {
-		std::println("webuser: '{}' is already disabled", login);
-		exit(1);
-	}
+    /* Make sure it isn't already disabled */
+    if (!strncmp(old_ep, "*:", 2)) {
+        std::println("webuser: '{}' is already disabled", login);
+        exit(1);
+    }
 
-	/* Change password */
-	strlcpy(new_ep, "*:", sizeof(new_ep));
-	strlcat(new_ep, old_ep, sizeof(new_ep));
-	create_web_account(login, new_ep, nobody.pw_uid, nobody.pw_gid);
+    /* Change password */
+    strlcpy(new_ep, "*:", sizeof(new_ep));
+    strlcat(new_ep, old_ep, sizeof(new_ep));
+    create_web_account(login, new_ep, nobody.pw_uid, nobody.pw_gid);
 }
 /* Recursively remove a directory and everything under it */
 void
 recursive_rmdir(const std::string &path)
 {
-	DIR *dp;
-	struct dirent *fp;
-	struct stat st;
+    DIR *dp;
+    struct dirent *fp;
+    struct stat st;
 
-	if ((dp = opendir(path.c_str())) == NULL) {
-		perror(path.c_str());
-		return;
-	}
-	while ((fp = readdir(dp)) != NULL) {
-		if (str::eq(fp->d_name, ".") || str::eq(fp->d_name, ".."))
-			continue;
-		const auto pname = std::format("{}/{}", path, fp->d_name);
-		if (stat(pname.c_str(), &st) != 0) {
-			perror(pname.c_str());
-			continue;
-		}
-		if (st.st_mode & S_IFDIR) {
-			recursive_rmdir(pname);
-		} else {
-			if (unlink(pname.c_str()))
-				perror(pname.c_str());
-		}
-	}
-	closedir(dp);
-	if (rmdir(path.c_str()))
-		perror(path.c_str());
+    if ((dp = opendir(path.c_str())) == NULL) {
+        perror(path.c_str());
+        return;
+    }
+    while ((fp = readdir(dp)) != NULL) {
+        if (str::eq(fp->d_name, ".") || str::eq(fp->d_name, ".."))
+            continue;
+        const auto pname = std::format("{}/{}", path, fp->d_name);
+        if (stat(pname.c_str(), &st) != 0) {
+            perror(pname.c_str());
+            continue;
+        }
+        if (st.st_mode & S_IFDIR) {
+            recursive_rmdir(pname);
+        } else {
+            if (unlink(pname.c_str()))
+                perror(pname.c_str());
+        }
+    }
+    closedir(dp);
+    if (rmdir(path.c_str()))
+        perror(path.c_str());
 }
 /* Remove a web account */
 void
 rmuser(char *login /* IN: Web login */
 )
 {
-	FILE *fp, *tmp;
-	const char *passfile = get_conf_param("passfile", PASS_FILE);
-	uid_t uid;
-	gid_t gid;
-	const auto userfile = get_userfile(login, &uid, &gid);
-	char buff[PATH_MAX];
-	const auto home = get_homedir(login);
-	char *epass;
+    FILE *fp, *tmp;
+    const char *passfile = get_conf_param("passfile", PASS_FILE);
+    uid_t uid;
+    gid_t gid;
+    const auto userfile = get_userfile(login, &uid, &gid);
+    char buff[PATH_MAX];
+    const auto home = get_homedir(login);
+    char *epass;
 
-	/* Only root and usradm may do this */
-	if (getuid() != 0 && getuid() != usradm.pw_uid) {
-		std::println("webuser: Permission denied");
-		exit(1);
-	}
+    /* Only root and usradm may do this */
+    if (getuid() != 0 && getuid() != usradm.pw_uid) {
+        std::println("webuser: Permission denied");
+        exit(1);
+    }
 
-	/* See if account exists */
-	epass = get_web_password(login);
-	if (!epass) {
-		std::println("webuser: no such login '{}'", login);
-		exit(1);
-	}
+    /* See if account exists */
+    epass = get_web_password(login);
+    if (!epass) {
+        std::println("webuser: no such login '{}'", login);
+        exit(1);
+    }
 
-	/* Prompt for verification */
-	std::print("Delete all files for {} [no]? ", login);
-	std::fflush(stdout);
-	fgets(buff, sizeof(buff), stdin);
-	if (tolower(buff[0]) != 'y') {
-		std::println("webuser: Deletion aborted");
-		exit(1);
-	}
+    /* Prompt for verification */
+    std::print("Delete all files for {} [no]? ", login);
+    std::fflush(stdout);
+    fgets(buff, sizeof(buff), stdin);
+    if (tolower(buff[0]) != 'y') {
+        std::println("webuser: Deletion aborted");
+        exit(1);
+    }
 
-	/* REMOVE PASSWORD FILE ENTRY... */
-	if (passfile != userfile) {
-		/* Open new .htpasswd file */
-		const auto tmpname = std::format("{}.{}", passfile, getpid());
-		if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
-			const auto msg = "fopen " + tmpname;
-			perror(msg.c_str());
-			exit(1);
-		}
+    /* REMOVE PASSWORD FILE ENTRY... */
+    if (passfile != userfile) {
+        /* Open new .htpasswd file */
+        const auto tmpname = std::format("{}.{}", passfile, getpid());
+        if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
+            const auto msg = "fopen " + tmpname;
+            perror(msg.c_str());
+            exit(1);
+        }
 
-		/* Copy all of passfile except any line(s) for specified login
-		 */
-		if ((fp = fopen(passfile, "r")) != NULL) {
-			const auto ustr = std::format("{}:", login);
-			while (fgets(buff, sizeof(buff), fp)) {
-				const auto line = std::string_view(buff);
-				if (!line.starts_with(ustr))
-					std::print(tmp, "{}", line);
-			}
-			fclose(fp);
-		}
+        /* Copy all of passfile except any line(s) for specified login
+         */
+        if ((fp = fopen(passfile, "r")) != NULL) {
+            const auto ustr = std::format("{}:", login);
+            while (fgets(buff, sizeof(buff), fp)) {
+                const auto line = std::string_view(buff);
+                if (!line.starts_with(ustr))
+                    std::print(tmp, "{}", line);
+            }
+            fclose(fp);
+        }
 
-		/* Commit the changes */
-		fclose(tmp);
-		if (rename(tmpname.c_str(), passfile)) {
-			perror("rename");
-			exit(1);
-		}
-		chown(passfile, cfadm.pw_uid, cfadm.pw_gid);
-		chmod(passfile, 0644);
-	}
+        /* Commit the changes */
+        fclose(tmp);
+        if (rename(tmpname.c_str(), passfile)) {
+            perror("rename");
+            exit(1);
+        }
+        chown(passfile, cfadm.pw_uid, cfadm.pw_gid);
+        chmod(passfile, 0644);
+    }
 
-	/* If using a combined userfile, remove the entry from there */
-	if (!userfile.starts_with(home)) {
-		/* Open new userfile */
-		const auto tmpname = std::format("{}.{}", userfile, getpid());
-		if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
-			const std::string msg("fopen " + tmpname);
-			perror(msg.c_str());
-			exit(1);
-		}
+    /* If using a combined userfile, remove the entry from there */
+    if (!userfile.starts_with(home)) {
+        /* Open new userfile */
+        const auto tmpname = std::format("{}.{}", userfile, getpid());
+        if ((tmp = fopen(tmpname.c_str(), "w")) == NULL) {
+            const std::string msg("fopen " + tmpname);
+            perror(msg.c_str());
+            exit(1);
+        }
 
-		/* Find login in user file */
-		if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
-			const auto ustr = std::format("{}:", login);
-			while (fgets(buff, sizeof(buff), fp)) {
-				const auto line = std::string_view(buff);
-				if (!line.starts_with(ustr))
-					std::print(tmp, "{}", line);
-			}
-			fclose(fp);
-		}
+        /* Find login in user file */
+        if ((fp = fopen(userfile.c_str(), "r")) != NULL) {
+            const auto ustr = std::format("{}:", login);
+            while (fgets(buff, sizeof(buff), fp)) {
+                const auto line = std::string_view(buff);
+                if (!line.starts_with(ustr))
+                    std::print(tmp, "{}", line);
+            }
+            fclose(fp);
+        }
 
-		/* Commit the changes */
-		fclose(tmp);
-		if (rename(tmpname.c_str(), userfile.c_str())) {
-			perror("rename");
-			exit(1);
-		}
-		chown(userfile.c_str(), uid, gid);
-		chmod(userfile.c_str(), 0644);
-	}
+        /* Commit the changes */
+        fclose(tmp);
+        if (rename(tmpname.c_str(), userfile.c_str())) {
+            perror("rename");
+            exit(1);
+        }
+        chown(userfile.c_str(), uid, gid);
+        chmod(userfile.c_str(), 0644);
+    }
 
-	/* Remove the web home directory */
-	recursive_rmdir(home);
+    /* Remove the web home directory */
+    recursive_rmdir(home);
 
-	/* If there is no Unix account of the same name */
-	if (!getpwnam(login)) {
-		/* remove the partfile dir */
-		recursive_rmdir(get_partdir(login));
-	}
+    /* If there is no Unix account of the same name */
+    if (!getpwnam(login)) {
+        /* remove the partfile dir */
+        recursive_rmdir(get_partdir(login));
+    }
 }
 time_t
 get_last_change_time(char *login /* IN : login to check */
 )
 {
-	DIR *dp;
-	struct dirent *fp;
-	struct stat st;
-	time_t last = 0;
-	const char *partdir = get_partdir(login);
+    DIR *dp;
+    struct dirent *fp;
+    struct stat st;
+    time_t last = 0;
+    const char *partdir = get_partdir(login);
 
-	if ((dp = opendir(partdir)) == NULL)
-		return 0;
-	while ((fp = readdir(dp)) != NULL) {
-		const auto file = std::format("{}/{}", partdir, fp->d_name);
-		if (stat(file.c_str(), &st) || !(st.st_mode & S_IFREG))
-			continue;
-		if (st.st_mtime > last)
-			last = st.st_mtime;
-	}
-	closedir(dp);
-	return last;
+    if ((dp = opendir(partdir)) == NULL)
+        return 0;
+    while ((fp = readdir(dp)) != NULL) {
+        const auto file = std::format("{}/{}", partdir, fp->d_name);
+        if (stat(file.c_str(), &st) || !(st.st_mode & S_IFREG))
+            continue;
+        if (st.st_mtime > last)
+            last = st.st_mtime;
+    }
+    closedir(dp);
+    return last;
 }
 /* List all web accounts */
 void
 listall(void)
 {
-	const char *passfile = get_conf_param("passfile", PASS_FILE);
-	FILE *fp;
-	char buff[256], fullname[256], email[256], tstr[40];
-	time_t tm, ctm;
-	std::println("S Login      Date   Email                               Full name");
+    const char *passfile = get_conf_param("passfile", PASS_FILE);
+    FILE *fp;
+    char buff[256], fullname[256], email[256], tstr[40];
+    time_t tm, ctm;
+    std::println(
+        "S Login      Date   Email                               Full name");
 
-	/* For each entry in the web password file... */
-	if ((fp = fopen(passfile, "r")) != NULL) {
-		char *p;
-		while (fgets(buff, sizeof(buff), fp)) {
-			p = strchr(buff, ':');
-			if (!p)
-				continue;
-			(*p) = '\0';
+    /* For each entry in the web password file... */
+    if ((fp = fopen(passfile, "r")) != NULL) {
+        char *p;
+        while (fgets(buff, sizeof(buff), fp)) {
+            p = strchr(buff, ':');
+            if (!p)
+                continue;
+            (*p) = '\0';
 
-			get_user_info(buff, fullname, email);
-			tm = get_last_change_time(buff);
-			strcpy(tstr, ((tm) ? ctime(&tm) + 4 : "--- --"));
-			tstr[6] = '\0';
-			time(&ctm);
-			if (strncmp(tstr + 16, ctime(&ctm) + 20, 4)) {
-				strncpy(tstr, tstr + 16, 4);
-				tstr[4] = '\0';
-			}
-			std::println("{:c} {:<10s} {:<6s} {:<35s} {}",
-			    ((p[1] == '*') ? 'D' : '-'), buff, tstr, email,
-			    fullname);
-		}
-		fclose(fp);
-	}
+            get_user_info(buff, fullname, email);
+            tm = get_last_change_time(buff);
+            strcpy(tstr, ((tm) ? ctime(&tm) + 4 : "--- --"));
+            tstr[6] = '\0';
+            time(&ctm);
+            if (strncmp(tstr + 16, ctime(&ctm) + 20, 4)) {
+                strncpy(tstr, tstr + 16, 4);
+                tstr[4] = '\0';
+            }
+            std::println("{:c} {:<10s} {:<6s} {:<35s} {}",
+                ((p[1] == '*') ? 'D' : '-'), buff, tstr, email, fullname);
+        }
+        fclose(fp);
+    }
 }
 
 void
 show(char *login /* IN: Web login */
 )
 {
-	char *epass; /* encrypted web password */
-	char fullname[256], email[256];
-	time_t tm;
-	epass = get_web_password(login);
-	if (!epass) {
-		std::println("webuser: no such login '{}'", login);
-		exit(1);
-	}
-	std::println("Web login     : {}", login);
-	std::println("Status        : {}",
-	    (!strncmp(epass, "*:", 2)) ? "Disabled" : "Active");
+    char *epass; /* encrypted web password */
+    char fullname[256], email[256];
+    time_t tm;
+    epass = get_web_password(login);
+    if (!epass) {
+        std::println("webuser: no such login '{}'", login);
+        exit(1);
+    }
+    std::println("Web login     : {}", login);
+    std::println("Status        : {}",
+        (!strncmp(epass, "*:", 2)) ? "Disabled" : "Active");
 
 #ifdef HAVE_DBM_OPEN
-	if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
-		DBM *db;
-		char *userfile = get_userfile(login, NULL, NULL);
-		if ((db = dbm_open(userfile, O_RDONLY, 0644)) != NULL) {
-			datum dkey, dval;
-			/* XXX need to alphabetize this list when printing it
-			 * either A) malloc array, fill in, qsort, and walk it
-			 * or  B) 2 nested for loops and keep the best next
-			 * key in 1st one */
-			for (dkey = dbm_firstkey(db); dkey.dptr != NULL;
-			     dkey = dbm_nextkey(db)) {
-				dbm_fetch(db, dkey);
-				dval = dbm_fetch(db, dkey);
-				dkey.dptr[0] = toupper(dkey.dptr[0]);
-				std::println("{:<14.{}s}: {:.{}s}",
-				    (const char *)dkey.dptr, dkey.dlen,
-				    (const char *)dval.dptr, dval.dlen);
-			}
-			dbm_close(db);
-		}
-	} else {
+    if (str::eq(get_conf_param("userdbm", USERDBM), "true")) {
+        DBM *db;
+        char *userfile = get_userfile(login, NULL, NULL);
+        if ((db = dbm_open(userfile, O_RDONLY, 0644)) != NULL) {
+            datum dkey, dval;
+            /* XXX need to alphabetize this list when printing it
+             * either A) malloc array, fill in, qsort, and walk it
+             * or  B) 2 nested for loops and keep the best next
+             * key in 1st one */
+            for (dkey = dbm_firstkey(db); dkey.dptr != NULL;
+                dkey = dbm_nextkey(db)) {
+                dbm_fetch(db, dkey);
+                dval = dbm_fetch(db, dkey);
+                dkey.dptr[0] = toupper(dkey.dptr[0]);
+                std::println("{:<14.{}s}: {:.{}s}", (const char *)dkey.dptr,
+                    dkey.dlen, (const char *)dval.dptr, dval.dlen);
+            }
+            dbm_close(db);
+        }
+    } else {
 #endif /* HAVE_DBM_OPEN */
-		get_user_info(login, fullname, email);
-		std::println("Full name     : {}", fullname);
-		std::println("Email address : {}", email);
+        get_user_info(login, fullname, email);
+        std::println("Full name     : {}", fullname);
+        std::println("Email address : {}", email);
 #ifdef HAVE_DBM_OPEN
-	}
+    }
 #endif /* HAVE_DBM_OPEN */
 
-	tm = get_last_change_time(login);
-	std::print("Last read time: {}", ((tm) ? ctime(&tm) : "never"));
+    tm = get_last_change_time(login);
+    std::print("Last read time: {}", ((tm) ? ctime(&tm) : "never"));
 }
 
 void
 chpass(char *login) /* IN: Web login */
 {
-	char *p, *old_ep;
-	char newpass1[256];
-	char newpass2[256];
+    char *p, *old_ep;
+    char newpass1[256];
+    char newpass2[256];
 
-	/* If root or usradm, then allow arbitrary login to be specified */
-	if (login && !str::eq(login, getlogin()) && getuid() != 0 &&
-	    getuid() != usradm.pw_uid) {
-		std::println("webuser: Permission denied");
-		exit(1);
-	}
+    /* If root or usradm, then allow arbitrary login to be specified */
+    if (login && !str::eq(login, getlogin()) && getuid() != 0 &&
+        getuid() != usradm.pw_uid) {
+        std::println("webuser: Permission denied");
+        exit(1);
+    }
 
-	/* Make sure a current account exists */
-	old_ep = get_web_password(login);
-	if (!old_ep) {
-		std::println("webuser: no such login '{}'", login);
-		exit(1);
-	}
+    /* Make sure a current account exists */
+    old_ep = get_web_password(login);
+    if (!old_ep) {
+        std::println("webuser: no such login '{}'", login);
+        exit(1);
+    }
 
-	/* Get new password */
-	p = getpass("New password:");
-	strcpy(newpass1, crypt(p, old_ep));
-	memset(p, 0, strlen(p));
+    /* Get new password */
+    p = getpass("New password:");
+    strcpy(newpass1, crypt(p, old_ep));
+    memset(p, 0, strlen(p));
 
-	p = getpass("Retype new password:");
-	strcpy(newpass2, crypt(p, old_ep));
-	memset(p, 0, strlen(p));
+    p = getpass("Retype new password:");
+    strcpy(newpass2, crypt(p, old_ep));
+    memset(p, 0, strlen(p));
 
-	if (!str::eq(newpass1, newpass2)) {
-		std::println("webuser: password mismatch");
-		exit(1);
-	}
+    if (!str::eq(newpass1, newpass2)) {
+        std::println("webuser: password mismatch");
+        exit(1);
+    }
 
-	/* Change password */
-	create_web_account(login, newpass1, nobody.pw_uid, nobody.pw_gid);
+    /* Change password */
+    create_web_account(login, newpass1, nobody.pw_uid, nobody.pw_gid);
 }
 
 int
 main(int argc, char **argv)
 {
-	struct passwd *pw;
-	char *login = NULL;
-	const char *options = "dehlprsuv"; /* Command-line options */
-	int i;
-	char cmd = 'u';
-	while ((i = getopt(argc, argv, options)) != -1) {
-		switch (i) {
-		case 'd':
-			cmd = i;
-			break;
-		case 'e':
-			cmd = i;
-			break;
-		case 'r':
-			cmd = i;
-			break;
-		case 'p':
-			cmd = i;
-			break;
-		case 's':
-			cmd = i;
-			break;
-		case 'u':
-			cmd = i;
-			break;
-		case 'l':
-			cmd = i;
-			break;
-		default:
-			usage();
-		}
-	}
-	argc -= optind;
-	argv += optind;
+    struct passwd *pw;
+    char *login = NULL;
+    const char *options = "dehlprsuv"; /* Command-line options */
+    int i;
+    char cmd = 'u';
+    while ((i = getopt(argc, argv, options)) != -1) {
+        switch (i) {
+        case 'd':
+            cmd = i;
+            break;
+        case 'e':
+            cmd = i;
+            break;
+        case 'r':
+            cmd = i;
+            break;
+        case 'p':
+            cmd = i;
+            break;
+        case 's':
+            cmd = i;
+            break;
+        case 'u':
+            cmd = i;
+            break;
+        case 'l':
+            cmd = i;
+            break;
+        default:
+            usage();
+        }
+    }
+    argc -= optind;
+    argv += optind;
 
-	if (argc > 0) {
-		login = argv[0];
-		argc--;
-		argv++;
-	}
-	if (argc > 0)
-		usage();
+    if (argc > 0) {
+        login = argv[0];
+        argc--;
+        argv++;
+    }
+    if (argc > 0)
+        usage();
 
-	if (geteuid()) {
-		std::println("This program must be installed setuid root");
-		exit(0);
-	}
+    if (geteuid()) {
+        std::println("This program must be installed setuid root");
+        exit(0);
+    }
 
-	/* Read in yapp configuration file */
-	get_yapp_conf();
+    /* Read in yapp configuration file */
+    get_yapp_conf();
 
-	/* Look up some standard logins to get UIDs for file permissions */
-	if ((pw = getpwnam(get_conf_param("nobody", NOBODY))) == NULL) {
-		perror("nobody");
-		exit(1);
-	}
-	memcpy(&nobody, pw, sizeof(cfadm)); /* save uid/gid */
-	if ((pw = getpwnam(get_conf_param("cfadm", CFADM))) == NULL) {
-		perror("cfadm");
-		exit(1);
-	}
-	memcpy(&cfadm, pw, sizeof(cfadm)); /* save uid/gid */
-	if ((pw = getpwnam(get_conf_param("usradm", USRADM))) == NULL) {
-		usradm.pw_uid = 0;
-		usradm.pw_gid = 0;
-	} else
-		memcpy(&usradm, pw, sizeof(usradm)); /* save uid/gid */
+    /* Look up some standard logins to get UIDs for file permissions */
+    if ((pw = getpwnam(get_conf_param("nobody", NOBODY))) == NULL) {
+        perror("nobody");
+        exit(1);
+    }
+    memcpy(&nobody, pw, sizeof(cfadm)); /* save uid/gid */
+    if ((pw = getpwnam(get_conf_param("cfadm", CFADM))) == NULL) {
+        perror("cfadm");
+        exit(1);
+    }
+    memcpy(&cfadm, pw, sizeof(cfadm)); /* save uid/gid */
+    if ((pw = getpwnam(get_conf_param("usradm", USRADM))) == NULL) {
+        usradm.pw_uid = 0;
+        usradm.pw_gid = 0;
+    } else
+        memcpy(&usradm, pw, sizeof(usradm)); /* save uid/gid */
 
-	if (!login)
-		login = getlogin();
-	if (!login) {
-		perror("getlogin");
-		exit(1);
-	}
-	switch (cmd) {
-	case 'd':
-		disable(login);
-		break;
-	case 'e':
-		enable(login);
-		break;
-	case 'l':
-		listall();
-		break;
-	case 'p':
-		chpass(login);
-		break;
-	case 'r':
-		rmuser(login);
-		break;
-	case 's':
-		show(login);
-		break;
-	case 'u':
-		update(login);
-		break;
-	}
+    if (!login)
+        login = getlogin();
+    if (!login) {
+        perror("getlogin");
+        exit(1);
+    }
+    switch (cmd) {
+    case 'd':
+        disable(login);
+        break;
+    case 'e':
+        enable(login);
+        break;
+    case 'l':
+        listall();
+        break;
+    case 'p':
+        chpass(login);
+        break;
+    case 'r':
+        rmuser(login);
+        break;
+    case 's':
+        show(login);
+        break;
+    case 'u':
+        update(login);
+        break;
+    }
 
-	exit(0);
+    exit(0);
 }

--- a/where.cc
+++ b/where.cc
@@ -18,12 +18,12 @@
 
 #define MAX_LIST_LENGTH 300
 
-flag_t debug = 0;    /* user settable parameter flags */
-flag_t flags = 0;    /* user settable parameter flags */
-flag_t status = 0;   /* system status flags           */
-uid_t uid;           /* User's UID                    */
-std::string login;   /* User's login                  */
-std::string bbsdir;  /* Directory for bbs files       */
+flag_t debug = 0;   /* user settable parameter flags */
+flag_t flags = 0;   /* user settable parameter flags */
+flag_t status = 0;  /* system status flags           */
+uid_t uid;          /* User's UID                    */
+std::string login;  /* User's login                  */
+std::string bbsdir; /* Directory for bbs files       */
 
 std::vector<assoc_t> conflist; /* System table of conferences   */
 
@@ -33,124 +33,119 @@ std::vector<assoc_t> conflist; /* System table of conferences   */
 char *
 strip_(char *s) /* ARGUMENTS: Original string  */
 {
-	static char buff[MAX_LINE_LENGTH];
-	char *p, *q;
-	for (p = buff, q = s; *q; q++)
-		if (*q != '_')
-			*p++ = *q;
-	*p = 0;
-	return buff;
+    static char buff[MAX_LINE_LENGTH];
+    char *p, *q;
+    for (p = buff, q = s; *q; q++)
+        if (*q != '_')
+            *p++ = *q;
+    *p = 0;
+    return buff;
 }
 
 void
 where(int argc, char **argv)
 {
-	long inode[MAX_LIST_LENGTH];
-	int i, n, fl = 0;
-	struct stat st;
-	char buff[MAX_LINE_LENGTH], login[MAX_LINE_LENGTH];
-	char word[20][MAX_LINE_LENGTH];
-	FILE *fp, *pp;
-	struct statfs buf;
-	/* Check for -s flag */
-	if (argc > 1 && str::eq(argv[1], "-s")) {
-		fl = 1;
-		argc--;
-		argv++;
-	}
+    long inode[MAX_LIST_LENGTH];
+    int i, n, fl = 0;
+    struct stat st;
+    char buff[MAX_LINE_LENGTH], login[MAX_LINE_LENGTH];
+    char word[20][MAX_LINE_LENGTH];
+    FILE *fp, *pp;
+    struct statfs buf;
+    /* Check for -s flag */
+    if (argc > 1 && str::eq(argv[1], "-s")) {
+        fl = 1;
+        argc--;
+        argv++;
+    }
 
-	/* Load in inode index */
-	for (i = 1; i < conflist.size(); i++) {
-		const auto path = str::concat({conflist[i].location, "/config"});
-		if (fl) {
-			statfs(path.c_str(), &buf);
-			if (buf.f_type == MOUNT_NFS)
-				continue;
-		}
-		if (!stat(path.c_str(), &st))
-			inode[i] = st.st_ino;
-		else
-			inode[i] = 0;
-	}
+    /* Load in inode index */
+    for (i = 1; i < conflist.size(); i++) {
+        const auto path = str::concat({conflist[i].location, "/config"});
+        if (fl) {
+            statfs(path.c_str(), &buf);
+            if (buf.f_type == MOUNT_NFS)
+                continue;
+        }
+        if (!stat(path.c_str(), &st))
+            inode[i] = st.st_ino;
+        else
+            inode[i] = 0;
+    }
 
-	if ((fp = popen("/usr/bin/fstat", "r")) == NULL) {
-		std::println("Can't open fstat");
-		exit(1);
-	}
-	std::println("USER     TT      PID CMD      CONFERENCE");
-	while (fgets(buff, MAX_LINE_LENGTH, fp)) {
-		if (sscanf(buff, "%s%s%s%s%s%s%s", &(word[0]), &(word[1]),
-		        &(word[2]), &(word[3]), &(word[4]), &(word[5]),
-		        &(word[6])) < 7 ||
-		    !(n = atoi(word[5])))
-			continue;
+    if ((fp = popen("/usr/bin/fstat", "r")) == NULL) {
+        std::println("Can't open fstat");
+        exit(1);
+    }
+    std::println("USER     TT      PID CMD      CONFERENCE");
+    while (fgets(buff, MAX_LINE_LENGTH, fp)) {
+        if (sscanf(buff, "%s%s%s%s%s%s%s", &(word[0]), &(word[1]), &(word[2]),
+                &(word[3]), &(word[4]), &(word[5]), &(word[6])) < 7 ||
+            !(n = atoi(word[5])))
+            continue;
 
-		for (i = 1; i < conflist.size() && inode[i] != n; i++)
-			;
-		if (i < conflist.size()) {
-			const auto cmd = std::format("ps -O ruser -p {}", word[2]);
-			if ((pp = popen(cmd.c_str(), "r")) == NULL) {
-				strcpy(word[12], word[0]);
-				strcpy(word[13], "??"); /* actually this is
-				                         * available */
-			} else {
-				fgets(buff, MAX_LINE_LENGTH, pp);
-				fgets(buff, MAX_LINE_LENGTH, pp);
-				/* Real thing */
-				/* 8431 thaler   s0  I+     0:00.97 nvi where.c */
-				/* actually this is available */
-				if (sscanf(buff, "%s%s%s%s%s%s", &(word[11]),
-				        &(word[12]), &(word[13]), &(word[14]),
-				        &(word[15]), &(word[16])) < 6) {
-					strcpy(word[12], word[0]);
-					strcpy(word[13], "??");
-				}
-				fclose(pp);
-			}
+        for (i = 1; i < conflist.size() && inode[i] != n; i++);
+        if (i < conflist.size()) {
+            const auto cmd = std::format("ps -O ruser -p {}", word[2]);
+            if ((pp = popen(cmd.c_str(), "r")) == NULL) {
+                strcpy(word[12], word[0]);
+                strcpy(word[13], "??"); /* actually this is
+                                         * available */
+            } else {
+                fgets(buff, MAX_LINE_LENGTH, pp);
+                fgets(buff, MAX_LINE_LENGTH, pp);
+                /* Real thing */
+                /* 8431 thaler   s0  I+     0:00.97 nvi where.c */
+                /* actually this is available */
+                if (sscanf(buff, "%s%s%s%s%s%s", &(word[11]), &(word[12]),
+                        &(word[13]), &(word[14]), &(word[15]),
+                        &(word[16])) < 6) {
+                    strcpy(word[12], word[0]);
+                    strcpy(word[13], "??");
+                }
+                fclose(pp);
+            }
 
-			/* Check user list */
-			if (argc > 1) {
-				for (i = 1;
-				     i < argc && !str::eq(word[12], argv[i]); i++)
-					;
-				if (i == argc)
-					continue;
-			}
-			std::println("{:<8} {} {:8} {:<8} {}",
-			    word[12], word[13], word[2], word[1],
-			    strip_(conflist[i].name));
-		}
-	}
-	fclose(fp);
+            /* Check user list */
+            if (argc > 1) {
+                for (i = 1; i < argc && !str::eq(word[12], argv[i]); i++);
+                if (i == argc)
+                    continue;
+            }
+            std::println("{:<8} {} {:8} {:<8} {}", word[12], word[13], word[2],
+                word[1], strip_(conflist[i].name));
+        }
+    }
+    fclose(fp);
 }
 
 int
 main(int argc, char *argv[])
 {
-	bbsdir = BBSDIR;
-	if (conflist = grab_list(bbsdir, "conflist")) {
-		std::println("Couldn't access conflist");
-		exit(1);
-	}
-	where(argc, argv);
-	return 0;
+    bbsdir = BBSDIR;
+    if (conflist = grab_list(bbsdir, "conflist")) {
+        std::println("Couldn't access conflist");
+        exit(1);
+    }
+    where(argc, argv);
+    return 0;
 }
 
 void
 wputs(char *s)
 {
-	fputs(s, stdout); /* NO newline like puts() does */
+    fputs(s, stdout); /* NO newline like puts() does */
 }
 
 void
 wputchar(int c)
 {
-	putchar(c);
+    putchar(c);
 }
 
 void
 error(const st::string_view &str1, const std::string_view &str2)
 {
-	std::println(stderr, "Got error {} ({}) in {}{}",
-	    errno, strerror(errno), str1, str2);
+    std::println(stderr, "Got error {} ({}) in {}{}", errno, strerror(errno),
+        str1, str2);
 }

--- a/www.cc
+++ b/www.cc
@@ -28,24 +28,24 @@
 static inline int
 asciihex2nibble(char c)
 {
-	// ASCII digits are 0x30 ('0') to 0x39 ('9')
-	// ASCII letters 'A'..'F' are 0x41..0x46
-	// ASCII letters 'a'..'f' are 0x61..0x66
-	return (c & 0xF) + ((c & 0x40) ? 9 : 0);
+    // ASCII digits are 0x30 ('0') to 0x39 ('9')
+    // ASCII letters 'A'..'F' are 0x41..0x46
+    // ASCII letters 'a'..'f' are 0x61..0x66
+    return (c & 0xF) + ((c & 0x40) ? 9 : 0);
 }
 
 static char
 x2c(const std::string_view &what)
 {
-	assert(what.size() == 2);
-	return (asciihex2nibble(what[0]) << 4) | asciihex2nibble(what[1]);
+    assert(what.size() == 2);
+    return (asciihex2nibble(what[0]) << 4) | asciihex2nibble(what[1]);
 }
 
 static std::string &
 plustospace(std::string &str)
 {
-	std::replace(str.begin(), str.end(), '+', ' ');
-	return str;
+    std::replace(str.begin(), str.end(), '+', ' ');
+    return str;
 }
 
 /*
@@ -55,53 +55,53 @@ plustospace(std::string &str)
 int
 url_encode(int argc, char **argv)
 {
-	FILE *fp;
-	char *from = argv[1];
+    FILE *fp;
+    char *from = argv[1];
 
-	/* If `url...` but not `url...|cmd`  (REDIRECT bit takes precedence) */
-	if ((status & S_EXECUTE) && !(status & S_REDIRECT)) {
-		fp = NULL;
-	} else {
-		if (status & S_REDIRECT) {
-			fp = stdout;
-		} else {
-			open_pipe();
-			fp = st_glob.outp;
-			if (!fp) {
-				fp = stdout;
-			}
-		}
-	}
+    /* If `url...` but not `url...|cmd`  (REDIRECT bit takes precedence) */
+    if ((status & S_EXECUTE) && !(status & S_REDIRECT)) {
+        fp = NULL;
+    } else {
+        if (status & S_REDIRECT) {
+            fp = stdout;
+        } else {
+            open_pipe();
+            fp = st_glob.outp;
+            if (!fp) {
+                fp = stdout;
+            }
+        }
+    }
 
-	if (argc < 2) {
-		std::println("syntax: url_encode string");
-		return 1;
-	}
-	while (*from) {
-		if (isalnum(*from) || strchr("$-_.+!*'(),", *from))
-			wfputc(*from++, fp);
-		else {
-			const auto hex = std::format("%%{:02X}", *from++);
-			wfputs(hex, fp);
-		}
-	}
-	if (fp)
-		fflush(fp); /* flush after done with wfput stuff */
-	return 1;
+    if (argc < 2) {
+        std::println("syntax: url_encode string");
+        return 1;
+    }
+    while (*from) {
+        if (isalnum(*from) || strchr("$-_.+!*'(),", *from))
+            wfputc(*from++, fp);
+        else {
+            const auto hex = std::format("%%{:02X}", *from++);
+            wfputs(hex, fp);
+        }
+    }
+    if (fp)
+        fflush(fp); /* flush after done with wfput stuff */
+    return 1;
 }
 
 static std::string &
 unescape_url(std::string &url)
 {
-	for (auto x = 0, y = 0; x < url.size(); ++x, ++y) {
-		url[x] = url[y];
-		if (url[x] == '%') {
-			assert((url.size() - x) >= 2);
-			url[x] = x2c(std::string_view{&url[y], 2});
-			y += 2;
-		}
-	}
-	return url;
+    for (auto x = 0, y = 0; x < url.size(); ++x, ++y) {
+        url[x] = url[y];
+        if (url[x] == '%') {
+            assert((url.size() - x) >= 2);
+            url[x] = x2c(std::string_view{&url[y], 2});
+            y += 2;
+        }
+    }
+    return url;
 }
 /*
  * With the -c option, converts newlines to 2 characters ("\n")
@@ -111,90 +111,90 @@ unescape_url(std::string &url)
 int
 www_parse_post(int argc, char **argv)
 {
-	int m = -1, cumul = 0;
-	int cl;
-	const auto env = expand("requestmethod", DM_VAR);
-	char *buff;
-	int convert = 0;
-	if (argc > 1 && strchr(argv[1], 'c'))
-		convert = 1;
+    int m = -1, cumul = 0;
+    int cl;
+    const auto env = expand("requestmethod", DM_VAR);
+    char *buff;
+    int convert = 0;
+    if (argc > 1 && strchr(argv[1], 'c'))
+        convert = 1;
 
-	const auto *env2 = getenv("CONTENT_TYPE");
-	if (env.empty() || !str::eq(env, "POST") || env2 == nullptr ||
-	    !str::eq(env2, "application/x-www-form-urlencoded")) {
-		def_macro("error", DM_VAR,
-		    "This command can only be used to decode form results.");
-		return 1;
-	}
-	const auto *cenv = getenv("CONTENT_LENGTH");
-	cl = (cenv) ? atoi(cenv) : 0;
+    const auto *env2 = getenv("CONTENT_TYPE");
+    if (env.empty() || !str::eq(env, "POST") || env2 == nullptr ||
+        !str::eq(env2, "application/x-www-form-urlencoded")) {
+        def_macro("error", DM_VAR,
+            "This command can only be used to decode form results.");
+        return 1;
+    }
+    const auto *cenv = getenv("CONTENT_LENGTH");
+    cl = (cenv) ? atoi(cenv) : 0;
 
-	buff = (char *)emalloc(cl + 1);
+    buff = (char *)emalloc(cl + 1);
 
-	/* Read in the whole thing */
-	for (cumul = 0; cumul < cl; cumul += m) {
-		m = read(saved_stdin[0].fd, buff + cumul, cl - cumul);
-		if (m < 0) {
-			error("reading full ", "content length");
-			break;
-		}
-	}
-	/*
-	std::println("Read {}/{} bytes", cumul, cl);
-	fflush(stdout);
-	*/
+    /* Read in the whole thing */
+    for (cumul = 0; cumul < cl; cumul += m) {
+        m = read(saved_stdin[0].fd, buff + cumul, cl - cumul);
+        if (m < 0) {
+            error("reading full ", "content length");
+            break;
+        }
+    }
+    /*
+    std::println("Read {}/{} bytes", cumul, cl);
+    fflush(stdout);
+    */
 
-	if (cumul > 0) {
-		buff[cumul] = '\0';
-		auto vars = str::splits(buff, "&", false);
-		for (auto &var: vars) {
-			plustospace(var);
-			unescape_url(var);
-			const auto vi = var.find('=');
-			if (vi == std::string::npos)
-				continue;
-			auto name = std::string_view(var.begin(), var.begin() + vi);
-			auto raw = std::string_view(var.begin() + vi + 1, var.end());
-			std::string value;
-			const auto prev = expand(name, DM_VAR);
-			if (!prev.empty()) {
-				value = prev;
-				value.push_back(' ');
-			}
-			for (const auto c: raw) {
-				if (convert) {
-					switch (c) {
-					case '\r':  // Ignore carriage return
-						continue;
-					case '\n':  // Convert newline to "\n"
-						value.append("\\n");
-						continue;
-					case '%':  // escape '%'
-						value.push_back('%');
-						break;
-					}
-				}
-				value.push_back(c);
-			}
-			def_macro(name, DM_VAR, value);
-		}
-	}
-	free(buff);
-	return 1;
+    if (cumul > 0) {
+        buff[cumul] = '\0';
+        auto vars = str::splits(buff, "&", false);
+        for (auto &var : vars) {
+            plustospace(var);
+            unescape_url(var);
+            const auto vi = var.find('=');
+            if (vi == std::string::npos)
+                continue;
+            auto name = std::string_view(var.begin(), var.begin() + vi);
+            auto raw = std::string_view(var.begin() + vi + 1, var.end());
+            std::string value;
+            const auto prev = expand(name, DM_VAR);
+            if (!prev.empty()) {
+                value = prev;
+                value.push_back(' ');
+            }
+            for (const auto c : raw) {
+                if (convert) {
+                    switch (c) {
+                    case '\r': // Ignore carriage return
+                        continue;
+                    case '\n': // Convert newline to "\n"
+                        value.append("\\n");
+                        continue;
+                    case '%': // escape '%'
+                        value.push_back('%');
+                        break;
+                    }
+                }
+                value.push_back(c);
+            }
+            def_macro(name, DM_VAR, value);
+        }
+    }
+    free(buff);
+    return 1;
 }
 
 void
 urlset(void)
 {
-	auto str = expand("querystring", DM_VAR);
-	if (str.empty())
-		return;
-	plustospace(str);
-	unescape_url(str);
-	const auto vars = str::split(str, "&", false);
-	for (size_t v = 0; v < vars.size(); v++) {
-		const auto fields = str::split(vars[v], "=", false);
-		if (fields.size() == 2 && !fields[0].empty())
-			def_macro(fields[0], DM_VAR, fields[1]);
-	}
+    auto str = expand("querystring", DM_VAR);
+    if (str.empty())
+        return;
+    plustospace(str);
+    unescape_url(str);
+    const auto vars = str::split(str, "&", false);
+    for (size_t v = 0; v < vars.size(); v++) {
+        const auto fields = str::split(vars[v], "=", false);
+        if (fields.size() == 2 && !fields[0].empty())
+            def_macro(fields[0], DM_VAR, fields[1]);
+    }
 }


### PR DESCRIPTION
This changes the clang-format configuration to use 4-space indent and runs it against all .cc files.

This is a purely mechanical source translation, and includes no behavioral or other functional changes.

I'm not happy with how, e.g., the dispatch tables were formatted, but we can play around with that and in the meantime, I think it is more important to have consistent automation around this.

Fixes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore / Style**
	- Standardized code formatting and indentation across the codebase for improved readability and consistency.
	- Updated configuration settings to establish a unified style without changing any functionality.

Overall, these cosmetic adjustments enhance maintainability and set the groundwork for future development improvements, while end-user behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->