### PR TITLE
tests: fix `str_test` and add a `test` make target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,7 @@ SRCS:=		arch.cc change.cc conf.cc dates.cc driver.cc edbuf.cc \
 
 OBJS:=		$(SRCS:%.cc=%.o)
 
-all:		$(PROG) $(EXTRA_PROGS)
+all:		$(PROG) $(EXTRA_PROGS) $(TESTS)
 
 $(PROG):	$(OBJS) GNUmakefile
 		$(CXX) $(CXXFLAGS) -o $(PROG) $(OBJS) $(LIBS) -lgdbm
@@ -63,6 +63,9 @@ clean:
 
 install:	$(PROG)
 		install -c -o cfadm -g cfadm -m 4111 $(PROG) $(SBINDIR)/bbs
+
+test:		$(TESTS)
+		for t in $(TESTS); do ./$$t; done
 
 tinstall:	$(PROG)
 		install -c -o cfadm -g cfadm -m 4551 $(PROG) $(SBINDIR)/bbs.testing

--- a/str_test.cc
+++ b/str_test.cc
@@ -141,11 +141,11 @@ TEST(StrTests, Match)
 
 TEST(StrTests, Contains)
 {
-    EXPECT_FALSE(str::contains({}, ""));
-    EXPECT_TRUE(str::contains({""}, ""));
-    EXPECT_FALSE(str::contains({"a"}, ""));
-    EXPECT_FALSE(str::contains({""}, "a"));
-    EXPECT_TRUE(str::contains({"a", "b", "c"}, "b"));
+    EXPECT_FALSE(str::contains(std::vector<std::string_view>{}, ""));
+    EXPECT_TRUE(str::contains(std::vector<std::string>{""}, ""));
+    EXPECT_FALSE(str::contains(std::vector<std::string_view>{"a"}, ""));
+    EXPECT_FALSE(str::contains(std::vector<std::string_view>{""}, "a"));
+    EXPECT_TRUE(str::contains(std::vector<std::string_view>{"a", "b", "c"}, "b"));
 }
 
 TEST(StrTests, Split)


### PR DESCRIPTION
`str_test.cc` was failing due to build ambiguity in the `Contains` test case (`str::contains` is overloaded for both vectors of string and string_view).

Add a `test` target to `GNUmakefile` to run tests.  As we add new test cases, we merely need to add these to the `TESTS` variable and they should be automatically run; this facilitates CI.